### PR TITLE
chore(claude): wire AWS MCP access and SessionStart setup hook

### DIFF
--- a/.claude/README-aws.md
+++ b/.claude/README-aws.md
@@ -1,0 +1,53 @@
+# AWS Access for Claude Code
+
+This repo is wired so Claude Code can both run on AWS and act on your AWS account.
+There are two independent layers — set up whichever you need.
+
+## 1. Resource access via AWS MCP servers (configured here)
+
+`.mcp.json` registers two official AWS Labs MCP servers:
+
+| Server     | Package                                     | Purpose                                   |
+| ---------- | ------------------------------------------- | ----------------------------------------- |
+| `aws-api`  | `awslabs.aws-api-mcp-server@latest`         | Call any AWS API (structured, scoped)     |
+| `aws-docs` | `awslabs.aws-documentation-mcp-server@latest` | Retrieve current AWS docs at query time |
+
+These run via `uvx` (the `uv` Python tool runner). The `SessionStart` hook
+`.claude/hooks/aws-setup-hook.sh` ensures `uv` is installed in ephemeral web
+sandboxes and reports credential status (never the secret values).
+
+Safety default: `aws-api` runs with `REQUIRE_MUTATION_CONSENT=true`, so write
+operations require approval. To make it read-only, set `READ_OPERATIONS_ONLY=true`
+in `.mcp.json`.
+
+### Credentials
+
+The MCP server uses the standard AWS SDK credential chain. Provide credentials as
+**environment variables / secrets in your Claude Code web environment settings** —
+never commit them:
+
+- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`)
+- or `AWS_PROFILE` with a mounted `~/.aws/credentials`
+
+Use least-privilege, ideally short-lived (STS) credentials — the sandbox is
+disposable.
+
+### Network policy
+
+The web environment's outbound network policy must allow reaching AWS API/MCP
+endpoints, or calls will fail. See
+https://code.claude.com/docs/en/claude-code-on-the-web
+
+## 2. Run the Claude model on Amazon Bedrock (optional, opt-in)
+
+This changes *where the model runs* (Anthropic API → your Bedrock account). It is
+**not** enabled by default because it requires valid Bedrock access. To enable, set
+in your environment:
+
+```bash
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+# plus AWS credentials as above
+```
+
+Your IAM principal needs `bedrock:InvokeModel*` and inference-profile permissions.

--- a/.claude/hooks/aws-setup-hook.sh
+++ b/.claude/hooks/aws-setup-hook.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SessionStart hook: prepare AWS access for Claude Code (web/ephemeral sandboxes).
+#
+# Purpose:
+# - Ensure `uv`/`uvx` is available so the AWS MCP servers in .mcp.json can launch.
+# - Report whether AWS credentials are present, without leaking secret values.
+#
+# This hook is advisory only: it never fails the session (always exits 0) and
+# never prints credential values. Configure AWS credentials as environment
+# variables / secrets in your Claude Code web environment settings, NOT in the
+# repository. See AGENTS.md and .claude/README-aws.md.
+
+set -uo pipefail
+
+log() { printf '[aws-setup] %s\n' "$1"; }
+
+# 1) Ensure uvx is available (needed to run the awslabs.* MCP servers).
+if ! command -v uvx >/dev/null 2>&1; then
+  log "uvx not found; attempting to install uv (Astral)..."
+  if command -v curl >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
+    # uv installs to ~/.local/bin or ~/.cargo/bin depending on platform.
+    for d in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+      [ -d "$d" ] && case ":$PATH:" in *":$d:"*) ;; *) PATH="$d:$PATH" ;; esac
+    done
+    export PATH
+  fi
+fi
+
+if command -v uvx >/dev/null 2>&1; then
+  log "uvx available: $(command -v uvx)"
+else
+  log "WARNING: uvx still unavailable -- AWS MCP servers in .mcp.json will not start."
+  log "         Install uv manually: curl -LsSf https://astral.sh/uv/install.sh | sh"
+fi
+
+# 2) Report AWS credential availability (presence only -- never the values).
+cred_source=""
+if [ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]; then
+  cred_source="AWS_BEARER_TOKEN_BEDROCK (Bedrock API key)"
+elif [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  cred_source="AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars"
+elif [ -n "${AWS_PROFILE:-}" ]; then
+  cred_source="AWS_PROFILE=${AWS_PROFILE}"
+elif [ -f "$HOME/.aws/credentials" ]; then
+  cred_source="~/.aws/credentials file"
+fi
+
+if [ -n "$cred_source" ]; then
+  log "AWS credentials detected via: ${cred_source}"
+  log "AWS_REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-<unset, MCP defaults to us-east-1>}}"
+  if [ "${CLAUDE_CODE_USE_BEDROCK:-0}" = "1" ]; then
+    log "Model routing: Amazon Bedrock (CLAUDE_CODE_USE_BEDROCK=1)."
+  fi
+else
+  log "No AWS credentials detected."
+  log "Set them as environment variables/secrets in your web environment settings"
+  log "(AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, or AWS_PROFILE). Do NOT commit secrets."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,17 @@
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/aws-setup-hook.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "aws-api": {
+      "command": "uvx",
+      "args": ["awslabs.aws-api-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "us-east-1",
+        "REQUIRE_MUTATION_CONSENT": "true"
+      }
+    },
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "AWS_DOCUMENTATION_PARTITION": "aws"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Scope
- **What changed:** Configures Claude Code to access AWS in two independent layers.
  - `.mcp.json` — registers the official AWS Labs MCP servers `aws-api` (`awslabs.aws-api-mcp-server`, structured access to any AWS API) and `aws-docs` (`awslabs.aws-documentation-mcp-server`, live AWS docs), launched via `uvx`. `aws-api` defaults to `REQUIRE_MUTATION_CONSENT=true` so write operations require approval.
  - `.claude/hooks/aws-setup-hook.sh` — `SessionStart` hook that ensures `uv`/`uvx` is installed in ephemeral web sandboxes and reports AWS credential presence (never the secret values). Advisory-only; always exits 0.
  - `.claude/settings.json` — wires the hook into `SessionStart`.
  - `.claude/README-aws.md` — documents MCP resource access plus optional Amazon Bedrock model routing.
- **Why:** Lets Claude Code operate on the AWS account (via MCP) and, optionally, run the model on Bedrock, with credentials supplied as environment secrets rather than committed to the repo.

## Notes
- No application/runtime code changed — this only affects the Claude Code tooling configuration.
- Amazon Bedrock model routing (`CLAUDE_CODE_USE_BEDROCK=1`) is intentionally **not** forced on, since it requires valid Bedrock access; it is documented as opt-in.
- AWS credentials must be provided as environment variables/secrets in the web environment settings (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or `AWS_PROFILE`); none are committed.

## Tests
- `.mcp.json` and `.claude/settings.json` validated as JSON.
- `aws-setup-hook.sh` executed successfully (exit 0); `uvx` detected and credential presence reported.

## Risk & Rollback
- Risk level: Low (tooling/config only; no runtime code paths affected).
- Rollback plan: revert this commit / delete the four added/modified files.

## Checklist
- [x] No secrets committed
- [x] JSON config validated
- [x] SessionStart hook runs and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1tDgyAPBMSkkq9NC9TeY)_