### PR TITLE
[CAP:316] Accounting: wire backend/frontend issue numbers into CAP-316 manifest

### DIFF
--- a/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+++ b/docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
@@ -1,6 +1,6 @@
 # Story: Read-only Retread Plant Labor & Overhead Cost Report endpoint
 
-> Target repo: **louisburroughs/durion-positivity-backend**
+> Target repo: **louisburroughs/durion-positivity-backend** — issue #724
 > Parent capability: CAP-316 — louisburroughs/durion#328
 > Labels: `type:story`, `domain:accounting`, `status:needs-review`
 > Branch: `cap/316-labor-overhead-cost-report`

--- a/docs/capabilities/CAP-316/CAP-316-spec.md
+++ b/docs/capabilities/CAP-316/CAP-316-spec.md
@@ -231,6 +231,6 @@ Response (shape; field names finalized during backend story):
 | Layer | Repo | Artifact |
 | --- | --- | --- |
 | Primary (high-level) | louisburroughs/durion | Issue #328 |
-| Backend story | louisburroughs/durion-positivity-backend | `01-labor-overhead-cost-report-endpoint.story.md` (this folder) → issue TBD |
-| Frontend story | louisburroughs/durion-positivity-frontend | `stories/frontend/CAP_316.frontend.md` (this folder) → issue TBD |
+| Backend story | louisburroughs/durion-positivity-backend | `01-labor-overhead-cost-report-endpoint.story.md` (this folder) → issue #724 |
+| Frontend story | louisburroughs/durion-positivity-frontend | `stories/frontend/CAP_316.77.frontend.md` (this folder) → issue #77 |
 | Contract | louisburroughs/durion | `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` (add CAP-316 section) |

--- a/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-316/CAPABILITY_MANIFEST.yaml
@@ -45,12 +45,12 @@ stories:
   children:
     backend:
       repo: louisburroughs/durion-positivity-backend
-      issue: ''  # TBD — see docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md
+      issue: 724
       story_markdown_path: ./01-labor-overhead-cost-report-endpoint.story.md
     frontend:
       repo: louisburroughs/durion-positivity-frontend
-      issue: ''  # TBD — see ./stories/frontend/CAP_316.frontend.md
-      story_markdown_path: ./stories/frontend/CAP_316.frontend.md
+      issue: 77
+      story_markdown_path: ./stories/frontend/CAP_316.77.frontend.md
   contract_guide:
     repo: louisburroughs/durion
     path: domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md

--- a/docs/capabilities/CAP-316/stories/frontend/CAP_316.77.frontend.md
+++ b/docs/capabilities/CAP-316/stories/frontend/CAP_316.77.frontend.md
@@ -1,6 +1,6 @@
 # [FRONTEND] [STORY] Accounting: Retread Plant Labor & Overhead Cost Report (read-only)
 
-> Target repo: **louisburroughs/durion-positivity-frontend**
+> Target repo: **louisburroughs/durion-positivity-frontend** — issue #77
 > Parent capability: CAP-316 — louisburroughs/durion#328
 > Backend story: `docs/capabilities/CAP-316/01-labor-overhead-cost-report-endpoint.story.md`
 > Labels: `type:story`, `domain:accounting`, `status:needs-review`


### PR DESCRIPTION
## Capability & Traceability
- cap: CAP-316
- Primary capability story: louisburroughs/durion#328
- Backend story: louisburroughs/durion-positivity-backend#724
- Frontend story: louisburroughs/durion-positivity-frontend#77
- Domain: accounting

## Scope
Follow-up to #329: wires the now-created backend/frontend story issue numbers into the CAP-316 capability manifest and spec traceability, and renames the frontend story file to the numbered convention `CAP_316.77.frontend.md`. Docs-only.

(Replaces #330, which was opened from a diverged branch and had merge conflicts.)

## Tests
- [ ] N/A — documentation only.

## Risk & Rollback
- Risk: low. Rollback: revert the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CTiEzTDLXMLkkGofdzHYR)_