### PR TITLE
[CAP:316] Accounting: wire backend/frontend issue numbers into CAP-316 manifest

### DIFF
--- a/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+++ b/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
@@ -1,6 +1,6 @@
 # Story: Read-only Retread Plant Labor & Overhead Cost Report endpoint
 
-> Target repo: **louisburroughs/durion-positivity-backend**
+> Target repo: **louisburroughs/durion-positivity-backend** — issue #724
 > Parent capability: CAP-316 — louisburroughs/durion#328
 > Labels: `type:story`, `domain:accounting`, `status:needs-review`
 > Branch: `cap/316-labor-overhead-cost-report`

--- a/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+++ b/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
@@ -1,0 +1,68 @@
+# Story: Read-only Retread Plant Labor & Overhead Cost Report endpoint
+
+> Target repo: **louisburroughs/durion-positivity-backend**
+> Parent capability: CAP-316 — louisburroughs/durion#328
+> Labels: `type:story`, `domain:accounting`, `status:needs-review`
+> Branch: `cap/316-labor-overhead-cost-report`
+
+## Description
+Provide a **read-only** accounting reporting endpoint that returns the MRTI "Retread Plant — Labor and
+Overhead Costs" matrix for a given **location/dealer** and **fiscal year**: every cost line (per the
+CAP-316 canonical taxonomy) with **12 monthly amounts + YTD**, plus section subtotals and a currency
+context. Amounts are derived from **posted GL data** (no new posting path). The endpoint maps each report
+line to its GL account(s) via Accounting-domain mapping and aggregates server-side so the frontend renders
+the returned matrix directly.
+
+See `docs/capabilities/CAP-316/CAP-316-spec.md` (durion) for the full line taxonomy, definitions, and
+aggregation rules.
+
+## Acceptance Criteria
+- `GET /v1/accounting/reports/retread/labor-overhead?locationId={id}&fiscalYear={yyyy}[&asOfMonth={1-12}]`
+  returns the full cost-line hierarchy in canonical order (Labor §1, Overhead §2) with `monthly[12]`
+  (index 0 = January) and `ytd` per line.
+- Leaf-line monthly amounts equal the sum of posted journal-entry-line amounts for the mapped GL
+  account(s), filtered by `locationId` dimension and transaction month within the fiscal year.
+- Subtotal lines (`1.1`, `1.3`, `2.1`, `2.4`, `2.7`, `2.9`, `2.11`, `2.15`, **Total Labor**,
+  **Total Overhead**, **Total Labor & Overhead**) are computed from their children, never mapped directly,
+  and equal the column-wise sum of children.
+- `ytd` equals the sum of monthly values for elapsed months (1 … `asOfMonth`; default 12).
+- Sign is preserved for credit/income lines (2.13 Inventory charge, 2.14 Rubber dust income).
+- Line `2.11.4` is returned in USD; all other amounts in the location's local currency. Response carries
+  `currency`, `localCurrencyPerUsd`, and `averageRate` (1.00 for US plants).
+- Each line includes metadata: `code`, `label`, `parentCode`, `level`, `costType`
+  (`FIXED|VARIABLE|FIXED_IF_LOW_VOLUME`), `isSubtotal`, and `definition` text.
+- Reflects **posted** ledger state only; the endpoint performs no mutation/posting/inference.
+- Unknown/zero-activity line → amounts `0` (line still present). Location with no postings → all `0`,
+  full layout preserved.
+- Authorization enforced via the financial-reporting permission family; unauthorized → `403`.
+- Provider behavioral contract test proves amounts trace to posted GL data for a seeded location/period.
+
+## Tasks
+- [ ] Define the report-line → GL-account **mapping** mechanism (coordinate with Accounting domain agent;
+      decide persisted master-data vs. static config for v1). Mapping must be location-aware.
+- [ ] Add `LaborOverheadCostReport` response DTOs (report header + ordered line list).
+- [ ] Implement a read-only service that queries posted ledger lines by account set + `locationId`
+      dimension + period, and assembles monthly + YTD + subtotals per the canonical taxonomy.
+- [ ] Add controller endpoint `GET /v1/accounting/reports/retread/labor-overhead` with OpenAPI annotations
+      and permission gating.
+- [ ] Regenerate `OpenAPI.yaml` and update the Angular SDK (`durion-positivity-sdk-angular`) per the
+      controller-change contract chain.
+- [ ] Update `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (durion) with a **CAP-316**
+      section: operationId, path, request/response shape, behavioral assertions, ADR constraints, contract
+      test traceability.
+- [ ] Unit tests: mapping resolution, monthly bucketing, subtotal roll-ups, YTD with mid-year `asOfMonth`,
+      negative-sign lines, USD-only line 2.11.4.
+- [ ] Provider contract + controller tests; integration test against seeded posted journal data.
+
+## Dependencies
+- CAP-050 Chart of Accounts (GL account catalog / metadata).
+- CAP-051 GL posting / ledger lines and the dimension model (`locationId`, cost-center).
+- CAP-054 Financial reporting conventions (`/v1/accounting/reports/...`, posted-state semantics).
+- Accounting-domain report-line → GL-account mapping (authored during refinement).
+
+## Notes for Agents
+- Follow accounting domain conventions; do **not** introduce a posting path — this is a pure read model.
+- Place alongside the existing financial reporting controller/service so it inherits reporting
+  permissions, error handling, and correlation/trace standards (AD-008).
+- Keep the canonical line order/numbering exactly as in the CAP-316 spec (the form layout is contractual).
+- Closed-period rules do not block reads; the report simply reflects posted state.

--- a/docs/capabilities/CAP-316/CAP-316-spec.md
+++ b/docs/capabilities/CAP-316/CAP-316-spec.md
@@ -231,6 +231,6 @@ Response (shape; field names finalized during backend story):
 | Layer | Repo | Artifact |
 | --- | --- | --- |
 | Primary (high-level) | louisburroughs/durion | Issue #328 |
-| Backend story | louisburroughs/durion-positivity-backend | `01-labor-overhead-cost-report-endpoint.story.md` (this folder) → issue TBD |
-| Frontend story | louisburroughs/durion-positivity-frontend | `stories/frontend/CAP_316.frontend.md` (this folder) → issue TBD |
+| Backend story | louisburroughs/durion-positivity-backend | `01-labor-overhead-cost-report-endpoint.story.md` (this folder) → issue #724 |
+| Frontend story | louisburroughs/durion-positivity-frontend | `stories/frontend/CAP_316.77.frontend.md` (this folder) → issue #77 |
 | Contract | louisburroughs/durion | `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (add CAP-316 section) |

