### PR TITLE
docs(adr): renumber User–Person Linkage ADR 0039 → 0043 + register in README

### DIFF
--- a/docs/adr/0015-identity-entity-relationships.adr.md
+++ b/docs/adr/0015-identity-entity-relationships.adr.md
@@ -137,7 +137,7 @@ invariants make §3 enforceable.
 
 > Enforcement mechanism, token-claim derivation, and migration of the duplicate
 > `users.person_id` column are specified in
-> [ADR-0039: User–Person Linkage Authority and Translation](0039-user-person-linkage-authority.adr.md).
+> [ADR-0043: User–Person Linkage Authority and Translation](0043-user-person-linkage-authority.adr.md).
 
 ---
 
@@ -216,4 +216,4 @@ invariants make §3 enforceable.
   removed all read fallbacks. I1/I2 hold; resilience trade-off recorded.
 - **2026-06-19**: Added §7 User–Person Linkage Invariants (I5–I7) to make §3
   enforceable, after finding `admin.alpha` seeded as a user with no person
-  (durion-positivity-backend#714). Enforcement/migration specified in ADR-0039.
+  (durion-positivity-backend#714). Enforcement/migration specified in ADR-0043.

--- a/docs/adr/0043-user-person-linkage-authority.adr.md
+++ b/docs/adr/0043-user-person-linkage-authority.adr.md
@@ -1,4 +1,4 @@
-# ADR-0039: User–Person Linkage Authority and Translation
+# ADR-0043: User–Person Linkage Authority and Translation
 
 **Status:** PROPOSED
 **Date:** 2026-06-19

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,6 +107,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0040   | Roles, JWT Permission Governance Policy   | ACCEPTED              | 2026-04-12 |
 | 0041   | Frontend Angular SDK API Transport Policy             | ACCEPTED              | 2026-04-25 |
 | 0042   | OpenAPI Annotation Standards for Backend Services     | ACCEPTED              | 2026-05-12 |
+| 0043   | User–Person Linkage Authority and Translation         | PROPOSED              | 2026-06-19 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 
@@ -156,6 +157,7 @@ Use this matrix during planning, implementation, and review to quickly decide wh
 | 0038 | Date-only string (YYYY-MM-DD) parsing and timezone-safe local-date construction without UTC assumptions                                                         | Coder, Test, Planner               |
 | 0041 | Frontend-to-backend Angular transport boundary, SDK-first API consumption, and `ApiBaseService` migration decisions                                                 | Coder, Test, Planner, Orchestrator |
 | 0042 | OpenAPI operation description as tool invocation contract: 7-element structure for unambiguous LLM tool selection and error self-correction                       | Coder, Test, Planner, Orchestrator |
+| 0043 | User↔Person link authority (`user_person_links` as sole source of truth), token `personId` derivation, mandatory translation (no userId/personId conflation), reconcile + seed-validation enforcement | Coder, Test, Planner, Orchestrator |
 
 ### Agent role shorthand
 


### PR DESCRIPTION
The User–Person Linkage Authority ADR was created as **0039**, which collides with the existing **0039 — Frontend Information-Bearing Contrast Policy** (numbers already run to 0042). Renumbered to the next free number **0043**.

## Changes
- `git mv 0039-user-person-linkage-authority.adr.md → 0043-…`; title `ADR-0039` → `ADR-0043`.
- ADR-0015 cross-references (§7 link + changelog) updated `0039` → `0043`.
- Registered 0043 in `docs/adr/README.md` — both the index table (PROPOSED, 2026-06-19) and the Decision Matrix.

Verified: no stale `0039-user-person` / `ADR-0039: User` references remain.

Note: ADR-0043 remains **PROPOSED** (Architecture/Backend/Security sign-off pending). Prior issues that referenced "ADR-0039" for this policy (#714, etc.) now point at the contrast ADR by number — the canonical doc is ADR-0043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)