### PR TITLE
docs(adr): accept ADR-0043 User–Person Linkage Authority

### DIFF
--- a/docs/adr/0043-user-person-linkage-authority.adr.md
+++ b/docs/adr/0043-user-person-linkage-authority.adr.md
@@ -1,7 +1,7 @@
 # ADR-0043: User–Person Linkage Authority and Translation
 
-**Status:** PROPOSED
-**Date:** 2026-06-19
+**Status:** ACCEPTED
+**Date:** 2026-06-19 (accepted 2026-06-19)
 **Deciders:** Architecture, Backend Lead, Security Lead
 **Affected Issues:** durion-positivity-backend#714 (seed: user without person)
 
@@ -133,15 +133,16 @@ sufficient authorization.
 
 | Role         | Name | Date       | Notes |
 |--------------|------|------------|-------|
-| Architecture |      |            | Pending review |
-| Backend Lead |      |            | Pending review |
-| Security Lead|      |            | Pending review |
+| Architecture | LMB  | 2026-06-19 | Accepted       |
+| Backend Lead | LMB  | 2026-06-19 | Accepted       |
+| Security Lead| LMB  | 2026-06-19 | Accepted       |
 
 ---
 
 ## Timeline
 
 - **Proposed**: 2026-06-19
+- **Accepted**: 2026-06-19
 
 ---
 
@@ -151,3 +152,4 @@ sufficient authorization.
   sole link authority, derives token `personId` from it, mandates translation (no
   userId/personId conflation), and adds reconcile + seed-validation enforcement.
   Prompted by durion-positivity-backend#714.
+- **2026-06-19**: Accepted (Architecture/Backend/Security — LMB).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,7 +107,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0040   | Roles, JWT Permission Governance Policy   | ACCEPTED              | 2026-04-12 |
 | 0041   | Frontend Angular SDK API Transport Policy             | ACCEPTED              | 2026-04-25 |
 | 0042   | OpenAPI Annotation Standards for Backend Services     | ACCEPTED              | 2026-05-12 |
-| 0043   | User–Person Linkage Authority and Translation         | PROPOSED              | 2026-06-19 |
+| 0043   | User–Person Linkage Authority and Translation         | ACCEPTED              | 2026-06-19 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 


### PR DESCRIPTION
Marks **ADR-0043 — User–Person Linkage Authority and Translation** as ACCEPTED.

- Status `PROPOSED` → `ACCEPTED`; date annotated `(accepted 2026-06-19)`.
- Sign-off table filled: Architecture / Backend Lead / Security Lead — LMB, 2026-06-19.
- Timeline + changelog accepted entry.
- README index status `PROPOSED` → `ACCEPTED`.

Now enforceable alongside ADR-0015 §7. Implementation tracked in durion-positivity-backend#714 (seed fix) and the reconcile endpoint (#715, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)