--- a/docs/capabilities/CAP-316/CAP-316-spec.md
+++ b/docs/capabilities/CAP-316/CAP-316-spec.md
@@ -1,0 +1,236 @@
+# CAP-316 — Retread Plant Labor & Overhead Cost Report (read-only) — Specification
+
+- **Capability:** CAP-316
+- **Primary (high-level) story:** louisburroughs/durion#328
+- **Domain:** accounting
+- **Type:** read-only reporting screen
+- **Source artifact:** `LOCostReportingForm2026.xlsx` (MRTI "Retread Plant — Labor and Overhead Costs (Chart of Accounts) Form")
+
+---
+
+## 1. Overview
+
+The source workbook is the MRTI annual **Labor and Overhead Cost Reporting** form for a tire retread
+plant. It captures, for one **dealer/location** and one **fiscal year**, the plant's labor and overhead
+costs broken into a fixed chart-of-accounts hierarchy, with one column per calendar month plus a
+year-to-date (YTD) total.
+
+This capability delivers the **"Master Form"** tab as a new, **read-only** accounting screen in Durion.
+The data is sourced from **existing accounting APIs / posted GL data** — the screen never accepts input,
+posts, or infers journal entries.
+
+### 1.1 Workbook tab → capability mapping
+
+| Workbook tab | Role | In scope for CAP-316 |
+| --- | --- | --- |
+| **Master Form** | The page to build: monthly + YTD cost matrix by location/year | ✅ Yes — this is the screen |
+| **Definitions** | Per-line include/exclude guidance + Fixed/Variable classification | ✅ Yes — as inline help/tooltips + line metadata |
+| **Cost per Unit (Local Currency)** | Same lines divided by production equivalent units | ❌ No — requires non-accounting production counts (separate capability) |
+| **Paste From File** | Flat monthly DB-import row per shop (one row per month, one column per leaf line) | ➖ Informs the backend response shape only; not a screen |
+
+### 1.2 Decisions captured from intake
+
+- **Data sourcing:** a **new backend read-only report endpoint** performs the report-line → GL-account
+  mapping and monthly/YTD aggregation server-side; the frontend renders the returned matrix.
+- **Screen scope:** Master Form monthly + YTD ($), Definitions as help/tooltips, and the currency-conversion row.
+- **GL mapping:** the concrete report-line → GL-account mapping is **authored by the Accounting domain
+  agent** during refinement. This spec defines the **line taxonomy** and the **mapping structure**, not the
+  account numbers.
+
+---
+
+## 2. Screen behavior (read-only)
+
+### 2.1 Selectors / context
+- **Location / Dealer** (required) — maps to the accounting `locationId` dimension.
+- **Fiscal Year** (required).
+- **As-of month** (optional, default = December / full year) — bounds the YTD and which monthly columns
+  are populated.
+- Header echoes the source form's context: `Dealer / Location`, `Year`, and the note
+  *"$ Amounts in Whole Dollars Local Currency (except line 2.11.4)"*.
+
+### 2.2 Grid
+- Rows follow the canonical hierarchy in §3 (section → line → sub-line), preserving numbering and order.
+- Columns: `January … December`, then `YTD`.
+- Subtotal rows: **Total Labor** (§1), **Total Overhead** (§2), **Total Labor & Overhead**.
+- All values are whole local-currency dollars. Empty/no-activity cells render `0`.
+- Each line offers inline help showing its **definition** (include / do-not-include guidance) and its
+  **Fixed/Variable** type from §3.
+- A **Currency Conversion** footer row shows "Local Currency per $US" (1.00 for US plants) and the average
+  rate used, for context only.
+
+### 2.3 States
+- `idle → loading → loaded | empty | error`.
+- **empty**: valid scope, no postings → full layout with all `0`.
+- **error**: backend `4xx/5xx` surfaced as a non-leaking message; `403` when unauthorized.
+
+### 2.4 Read-only guarantees
+- No create/update/delete actions, no posting, no "reverse/imply GL" behavior.
+- No editable cells. Export (CSV/print) is presentation-only and optional for v1.
+
+---
+
+## 3. Canonical cost-line taxonomy
+
+Codes, labels, hierarchy, Fixed/Variable type, and definitions are taken verbatim from the workbook's
+**Master Form** and **Definitions** tabs. `*` on a type means "Fixed if volume change is minimal"
+(per the Definitions note). Leaf lines map to GL accounts; parent lines are computed subtotals.
+
+### §1 Labor
+
+| Code | Label | Type | Roll-up | Definition (include / exclude) |
+| --- | --- | --- | --- | --- |
+| 1.1 | Wages and Bonuses (including shop manager) | — | sum of 1.1.1–1.1.2 | — |
+| 1.1.1 | Hourly wages and bonuses | Variable | leaf | Incl: wages/bonuses for hourly retread-plant workers (production, maintenance, janitor, plant clerk), matching MRT Weekly Production Report hours. Excl: warehousing/distribution/sales/corporate office wages; production outside the MRT process. |
+| 1.1.2 | Management salaries | Fixed * | leaf | Incl: salaries/bonuses for salaried retread-plant personnel matching MRT Weekly Production Report hours. |
+| 1.2 | Misc Labor (contract and temp production employees) | Variable | leaf | Incl: wages for temporary/contract workers matching MRT Weekly Production Report hours. |
+| 1.3 | Taxes and Benefits | — | sum of 1.3.1–1.3.6 | Relating to the wages in §1.1. |
+| 1.3.1 | FICA | Variable | leaf | Payroll tax on §1.1 wages. |
+| 1.3.2 | Fed Unemployment | Variable | leaf | Federal unemployment tax on §1.1 wages. |
+| 1.3.3 | State Unemployment | Variable | leaf | State unemployment tax on §1.1 wages. |
+| 1.3.4 | Medical/dental insurance, life, health, disability | Variable | leaf | Employee benefit costs related to §1.1. |
+| 1.3.5 | Retirement plan contributions | Variable | leaf | Employer retirement contributions related to §1.1. |
+| 1.3.6 | Employee Insurance – workers' comp | Variable | leaf | Workers' compensation insurance for plant employees. |
+| 1.5 | Uniforms rental / laundry | Variable * | leaf | Incl: uniforms or shirt/trouser program, if provided. |
+| — | **Total Labor** | — | sum of 1.1, 1.2, 1.3, 1.5 | Section subtotal. |
+
+> Note: the form has no §1.4; numbering follows the source form.
+
+### §2 Overhead
+
+| Code | Label | Type | Roll-up | Definition (include / exclude) |
+| --- | --- | --- | --- | --- |
+| 2.1 | Building | — | sum of 2.1.1–2.1.3 | — |
+| 2.1.1 | Depreciation | Fixed | leaf | Incl: "bricks & mortar", only if owned, 20-yr straight line. Excl: if renting (use 2.1.3); building-financing interest; land depreciation. |
+| 2.1.2 | Maintenance | Fixed | leaf | Incl: building maintenance, garbage removal fees. |
+| 2.1.3 | Rent | Fixed | leaf | Incl: building rental (only the retread-plant % of footage); leasehold improvements if owned. Excl: mortgage payments. |
+| 2.2 | Training Costs | Variable * | leaf | Incl: outside-trainer expense. Excl: trainer/trainee labor (use 1.1.1). |
+| 2.3 | Employment advertising / recruiting costs | Fixed | leaf | Recruiting/advertising for plant staff. |
+| 2.4 | Vehicle expenses (rubber dust trailer, shop truck) | Variable * | sum of 2.4.1–2.4.5 | Incl: vehicles for retread-plant use only; rubber-dust trailer fees. Excl: sales/distribution/warehousing vehicles; vehicle insurance (use 2.7.3); forklifts (use 2.11.5). |
+| 2.4.1 | Gas & Oil | — | leaf | Fuel/oil for plant vehicles. |
+| 2.4.2 | Maintenance | — | leaf | Maintenance for plant vehicles. |
+| 2.4.3 | Taxes | — | leaf | Taxes on plant vehicles. |
+| 2.4.4 | Depreciation | — | leaf | Depreciation of plant vehicles (standard methods). |
+| 2.4.5 | Rent | — | leaf | Rental of plant vehicles. |
+| 2.5 | Telephone | Fixed | leaf | Incl: voice/modem/data lines for plant; cell phones for plant personnel. |
+| 2.6 | Travel and Entertainment | Fixed | leaf | Incl: travel for plant manager/employees (e.g. PMPC). Excl: owner/corporate travel; promotional/entertainment (sales cost). |
+| 2.7 | Insurance | — | sum of 2.7.1–2.7.3 | Incl: fire/theft/liability for the retread plant; plant-vehicle insurance (2.7.3). Excl: warehouse/sales insurance. |
+| 2.7.1 | Fire | — | leaf | Fire insurance for the plant. |
+| 2.7.2 | Theft | — | leaf | Theft insurance for the plant. |
+| 2.7.3 | Liability | — | leaf | Liability insurance for the plant (incl. plant vehicles). |
+| 2.8 | Property Taxes | Fixed | leaf | Incl: property taxes for dealer-owned plant. Excl: if building rented; sales/income taxes. |
+| 2.9 | Supplies | — | sum of 2.9.1–2.9.4 | — |
+| 2.9.1 | Shop Consumables (rasps, grinding wheels, brushes) | Variable | leaf | Incl: buffing blades/brushes, grinding wheels. Excl: materials assembled to the tire (tread rubber, cushion gum, rope rubber, patches, cement, paint). |
+| 2.9.2 | Curing Consumables (envelopes, lube, wicks, poly) | Variable | leaf | Incl: curing envelopes, wicks, envelope lube, poly. |
+| 2.9.3 | Miscellaneous | Fixed | leaf | Incl: janitorial supplies, treatment chemicals, etc. |
+| 2.9.4 | Office | Fixed * | leaf | Incl: paper, pens, labels, office supplies. |
+| 2.10 | Utilities – gas, electric, water | Variable | leaf | Incl: gas/electric/water for the plant (may be an allocated % if shared). Excl: utilities for other operations in the building. |
+| 2.11 | Equipment expense | — | sum of 2.11.1–2.11.6 | — |
+| 2.11.1 | Maintenance | Variable * | leaf | Incl: equipment repairs/spare parts, computer maintenance, custom-mold cleaning. Excl: items under MRT warranty. |
+| 2.11.2 | Rental | Fixed | leaf | Incl: rental fees for air compressors, etc. |
+| 2.11.3 | Small tools and equipment | Fixed | leaf | Small tools/equipment purchases. |
+| 2.11.4 | Depreciation – MRT process equipment (**$US only**) | Fixed | leaf | Incl: MRT process equipment & installation at start-up/expansion (regardless of ownership); MRT mods > $5,000; 10-yr straight line (MRT provides value). Excl: non-MRT-process equipment. **Reported in USD even on local-currency plants.** |
+| 2.11.5 | Depreciation – Other shop equipment (boiler, cyclone, air compressors, capital cost of conversion) | Fixed | leaf | Incl: dealer-installed process support equipment, forklifts, capital conversion costs; 10-yr straight line (forklifts/computers use std methods). Excl: MRT-provided gas hot-water unit (in 2.11.4); equipment sales taxes; equipment financing interest. |
+| 2.11.6 | MRTI equipment leases or rent | Fixed | leaf | Incl: MRT software license fees (CIA, BIB TREAD); custom-mold rental. Excl: MRT process equipment rented from MRT/3rd party (in 2.11.4). |
+| 2.12 | Administration fees | Fixed | leaf | Incl: allocation for corporate accounting/payroll/personnel support (consistent monthly, not %-of-sales). Excl: corporate costs that would persist if plant closed (senior mgmt salaries, sales commissions). |
+| 2.13 | Inventory charge | Variable | leaf | Interest charge/credit for money funding inventory of materials & consumables. Expense = positive; interest income = negative. Excl: casing/stock-casing inventory charges; equipment financing interest. |
+| 2.14 | Income from rubber dust sales | Variable | leaf | Income from rubber-dust sales (enter as negative); or removal cost if not sold (positive). Excl: rubber-dust trailer rentals/fees (use 2.4). |
+| 2.15 | Production Quality | — | sum of 2.15.1–2.15.2 | — |
+| 2.15.1 | Casings scrapped in production (e.g. torn belts by buffer) | Variable | leaf | Incl: cost of casings damaged by the plant during production (casing cost + disposal). Excl: RAR scrap disposal fees. |
+| 2.15.2 | Adjustments (customer returns, user price plus transportation both ways) | Variable | leaf | Incl: materials/workmanship adjustment costs (fees, transport), shown in the month paid (not accrual), matching adjustments reported to MRT Quality. Excl: commercial concession adjustments; RAR disposal fees. |
+| — | **Total Overhead** | — | sum of 2.1–2.15 | Section subtotal. |
+| — | **Total Labor & Overhead** | — | Total Labor + Total Overhead | Grand total. |
+
+### §3.1 Currency conversion (footer)
+- **Local Currency per $US** — `1.00` for US plants; otherwise the configured rate.
+- The form displays an **Average** rate used for the year (workbook label "Avg").
+- Presentation context only; does not alter the stored local-currency amounts (except line 2.11.4 which is USD by definition).
+
+---
+
+## 4. Data sourcing — backend report endpoint
+
+A new **read-only** reporting endpoint returns the full matrix so the frontend does no aggregation.
+
+### 4.1 Proposed contract (to be finalized in BACKEND_CONTRACT_GUIDE)
+```
+GET /v1/accounting/reports/retread/labor-overhead
+    ?locationId={id}&fiscalYear={yyyy}[&asOfMonth={1-12}]
+```
+
+Response (shape; field names finalized during backend story):
+```jsonc
+{
+  "locationId": "LOC-107",
+  "locationLabel": "Smetzer's Wooster",
+  "fiscalYear": 2026,
+  "asOfMonth": 12,
+  "currency": "USD",
+  "localCurrencyPerUsd": 1.00,
+  "averageRate": 1.00,
+  "lines": [
+    {
+      "code": "1.1.1",
+      "label": "Hourly wages and bonuses",
+      "parentCode": "1.1",
+      "level": 3,
+      "costType": "VARIABLE",          // FIXED | VARIABLE | FIXED_IF_LOW_VOLUME
+      "isSubtotal": false,
+      "definition": "Incl: ... Excl: ...",
+      "monthly": [0,0,0,0,0,0,0,0,0,62645,0,0],  // index 0 = January
+      "ytd": 62645
+    }
+    // ... all lines + subtotal rows in canonical order
+  ]
+}
+```
+
+### 4.2 Aggregation rules (server-side)
+- For each **leaf** line, sum posted journal-entry-line amounts whose GL account is in that line's mapped
+  account set, whose `locationId` dimension = requested location, and whose transaction date falls in the
+  given month of the fiscal year.
+- **Subtotal** lines are computed from their children (never mapped directly).
+- **YTD** = sum of monthly values for elapsed months (1 … `asOfMonth`).
+- Sign conventions: lines 2.13 and 2.14 may be negative (income/credit) per the Definitions; preserve sign.
+- Amounts returned as whole local-currency dollars; line 2.11.4 in USD.
+- Reflects **posted** ledger state only (consistent with CAP-054 reporting behavior).
+
+### 4.3 Report-line → GL-account mapping
+- Mapping is **Accounting-domain-authored** (per intake decision). The endpoint resolves each report line
+  to one or more GL accounts via this mapping; the screen never embeds account numbers.
+- Open question for refinement: persisted, location-overridable master-data vs. static domain config for v1.
+
+### 4.4 Reuse of existing capabilities
+- **CAP-050** Chart of Accounts — GL account catalog / account metadata.
+- **CAP-051** GL posting / ledger lines + dimension model (`locationId`, cost-center) — the source of
+  posted amounts by account + dimension + date.
+- **CAP-054** Financial reporting — established pattern that reporting reflects posted state; this endpoint
+  follows the same conventions and lives alongside the `/v1/accounting/reports/...` family.
+
+---
+
+## 5. Authorization, NFRs, observability
+- Gated by the financial-reporting permission family (e.g. `reporting:view:financial-statements` or a
+  retread-report-specific scope to be confirmed by the Security/Accounting domains). Unauthorized → `403`.
+- No PII; data is financial aggregates by location.
+- Single round-trip for a full year; target P95 well within standard reporting SLAs.
+- Correlation/trace standards (AD-008) apply; reporting reads are auditable but non-mutating.
+
+---
+
+## 6. Out of scope
+- Cost-per-Unit view (needs production equivalent-unit counts — non-accounting source).
+- Data entry / the "Paste From File" import path.
+- Editing the report-line → GL mapping UI (admin capability, if needed, is separate).
+- Multi-location consolidation / cross-year comparison (possible future enhancement).
+
+---
+
+## 7. Traceability
+
+| Layer | Repo | Artifact |
+| --- | --- | --- |
+| Primary (high-level) | louisburroughs/durion | Issue #328 |
+| Backend story | louisburroughs/durion-positivity-backend | `01-labor-overhead-cost-report-endpoint.story.md` (this folder) → issue TBD |
+| Frontend story | louisburroughs/durion-positivity-frontend | `stories/frontend/CAP_316.frontend.md` (this folder) → issue TBD |
+| Contract | louisburroughs/durion | `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (add CAP-316 section) |

--- a/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
@@ -1,0 +1,79 @@
+meta:
+  capability_id: CAP:316
+  capability_name: 'CAP-316: Retread Plant Labor & Overhead Cost Report (read-only)'
+  owner_repo: louisburroughs/durion
+  created_utc: '2026-06-22T00:00:00Z'
+  last_updated_utc: '2026-06-22T00:00:00Z'
+parent_capability:
+  repo: louisburroughs/durion
+  issue: 328
+  title: 'CAP-316: Retread Plant Labor & Overhead Cost Report (read-only)'
+  domain: accounting
+  labels:
+  - type:capability
+  - domain:accounting
+  - CAP:316
+coordination:
+  github_project_url: https://github.com/users/louisburroughs/projects/1
+  status_field_name: status:{Backlog,Ready,In Progress,In Review,Done}
+  preferred_branch_prefix: cap/
+contract_registry:
+  root_path: domains
+  guide_path_suffix: .business-rules/BACKEND_CONTRACT_GUIDE.md
+  contract_status_markers:
+  - draft
+  - stable-for-ui
+repositories:
+- name: durion-positivity-backend
+  slug: louisburroughs/durion-positivity-backend
+  type: backend
+  notes: 'Read-only Labor & Overhead cost report endpoint.'
+- name: durion-positivity-frontend
+  slug: louisburroughs/durion-positivity-frontend
+  type: frontend
+  notes: 'Read-only cost report screen (Angular).'
+stories:
+- parent_story:
+    repo: louisburroughs/durion
+    issue: 328
+    title: 'CAP-316: Retread Plant Labor & Overhead Cost Report (read-only)'
+    domain: accounting
+    labels:
+    - type:capability
+    - domain:accounting
+    - CAP:316
+  children:
+    backend:
+      repo: louisburroughs/durion-positivity-backend
+      issue: ''  # TBD — see docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+      story_markdown_path: ./01-labor-overhead-cost-report-endpoint.story.md
+    frontend:
+      repo: louisburroughs/durion-positivity-frontend
+      issue: ''  # TBD — see ./stories/frontend/CAP_316.frontend.md
+      story_markdown_path: ./stories/frontend/CAP_316.frontend.md
+  contract_guide:
+    repo: louisburroughs/durion
+    path: domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md
+    anchor: ''
+    status: draft
+    openapi:
+      spec_path: pos-accounting/target/openapi.json
+  pr_links:
+    durion_contract_pr: ''
+    backend_pr: ''
+    frontend_prs: []
+  merge_order:
+  - durion_contract_pr
+  - backend_pr
+  - frontend_prs
+execution:
+  agent_rules:
+  - Backend changes that affect API/event behavior REQUIRE a durion contract PR.
+  - Frontend work starts only when contract status is stable-for-ui.
+  - 'One branch per repo per capability: cap/316.'
+  - Read-only capability — no posting/mutation paths may be introduced.
+  definition_of_done:
+  - All PRs merged and required checks green
+  - Contract guide entry (CAP-316) added with examples + behavioral assertions
+  - Provider behavioral contract tests prove amounts trace to posted GL data
+  - Frontend wired to stable contract; screen is strictly read-only

--- a/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
@@ -45,12 +45,12 @@ stories:
   children:
     backend:
       repo: louisburroughs/durion-positivity-backend
-      issue: ''  # TBD — see docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+      issue: 724
       story_markdown_path: ./01-labor-overhead-cost-report-endpoint.story.md
     frontend:
       repo: louisburroughs/durion-positivity-frontend
-      issue: ''  # TBD — see ./stories/frontend/CAP_316.frontend.md
-      story_markdown_path: ./stories/frontend/CAP_316.frontend.md
+      issue: 77
+      story_markdown_path: ./stories/frontend/CAP_316.77.frontend.md
   contract_guide:
     repo: louisburroughs/durion
     path: domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md

--- a/docs/capabilities/CAP-316/stories/frontend/CAP_316.77.frontend.md
+++ b/docs/capabilities/CAP-316/stories/frontend/CAP_316.77.frontend.md
@@ -1,6 +1,6 @@
 # [FRONTEND] [STORY] Accounting: Retread Plant Labor & Overhead Cost Report (read-only)
 
-> Target repo: **louisburroughs/durion-positivity-frontend**
+> Target repo: **louisburroughs/durion-positivity-frontend** — issue #77
 > Parent capability: CAP-316 — louisburroughs/durion#328
 > Backend story: `docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md`
 > Labels: `type:story`, `domain:accounting`, `status:needs-review`

--- a/docs/capabilities/CAP-316/stories/frontend/CAP_316.frontend.md
+++ b/docs/capabilities/CAP-316/stories/frontend/CAP_316.frontend.md
@@ -1,0 +1,130 @@
+# [FRONTEND] [STORY] Accounting: Retread Plant Labor & Overhead Cost Report (read-only)
+
+> Target repo: **louisburroughs/durion-positivity-frontend**
+> Parent capability: CAP-316 — louisburroughs/durion#328
+> Backend story: `docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md`
+> Labels: `type:story`, `domain:accounting`, `status:needs-review`
+> Branch: `cap/316-labor-overhead-cost-report`
+
+## 1. Story Header
+- **Title:** Retread Plant Labor & Overhead Cost Report (read-only monthly + YTD by location/year)
+- **Primary Persona:** Finance Ops User / Accounting Clerk (read-only reporting)
+- **Persona Metadata**
+  - `primary_persona`: Finance Ops User / Accounting Clerk
+  - `canonical_persona`: Accounting Associate
+  - `persona_family`: Accounting Associate
+  - `actor_type`: human
+- **Business Value:** Lets finance users and auditors review a retread plant's annual labor & overhead
+  costs in the canonical MRTI chart-of-accounts layout (monthly + YTD) for any location/year, sourced from
+  posted GL data, without spreadsheets or database access.
+
+## 2. Story Intent
+**As a** Finance Ops user
+**I want** a read-only screen that shows the retread-plant Labor & Overhead cost report for a chosen
+location and fiscal year, with monthly (Jan–Dec) and YTD columns and the canonical cost-line hierarchy
+**So that** I can review and audit plant costs in the familiar MRTI form layout directly from posted
+accounting data.
+
+### In-scope
+- Location/dealer + fiscal year (+ optional as-of month) selectors.
+- Hierarchical cost matrix: Labor §1, Overhead §2, sub-lines, and subtotals (Total Labor, Total Overhead,
+  Total Labor & Overhead), with Jan–Dec + YTD columns.
+- Per-line inline help: definition (include/exclude) and Fixed/Variable classification.
+- Currency-conversion context row (Local Currency per $US; 1.00 for US plants).
+- Empty/error/unauthorized states; optional presentation-only export (CSV/print).
+
+### Out-of-scope
+- Any data entry, editing, posting, or GL inference.
+- Cost-per-Unit view (requires production unit counts — separate capability).
+- The "Paste From File" import path.
+- Editing the report-line → GL mapping.
+
+## 3. Actors & Stakeholders
+- **Primary user:** Finance Ops / Accounting Clerk.
+- **Secondary:** Auditors/Compliance (read-only), plant/dealer management (review).
+- **System of record:** Accounting backend (posted GL data) via the CAP-316 report endpoint.
+
+## 4. Preconditions & Dependencies
+- Backend endpoint (CAP-316 backend story):
+  `GET /v1/accounting/reports/retread/labor-overhead?locationId={id}&fiscalYear={yyyy}[&asOfMonth={1-12}]`
+  returning the line matrix + currency context (see backend story for shape).
+- Location/dealer list available for the selector (existing location reference data).
+- User holds the financial-reporting permission.
+
+## 5. UX Summary
+- **Entry point:** Accounting → Reports → "Retread Labor & Overhead Cost Report".
+- **Layout:** header (Dealer/Location, Year, "$ in whole dollars local currency (except 2.11.4)"),
+  selector bar, then a sticky-header matrix grid; currency-conversion row in the footer.
+- **Grid:** first column = cost-line code + label (indented by level); 12 month columns; YTD column.
+  Subtotal rows visually emphasized. Help affordance (ⓘ) per line reveals definition + Fixed/Variable type.
+- **Navigation:** changing location/year/as-of month reloads the report.
+
+## 6. Functional Behavior
+- On load with a selected location + year, call the report endpoint once and render the returned ordered
+  lines as-is (no client-side aggregation — backend provides monthly, YTD, and subtotals).
+- As-of month bounds populated columns/YTD; future months render empty/`0`.
+- Numbers formatted as whole dollars; negative values (e.g. 2.13, 2.14) shown per accounting convention
+  (e.g. parentheses or minus).
+- Line 2.11.4 indicated as USD even when the plant currency is local.
+
+## 7. Business Rules (UI)
+- Strictly read-only: no editable cells, no mutating actions.
+- Render every line in canonical order even when `0`; never drop lines (the form layout is contractual).
+- Subtotals come from the backend; the UI does not recompute or "fix" mismatches — it displays returned
+  values (and may show a diagnostic if a subtotal ≠ sum of children, without altering data).
+- Help text and Fixed/Variable type come from line metadata; do not hard-code.
+
+## 8. Data Requirements
+- **Report header:** `locationId`, `locationLabel`, `fiscalYear`, `asOfMonth`, `currency`,
+  `localCurrencyPerUsd`, `averageRate`.
+- **Per line:** `code`, `label`, `parentCode`, `level`, `costType`, `isSubtotal`, `definition`,
+  `monthly[12]` (index 0 = January), `ytd`.
+- All amounts read-only; derived/calculated entirely server-side.
+
+## 9. Service Contracts (frontend perspective)
+- **Load:** `GET /v1/accounting/reports/retread/labor-overhead` with `locationId`, `fiscalYear`,
+  optional `asOfMonth`. Use the generated Angular SDK client.
+- **No** create/update/submit calls.
+- Handle `200` (render), `400` (invalid params → inline message), `403` (not authorized → access message),
+  `404` (unknown location → message), `5xx` (retryable error state).
+
+## 10. State Model
+- `idle → loading → loaded | empty | error`.
+- `empty`: `200` with all-zero lines → show full layout with `0`s and an "no posted activity" note.
+- `error`: surface non-leaking message; offer retry.
+
+## 11. Alternate / Error Flows
+- Missing/invalid location or year → block load, prompt selection.
+- `403` → access-denied panel, no data.
+- Backend timeout/`5xx` → error state with retry.
+- Partial data / missing mapping for a line → backend returns `0`; UI may show a subtle "unmapped" hint via
+  the line help, without erroring the report.
+
+## 12. Acceptance Criteria
+- [ ] Selecting a location + fiscal year renders the full Labor & Overhead hierarchy with Jan–Dec + YTD
+      columns and subtotal rows, in canonical order.
+- [ ] Displayed amounts match the backend response exactly (no client aggregation).
+- [ ] Per-line help shows the correct definition and Fixed/Variable classification.
+- [ ] Currency-conversion row is shown (1.00 for US plants); 2.11.4 indicated as USD.
+- [ ] As-of month bounds the populated columns and YTD.
+- [ ] Empty, error, and `403` states render correctly with no data leakage.
+- [ ] No mutating actions exist anywhere on the screen.
+- [ ] Accessible: keyboard-navigable grid, header associations for screen readers; i18n via ngx-translate.
+
+## 13. Audit & Observability
+- Read-only view; no audit writes. Include correlation/trace headers via the SDK per platform standard.
+
+## 14. Non-Functional UI Requirements
+- Single request per (location, year, as-of) selection; loading indicator while fetching.
+- Accessibility: ARIA grid semantics, keyboard navigation, sufficient contrast (html-css + a11y guidance).
+- i18n: all labels/help via ngx-translate (ADR-0029…0038 Angular conventions); numeric/locale formatting.
+- Responsive down to tablet; matrix horizontally scrollable with sticky line-label column.
+
+## 15. Applied Safe Defaults
+- Read-only, permission-gated, no payload of raw GL detail (aggregates only).
+- Lines always rendered in canonical order; zeros shown rather than omitted.
+
+## 16. Open Questions
+- Confirm the financial-reporting permission scope name for this report.
+- Confirm the location/dealer selector source aligns with the accounting `locationId` dimension.
+- Is CSV/print export required for v1, or a fast-follow?


### PR DESCRIPTION
Superseded by #331 (this branch had diverged from the squash-merged `master` and could not merge cleanly). Closing in favor of #331, which is merged.