### PR TITLE
[CAP:007] Invoice finder search story — manifest + impl doc

### DIFF
--- a/docs/capabilities/CAP-007/CAP-007-backend-implementation.md
+++ b/docs/capabilities/CAP-007/CAP-007-backend-implementation.md
@@ -1,4 +1,4 @@
-# CAP-007 — Invoice Finder Search Endpoint (Backend Implementation)
+## CAP-007 — Invoice Finder Search Endpoint (Backend Implementation)
 
 Parent capability: **CAP:007 — Convert Workorder to Invoice** (durion#7)
 Parent story: durion#337 · Backend child: durion-positivity-backend#765
@@ -19,10 +19,10 @@ two cross-service clients, mirroring the proven pos-workorder finder
 
 ## Endpoint
 
-```
+```text
 GET /v1/invoices/search?q={q}&page={p}&size={s}
 Authority: invoice:manage   Event: INVOICE_SEARCH (fastRead)
-200 → Page<InvoiceSearchResult>
+200 → Page<InvoiceSearchResult>   400 invalid pageable   403 missing invoice:manage
 ```
 
 `InvoiceSearchResult`: `invoiceId, invoiceNumber, customerName, workorderNumber,

--- a/docs/capabilities/CAP-007/CAP-007-backend-implementation.md
+++ b/docs/capabilities/CAP-007/CAP-007-backend-implementation.md
@@ -1,0 +1,95 @@
+# CAP-007 — Invoice Finder Search Endpoint (Backend Implementation)
+
+Parent capability: **CAP:007 — Convert Workorder to Invoice** (durion#7)
+Parent story: durion#337 · Backend child: durion-positivity-backend#765
+Branch: `cap/CAP007`
+
+## Summary
+
+Adds a free-text **invoice finder** backing the billing landing invoice-detail card.
+A new endpoint `GET /v1/invoices/search?q=` matches the query against the **invoice
+number**, **customer name**, and **workorder number**, returning a paginated
+`InvoiceSearchResult` enriched with the resolved customer display name and human
+workorder number.
+
+The invoice row stores only `workorderId` (UUID) and `partyId` (string) — neither the
+customer name nor the human workorder number — so the search resolves and enriches via
+two cross-service clients, mirroring the proven pos-workorder finder
+(`WorkorderSearchController` + `CustomerReferenceService`).
+
+## Endpoint
+
+```
+GET /v1/invoices/search?q={q}&page={p}&size={s}
+Authority: invoice:manage   Event: INVOICE_SEARCH (fastRead)
+200 → Page<InvoiceSearchResult>
+```
+
+`InvoiceSearchResult`: `invoiceId, invoiceNumber, customerName, workorderNumber,
+status, total, createdAt`.
+
+## Query semantics
+
+`InvoiceRepository.searchByQuery`:
+
+```jpql
+SELECT i FROM Invoice i
+WHERE LOWER(i.invoiceNumber) LIKE LOWER(CONCAT('%', :q, '%'))
+   OR i.partyId IN :customerIds
+   OR i.workorderId IN :workorderIds
+```
+
+- `customerIds` — party ids resolved from the customer-name leg (CRM).
+- `workorderIds` — workorder ids resolved from the workorder-number leg (workorder svc).
+- Empty legs pass a non-matching sentinel (`"__none__"` / `new UUID(0,0)`) so the JPQL
+  `IN` clauses stay non-empty.
+
+## Cross-service clients (RestClient, direct DNS)
+
+| Client | Target | Calls |
+| --- | --- | --- |
+| `CustomerReferenceClient` | pos-customer `/v1/crm` | `GET /accounts/parties?name=` (id search), `GET /{partyId}` (name enrichment) |
+| `WorkorderReferenceClient` | pos-workorder `/v1/workorders` | `GET /search?q=` (number→ids), `POST /numbers:resolve` (ids→numbers enrichment) |
+
+`RestClientConfig` (new) declares a `@Primary RestClient.Builder` so the module's
+outbound clients resolve in boots where the auto-configured builder is absent (e.g. the
+`openapi`/`dev` profile with service discovery disabled).
+
+## pos-workorder addition
+
+`POST /v1/workorders/numbers:resolve` (`WorkorderSearchController.resolveNumbers`) —
+batch id→number resolution consumed server-side by pos-invoice for row enrichment.
+Event `WORKORDER_NUMBER_RESOLVE`.
+
+## Files
+
+### pos-invoice
+- `internal/client/CustomerReferenceClient.java` (new)
+- `internal/client/WorkorderReferenceClient.java` (new)
+- `internal/config/RestClientConfig.java` (new)
+- `internal/dto/InvoiceSearchResult.java` (new)
+- `internal/controller/InvoiceSearchController.java` (new)
+- `internal/service/InvoiceSearchServiceImpl.java` (new) · `service/InvoiceSearchService.java` (new)
+- `internal/repository/InvoiceRepository.java` (+`searchByQuery`)
+- `internal/config/EventTypes.java` (+`INVOICE_SEARCH`)
+- tests: `InvoiceSearchServiceImplTest`, `InvoiceSearchControllerTest`
+
+### pos-workorder
+- `internal/dto/WorkorderNumberResolveRequest.java`, `WorkorderNumberRef.java` (new)
+- `internal/controller/WorkorderSearchController.java` (+`resolveNumbers`)
+- `internal/service/WorkorderSearchServiceImpl.java` + `service/WorkorderSearchService.java` (+`resolveNumbers`)
+- `internal/config/EventTypes.java` (+`WORKORDER_NUMBER_RESOLVE`)
+- test: `WorkorderNumberResolveTest`
+
+## Contract chain
+
+- `pos-invoice/openapi.yaml` + `openapi.json` regenerated (adds `/v1/invoices/search`,
+  `InvoiceSearchResult`, `PageInvoiceSearchResult`).
+- Angular SDK `@durion-sdk/invoice` regenerated (`InvoiceSearchService.searchInvoices`,
+  `InvoiceSearchResult`); repacked tarball installed into the frontend.
+
+## Test results
+
+`InvoiceSearchServiceImplTest` (3), `InvoiceSearchControllerTest` (3),
+`WorkorderNumberResolveTest` (2) — all green.
+Frontend billing specs: 41 passing; dev build clean.

--- a/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
@@ -270,6 +270,44 @@ stories:
   - durion_contract_pr
   - backend_pr
   - frontend_prs
+- parent_story:
+    repo: louisburroughs/durion
+    issue: 337
+    title: '[STORY] Invoicing: Invoice Finder Search Endpoint (billing detail card)'
+    labels:
+    - domain:workexec
+    - layer:functional
+    - type:story
+    - CAP:007
+  children:
+    backend:
+      repo: louisburroughs/durion-positivity-backend
+      issue: 765
+    frontend:
+      repo: louisburroughs/durion-positivity-frontend
+      issue: null
+      impacted_component_repos: []
+      business_rules:
+      - repo: louisburroughs/durion
+        path: domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+      story_markdown_path: ''
+  contract_guide:
+    repo: louisburroughs/durion
+    path: domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+    anchor: ''
+    status: draft
+    openapi:
+      producer_repo: louisburroughs/durion-positivity-backend
+      spec_path: pos-invoice/openapi.yaml
+      generated: true
+  pr_links:
+    durion_contract_pr: ''
+    backend_pr: ''
+    frontend_prs: []
+  merge_order:
+  - durion_contract_pr
+  - backend_pr
+  - frontend_prs
 execution:
   agent_rules:
   - Backend changes that affect API/event behavior REQUIRE a durion contract PR.

--- a/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
@@ -294,8 +294,8 @@ stories:
   contract_guide:
     repo: louisburroughs/durion
     path: domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md
-    anchor: ''
-    status: draft
+    anchor: '#cap-007-invoice-finder-search'
+    status: stable-for-ui
     openapi:
       producer_repo: louisburroughs/durion-positivity-backend
       spec_path: pos-invoice/openapi.yaml

--- a/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
+++ b/docs/capabilities/CAP-007/CAPABILITY_MANIFEST.yaml
@@ -301,12 +301,15 @@ stories:
       spec_path: pos-invoice/openapi.yaml
       generated: true
   pr_links:
-    durion_contract_pr: ''
-    backend_pr: ''
-    frontend_prs: []
+    durion_contract_pr: louisburroughs/durion#338
+    backend_pr: louisburroughs/durion-positivity-backend#766
+    sdk_pr: louisburroughs/durion-positivity-sdk-angular#21
+    frontend_prs:
+    - louisburroughs/durion-positivity-frontend#135
   merge_order:
   - durion_contract_pr
   - backend_pr
+  - sdk_pr
   - frontend_prs
 execution:
   agent_rules:

--- a/domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -219,6 +219,51 @@ Headers and auth notes:
 
 ---
 
+## CAP-007: Invoice Finder Search
+
+### Capability Metadata
+
+- Capability: `cap:007` — Convert Workorder to Invoice
+- Parent story: [durion#337](https://github.com/louisburroughs/durion/issues/337)
+- Backend child: [durion-positivity-backend#765](https://github.com/louisburroughs/durion-positivity-backend/issues/765)
+- Module: `pos-invoice` (with a server-side dependency on `pos-workorder`)
+
+### Frontend API Lookup
+
+- `GET /v1/invoices/search?q={q}&page={p}&size={s}` → `Page<InvoiceSearchResult>` — finder backing the billing landing invoice-detail card. SDK: `InvoiceSearchService.searchInvoices(pageable, q)`.
+
+### Permission Matrix
+
+- `GET /v1/invoices/search` requires authority `invoice:manage`.
+- `POST /v1/workorders/numbers:resolve` (pos-workorder, internal) requires authority `workorder:workorder:view`.
+
+### Behavioral Assertions
+
+- The query matches the **invoice number** (case-insensitive substring; LIKE metacharacters `%`/`_` are escaped and matched literally), the **customer name** (resolved to party ids via pos-customer), or the **workorder number** (resolved to workorder ids via pos-workorder).
+- Each result row is enriched with the resolved customer display name and the human workorder number; the invoice row itself stores only `partyId` and `workorderId`.
+- A blank/whitespace `q` returns an empty page (the finder requires a term; it does not list all invoices).
+- Page size is capped at 50; default sort is `createdAt` descending for deterministic pagination.
+- Reference resolution/enrichment runs outside any open DB transaction, with bounded connect/read timeouts on the outbound calls; a sibling-service failure degrades the affected enrichment field to null rather than failing the search.
+- `InvoiceSearchResult`: `invoiceId`, `invoiceNumber`, `customerName`, `workorderId`, `workorderNumber`, `status` (`DRAFT|FINALIZED|POSTED|ERROR`), `total`, `createdAt`.
+
+### Status Code Semantics (ADR-0017)
+
+- `200 OK` — page of results (possibly empty).
+- `400 Bad Request` — invalid pagination parameters.
+- `403 Forbidden` — caller lacks `invoice:manage`.
+
+### Events
+
+- `INVOICE_SEARCH` (fastRead) — emitted on invoice search.
+- `WORKORDER_NUMBER_RESOLVE` (fastRead) — emitted on the pos-workorder batch id→number resolution.
+
+### Implementation Links
+
+- [Parent story #337](https://github.com/louisburroughs/durion/issues/337) · [Backend #765](https://github.com/louisburroughs/durion-positivity-backend/issues/765)
+- Implementation doc: `docs/capabilities/CAP-007/CAP-007-backend-implementation.md`
+
+---
+
 ## Events & Cross-Domain Dependencies
 
 - This domain exchanges data with other services only through REST APIs and message/event contracts.


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:007`
- Parent CAPABILITY (durion): louisburroughs/durion#7
- Parent STORY (durion): louisburroughs/durion#337
- Backend child: louisburroughs/durion-positivity-backend#765
- Domain: `domain:workexec`

## Contract References
- Contract guide: `domains/billing/.business-rules/BACKEND_CONTRACT_GUIDE.md`
- Backend PR: louisburroughs/durion-positivity-backend cap/CAP007 (linked below)

## Scope
- **What changed:** Attach the invoice finder search story to CAP:007 — adds the story entry (parent #337 / backend child #765, billing contract guide, pos-invoice openapi) to `CAPABILITY_MANIFEST.yaml` and a backend implementation doc.
- **Why:** Track the new `GET /v1/invoices/search` finder backing the billing invoice-detail card under its owning capability.

## Tests
- [x] N/A — docs/manifest only

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert this commit; no runtime impact.

## Checklist
- [x] Branch name matches `cap/CAP007`
- [x] PR title starts with `[CAP:007]`
- [x] Links to parent + child issues present
- [x] Contract guide referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPnKQCAYe7utAWerR4H7gY
