### PR TITLE
docs(adr): accept ADR-0015 with person-unification invariants

### DIFF
--- a/docs/adr/0015-identity-entity-relationships.adr.md
+++ b/docs/adr/0015-identity-entity-relationships.adr.md
@@ -87,7 +87,26 @@ all `Person` relationships in people"*), the following invariants are adopted.
 |---|---|---|
 | 1 | Customer Directory unions commercial + individual customers (I3) | ✅ implemented |
 | 2 | Repair commercial-contact person names + status in `pos-people` (I4) | ✅ implemented |
-| 3 | `pos-people` as SoT; demote `person_party` to a link (I1, I2) | ⏳ pending decision OD1 (thin-link vs event-synced cache) |
+| 3 | `pos-people` as SoT; demote `person_party` to a link (I1, I2) | ▶ in progress — **OD1 resolved: 3a thin-link** |
+
+#### Phase 3 (3a thin-link) execution sequence
+
+Must be staged; each step ships independently and keeps reads working.
+
+1. **Reconcile identity ids (prerequisite for I1).** Seed/data currently links
+   contact `person_party.person_id` to `01960025-*` while the canonical
+   `pos-people.person` rows are `01960026-*`. Repoint `person_party.person_id`
+   to the canonical `pos-people.person.id`; reconcile orphans. Until this holds,
+   demotion cannot read identity from `pos-people`.
+2. **Add identity read path.** `PeopleClient` batch fetch of person
+   name/contact by id; pos-people exposes a get-by-ids endpoint if absent.
+3. **Rewrite pos-customer readers** (contact summaries, `GetPersonResponse`,
+   individual-customer directory display) to source name/contact from
+   `pos-people` instead of `person_party` columns.
+4. **Drop duplicated columns** from `person_party` (name, contact) once no
+   reader depends on them.
+5. **Disable `PeopleClient` local-id fallback** outside dev; add orphan
+   reconciliation/guard (I1).
 
 ---
 

--- a/docs/adr/0015-identity-entity-relationships.adr.md
+++ b/docs/adr/0015-identity-entity-relationships.adr.md
@@ -1,9 +1,10 @@
 # ADR-0015: Person, Customer, and User Entity Semantics and Relationships
 
-**Status:** PROPOSED  
-**Date:** 2026-02-17  
+**Status:** ACCEPTED  
+**Date:** 2026-02-17 (accepted 2026-06-16)  
 **Deciders:** Architecture, Backend Lead, Security Lead  
-**Affected Issues:** N/A
+**Affected Issues:** N/A  
+**Realized by:** [PLAN-person-unification](../capabilities/PLAN-person-unification.md)
 
 ---
 
@@ -63,6 +64,30 @@ A `User` is an entity with a security relationship to the system (i.e., can auth
 - Duplicate `User` entities are allowed for migration/legacy, but only one can be ACTIVE per `Person`.
 
 **Decision:** ✅ **Resolved** - Adopt the above definitions and constraints for `Person`, `Customer`, and `User` entities across all modules.
+
+### 6. Person Unification Invariants
+
+Resolving the 2026-02-17 sign-off note (*"revisit people-crm relationship to have
+all `Person` relationships in people"*), the following invariants are adopted.
+`pos-people.person` is the single source of truth for every individual.
+
+- **I1** — Every `pos-customer.person_party.person_id` references an existing
+  `pos-people.person.id`. No orphan links; the `PeopleClient` local-id fallback is
+  disabled outside development.
+- **I2** — Person name and contact attributes are owned by `pos-people`.
+  `pos-customer` references them; it does not master them.
+- **I3** — The Customer Directory is the union of `commercial_party` and the
+  standalone individual customers in `person_party`, each tagged by `partyType`.
+- **I4** — The People Directory lists all `person` rows, filterable by type;
+  `status = null` denotes a non-employee person (customer contact, individual).
+
+### Remediation status (per PLAN-person-unification)
+
+| Phase | Scope | Status |
+|---|---|---|
+| 1 | Customer Directory unions commercial + individual customers (I3) | ✅ implemented |
+| 2 | Repair commercial-contact person names + status in `pos-people` (I4) | ✅ implemented |
+| 3 | `pos-people` as SoT; demote `person_party` to a link (I1, I2) | ⏳ pending decision OD1 (thin-link vs event-synced cache) |
 
 ---
 
@@ -132,3 +157,6 @@ A `User` is an entity with a security relationship to the system (i.e., can auth
 ## Changelog
 
 - **2026-02-17**: Initial draft
+- **2026-06-16**: Accepted. Added Person Unification Invariants (I1–I4) and
+  remediation status; linked PLAN-person-unification. Phases 1–2 implemented;
+  Phase 3 pending OD1.

--- a/docs/capabilities/PLAN-person-unification.md
+++ b/docs/capabilities/PLAN-person-unification.md
@@ -1,9 +1,7 @@
 # PLAN: Person Unification — single person identity across pos-people / pos-customer
 
-**Status:** DRAFT
-**Date:** 2026-06-16
-**Owner:** Architecture / Backend Lead
-**Anchors:** [ADR-0015](../adr/0015-identity-entity-relationships.adr.md) (PROPOSED), [ADR-0022](../adr/0022-audit-stable-person-identifier-claim-policy.adr.md), [SPEC-people-directory-backend](SPEC-people-directory-backend.md)
+**Status:** DRAFT **Date:** 2026-06-16 **Owner:** Architecture / Backend Lead **Anchors:** [ADR-0015](../adr/0015-identity-entity-relationships.adr.md) (PROPOSED),
+[ADR-0022](../adr/0022-audit-stable-person-identifier-claim-policy.adr.md), [SPEC-people-directory-backend](SPEC-people-directory-backend.md)
 
 ---
 
@@ -11,32 +9,36 @@
 
 Two observable asymmetries reported on durionpos.org:
 
-1. **Commercial parties appear in the People list.** 3 of 106 people rows are named after companies+departments (`"General Piedmont Freight"`, `"Operations Tarheel Logistics"`, `"Accounts Rowan Road Services"`).
-2. **Individual (person) customers do not appear in the Customer list.** The CRM Customer Directory shows only commercial organizations (20 LLCs), never individual person-customers.
+1. **Commercial parties appear in the People list.** 3 of 106 people rows are named after companies+departments (`"General Piedmont Freight"`,
+   `"Operations Tarheel Logistics"`, `"Accounts Rowan Road Services"`).
+2. **Individual (person) customers do not appear in the Customer list.** The CRM Customer Directory shows only commercial organizations (20 LLCs), never individual
+   person-customers.
 
 Root cause: person identity is split across **three stores with no unified read model**:
 
-| Store | Service | Holds | Authoritative? |
-|---|---|---|---|
-| `person` | pos-people | employees + non-employee persons (`status=null`) | **intended SoT** (ADR-0015) |
-| `person_party` | pos-customer | individual customers + commercial-account contacts | duplicate person data |
-| `commercial_party` | pos-customer | organizations | yes (orgs only) |
+| Store              | Service      | Holds                                              | Authoritative?              |
+| ------------------ | ------------ | -------------------------------------------------- | --------------------------- |
+| `person`           | pos-people   | employees + non-employee persons (`status=null`)   | **intended SoT** (ADR-0015) |
+| `person_party`     | pos-customer | individual customers + commercial-account contacts | duplicate person data       |
+| `commercial_party` | pos-customer | organizations                                      | yes (orgs only)             |
 
-`AbstractParty` uses `InheritanceType.TABLE_PER_CLASS` → `commercial_party` and `person_party` are physically separate tables with no shared parent table; concrete-typed repositories each see only their own slice.
+`AbstractParty` uses `InheritanceType.TABLE_PER_CLASS` → `commercial_party` and `person_party` are physically separate tables with no shared parent table; concrete-typed
+repositories each see only their own slice.
 
 ### Evidence (code)
 
 - `PartyServiceImpl.browseParties()` → `partyRepository.findAll()` where `partyRepository : CommercialPartyRepository` → **commercial_party only**.
 - `pos-people/.../R__seed_people_operational_data.sql:125+` seeds `(first='General', last='Piedmont Freight')` style rows (namespace `01960026`) — the role+company names.
-- `person_party.person_id` already carries the canonical pos-people `personId` (set via `PeopleClient.resolveOrCreatePersonId`) — **the unifying link already exists, it is just unused for listing**.
+- `person_party.person_id` already carries the canonical pos-people `personId` (set via `PeopleClient.resolveOrCreatePersonId`) — **the unifying link already exists, it is
+  just unused for listing**.
 - `PeopleClient.resolveOrCreatePersonId` has `allowLocalFallback`: on resolve failure it generates a local UUID, so `person_party.person_id` can orphan from pos-people.
 
 ---
 
 ## 2. Target model (per ADR-0015 sign-off)
 
-ADR-0015 sign-off note (LMB): *"Have to revisit people-crm relationship to have all `Person` relationships in people."*
-SPEC-people-directory confirms `person.status = null` is the intended home for non-employee persons.
+ADR-0015 sign-off note (LMB): _"Have to revisit people-crm relationship to have all `Person` relationships in people."_ SPEC-people-directory confirms `person.status = null`
+is the intended home for non-employee persons.
 
 ```
 pos-people.person                ← SINGLE source of truth for every human
@@ -52,6 +54,7 @@ pos-customer:
 ```
 
 **Invariants:**
+
 - I1 — Every `person_party.person_id` references an existing `pos-people.person.id` (no orphans; `allowLocalFallback` disabled in non-dev).
 - I2 — Person name/contact is owned by pos-people; pos-customer reads it, does not master it.
 - I3 — Customer Directory = `commercial_party` ∪ `person_party`, each tagged by `partyType`.
@@ -61,22 +64,27 @@ pos-customer:
 
 ## 3. Phased delivery
 
-### Phase 1 — Customer Directory shows all customers *(visible fix; lowest risk)*
+### Phase 1 — Customer Directory shows all customers _(visible fix; lowest risk)_
 
 **Goal:** individuals appear alongside commercial parties in the CRM Customer Directory.
 
 **Backend (pos-customer):**
+
 - Add `PersonPartyRepository` paged listing (already `JpaRepository<PersonParty>`; add `findAll(Pageable)` use + name/search query exists at `PersonPartyRepository:25`).
-- New service method `PartyService.browseCustomers(Pageable, type)` returning a unified `SearchPartiesResponse` where each `PartySummary` carries `partyType` (`COMMERCIAL` | `PERSON`).
-  - Implementation option A (preferred): two paged queries (commercial + person), merge + sort in service, single page window. Simpler, avoids `TABLE_PER_CLASS` UNION pitfalls.
+- New service method `PartyService.browseCustomers(Pageable, type)` returning a unified `SearchPartiesResponse` where each `PartySummary` carries `partyType` (`COMMERCIAL` |
+  `PERSON`).
+  - Implementation option A (preferred): two paged queries (commercial + person), merge + sort in service, single page window. Simpler, avoids `TABLE_PER_CLASS` UNION
+    pitfalls.
   - Option B: native `UNION ALL` projection view `v_customer_directory(party_id, display_name, party_type, primary_contact, vehicle_count)`.
 - Keep `browseParties` (commercial-only) for back-compat or redirect callers; prefer replacing per pre-production policy.
 
 **Frontend (durion-positivity-frontend):**
+
 - Customer Directory: add a **type column** + filter chips (All / Commercial / Individual), mirroring People Directory chips.
 - Row click routes by type: commercial → `/app/crm/party/{id}`, person → individual detail.
 
 **Acceptance:**
+
 - Customer Directory lists both seed commercial parties and seeded individual person-customers.
 - Filter chips narrow correctly; counts match DB.
 
@@ -84,13 +92,15 @@ pos-customer:
 
 ---
 
-### Phase 2 — Fix contact-person naming *(data quality)*
+### Phase 2 — Fix contact-person naming _(data quality)_
 
 **Goal:** commercial-contact persons read as real humans, not `department + company`.
 
-**Cause:** `pos-people/R__seed_people_operational_data.sql:125+` (and historical `resolveOrCreatePersonId` calls from the deprecated `contact` flow) seeded `first=<dept>, last=<company>`.
+**Cause:** `pos-people/R__seed_people_operational_data.sql:125+` (and historical `resolveOrCreatePersonId` calls from the deprecated `contact` flow) seeded
+`first=<dept>, last=<company>`.
 
 **Work:**
+
 - Correct the seed rows (namespace `01960026`) to real contact first/last names (align with `pos-customer` `CUST-CPC-*` person_party rows: Greg Whitfield, Teresa Mullen, …).
 - One-shot migration `Vn__fix_commercial_contact_person_names.sql` in pos-people to repair existing rows where `person.id` ∈ `01960026-*` and name looks role+company.
 - Verify no employee rows (`status IS NOT NULL`) are touched.
@@ -101,15 +111,19 @@ pos-customer:
 
 ---
 
-### Phase 3 — Person as single source of truth *(ADR-0015 realization; cross-repo)*
+### Phase 3 — Person as single source of truth _(ADR-0015 realization; cross-repo)_
 
 **Goal:** stop duplicating person data; pos-people authoritative, pos-customer references.
 
 **Decision required (sub-options):**
-- **3a (thin link):** demote `person_party` to `{person_id, customer_number, customer status/tier, party_relationship FKs}`; drop `first_name/last_name/primary_address`; read identity from pos-people via client/projection. Cleanest; biggest change.
-- **3b (read cache + events):** keep `person_party` columns as a denormalized cache, but make pos-people authoritative on write and sync via domain events (ADR-0027: `PersonUpdated` → pos-customer updates cache). Lower coupling on read path; eventual consistency.
+
+- **3a (thin link):** demote `person_party` to `{person_id, customer_number, customer status/tier, party_relationship FKs}`; drop `first_name/last_name/primary_address`; read
+  identity from pos-people via client/projection. Cleanest; biggest change.
+- **3b (read cache + events):** keep `person_party` columns as a denormalized cache, but make pos-people authoritative on write and sync via domain events (ADR-0027:
+  `PersonUpdated` → pos-customer updates cache). Lower coupling on read path; eventual consistency.
 
 **Cross-cutting:**
+
 - Disable `PeopleClient.allowLocalFallback` outside dev → enforce I1 (no orphan person_id).
 - Backfill/repair: every existing `person_party.person_id` must resolve to a `person` row; reconcile orphans.
 - Promote **ADR-0015 PROPOSED → ACCEPTED**, add unification rules (I1–I4) + per-module remediation checklist (model on ADR-0022 checklist).
@@ -123,14 +137,14 @@ pos-customer:
 
 ## 4. Cross-repo story map
 
-| # | Repo | Title | Depends on |
-|---|---|---|---|
-| 1 | pos-customer | Unified `browseCustomers` (commercial ∪ person) | — |
-| 2 | frontend | Customer Directory type filter + routing | 1 |
-| 3 | pos-people | Fix commercial-contact person names (seed + migration) | — |
-| 4 | durion (docs) | Promote ADR-0015 → ACCEPTED + remediation checklist | — |
-| 5 | pos-customer / pos-people | person_party demotion **(3a)** or event sync **(3b)** | 4 |
-| 6 | pos-customer | Disable local fallback + reconcile orphan person_id | 4 |
+| #   | Repo                      | Title                                                  | Depends on |
+| --- | ------------------------- | ------------------------------------------------------ | ---------- |
+| 1   | pos-customer              | Unified `browseCustomers` (commercial ∪ person)        | —          |
+| 2   | frontend                  | Customer Directory type filter + routing               | 1          |
+| 3   | pos-people                | Fix commercial-contact person names (seed + migration) | —          |
+| 4   | durion (docs)             | Promote ADR-0015 → ACCEPTED + remediation checklist    | —          |
+| 5   | pos-customer / pos-people | person_party demotion **(3a)** or event sync **(3b)**  | 4          |
+| 6   | pos-customer              | Disable local fallback + reconcile orphan person_id    | 4          |
 
 **Critical path:** 4 → 5/6 (Phase 3 gated on the ADR decision). Phases 1 and 2 are independent and shippable immediately.
 
@@ -138,25 +152,25 @@ pos-customer:
 
 ## 5. ADR compliance
 
-| ADR | Bearing |
-|---|---|
-| ADR-0011 | business logic in service layer (unified browse, name repair) |
-| ADR-0013 | UUID v7 person ids preserved |
-| ADR-0022 | stable person identifier — do **not** rewrite `person.id`; only names (Phase 2) |
+| ADR      | Bearing                                                                           |
+| -------- | --------------------------------------------------------------------------------- |
+| ADR-0011 | business logic in service layer (unified browse, name repair)                     |
+| ADR-0013 | UUID v7 person ids preserved                                                      |
+| ADR-0022 | stable person identifier — do **not** rewrite `person.id`; only names (Phase 2)   |
 | ADR-0023 | prefer Specification/projection over raw SQL where expressible (Phase 1 Option A) |
-| ADR-0026 | paginate unified Customer Directory |
-| ADR-0027 | event-driven sync if Phase 3b chosen |
+| ADR-0026 | paginate unified Customer Directory                                               |
+| ADR-0027 | event-driven sync if Phase 3b chosen                                              |
 
 ---
 
 ## 6. Risks
 
-| Risk | Phase | Mitigation |
-|---|---|---|
-| `TABLE_PER_CLASS` UNION performance | 1 | prefer two-query merge (Option A) or materialized view |
-| Rewriting person.id breaks audit refs | 2 | repair **names only**, never ids (ADR-0022) |
-| Orphan `person_id` from prior fallback | 3 | reconciliation pass before disabling fallback |
-| Eventual-consistency drift (3b) | 3 | choose 3a if strong consistency required |
+| Risk                                   | Phase | Mitigation                                             |
+| -------------------------------------- | ----- | ------------------------------------------------------ |
+| `TABLE_PER_CLASS` UNION performance    | 1     | prefer two-query merge (Option A) or materialized view |
+| Rewriting person.id breaks audit refs  | 2     | repair **names only**, never ids (ADR-0022)            |
+| Orphan `person_id` from prior fallback | 3     | reconciliation pass before disabling fallback          |
+| Eventual-consistency drift (3b)        | 3     | choose 3a if strong consistency required               |
 
 ---
 


### PR DESCRIPTION
Promotes ADR-0015 (Person/Customer/User semantics) from PROPOSED → ACCEPTED, resolving the 2026-02-17 sign-off note: *"revisit people-crm relationship to have all Person relationships in people."*

## Changes
- **Person Unification Invariants I1–I4** — `pos-people.person` is the single source of truth; person_party references it; Customer Directory = commercial ∪ individual; People Directory lists all persons (`status=null` = non-employee).
- **Remediation status table** tracking the three [PLAN-person-unification](docs/capabilities/PLAN-person-unification.md) phases: Phase 1 ✅, Phase 2 ✅ (both in durion-positivity-backend PR #672), Phase 3 ⏳ gated on OD1.

## Phase 3 decision needed (OD1)
Before Phase 3 (I1/I2 — person_party demotion), choose:
- **3a thin-link** — strong consistency, bigger change
- **3b event-synced cache** — lower coupling, eventual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)