### PR TITLE
docs(adr): amend ADR-0044 with scoped pos-warranty v1 sync-client exception

### DIFF
--- a/docs/adr/0044-platform-event-only-domain-walls.adr.md
+++ b/docs/adr/0044-platform-event-only-domain-walls.adr.md
@@ -1,6 +1,6 @@
 # ADR-0044: Event-Only Domain Walls and Module Communication Policy
 
-**Status:** ACCEPTED
+**Status:** ACCEPTED — amended 2026-07-16 (scoped pos-warranty v1 exception, see §Amendments)
 **Date:** 2026-07-08 (accepted 2026-07-08)
 **Deciders:** Architecture, Backend Lead
 **Affected Issues:** durion-positivity-backend#823
@@ -213,6 +213,29 @@ becomes tier-1 operational surface (lag, DLQ, partition management); one fronten
 point of failure, not designed as a broker); keeping sync reads with caching (does not remove the
 runtime dependency or the model leak); synchronous write exceptions (would leave the strongest
 coupling — accounting↔invoice/workorder — in place indefinitely).
+
+---
+
+## Amendments
+
+### 2026-07-16 — Scoped exception: pos-warranty v1 synchronous clients
+
+`pos-warranty` (new domain module, durion-positivity-backend#786) is granted a scoped exception to
+R1 for its v1: synchronous `@LoadBalanced RestClient` calls from
+`com.positivity.warranty.internal.client` to `pos-invoice`, `pos-workorder`, `pos-catalog`,
+`pos-customer`, and `pos-vehicle-inventory` are permitted, per
+`durion-positivity-backend/docs/PRD-warranty-claims-module.md` §9.4 (approved 2026-07-15).
+Rationale: candidate-line origin search across invoices/workorders and settlement execution
+against pos-invoice are inherently synchronous counter flows. The dependency is one-directional:
+no module calls into pos-warranty synchronously; warranty state leaves the module only as
+`warranty.*` domain events (including a full claim snapshot event for replica builders).
+
+- **Enforcement.** Encoded in `DomainWallsTest` (pos-archunit) as a per-consumer exception map
+  (`pos-warranty` → exactly those five targets). The utility whitelist is **unchanged**; any other
+  module adding a synchronous domain client, and pos-warranty targeting any other domain module,
+  still fails the build. Widening the map requires a further amendment to this ADR.
+- **Evolution.** Migration to event-fed read-only replicas (R3) remains the target pattern for
+  these reads; it MUST accompany any warranty v2.
 
 ---
 


### PR DESCRIPTION
Ports the ADR-0044 amendment (already present in `durion-positivity-backend/docs/adr-0044-event-only-domain-walls.md` on the pos-warranty branch) into the canonical ADR text here: a **scoped, dated exception** permitting pos-warranty v1 synchronous `@LoadBalanced RestClient` calls from `com.positivity.warranty.internal.client` to pos-invoice, pos-workorder, pos-catalog, pos-customer, and pos-vehicle-inventory, per `PRD-warranty-claims-module.md` §9.4 (approved 2026-07-15).

The exception is one-directional and narrowly enforced: no module calls into pos-warranty synchronously; warranty state leaves the module only as `warranty.*` domain events (including a full `warranty.claim.snapshot` aggregate for replica builders). `DomainWallsTest` in pos-archunit encodes it as a per-consumer exception map — the global utility whitelist is unchanged, any other module adding a sync domain client still fails the build, and event-fed replicas (R3) remain mandatory for warranty v2.

## Capability & Traceability
- Capability: warranty claims module (no `cap:` id — work tracked against the PRD)
- Parent STORY (durion): n/a — spec is `durion-positivity-backend/docs/PRD-warranty-claims-module.md`
- Child issue: louisburroughs/durion-positivity-backend#786; implementation PR louisburroughs/durion-positivity-backend#920
- Domain: `domain:warranty`

## Contract References
- n/a — documentation-only ADR amendment; no API or event behavior changes in this PR. The enforcement change (DomainWallsTest exception map) and the warranty event contracts ship in durion-positivity-backend#920.

## Scope
- What changed: `docs/adr/0044-platform-event-only-domain-walls.adr.md` — status line marked amended 2026-07-16; new `## Amendments` section recording the scoped exception, its enforcement mechanism, and the v2 replica obligation.
- Why: the backend copy of the ADR was amended when pos-warranty was built; the canonical text here must not drift from what pos-archunit enforces.

## Tests
- [ ] Unit tests added/updated — n/a (docs only)
- [ ] Integration tests added/updated — n/a
- [x] Provider behavioral contract tests added/updated (backend) — enforcement verified in durion-positivity-backend#920: pos-archunit full suite 20/20 incl. `DomainWallsTest` with the exception map
- [ ] Consumer/UI tests added/updated (frontend) — n/a
- How to run: in durion-positivity-backend, `./mvnw -pl pos-archunit -am -Dtest='ArchitectureTests,DomainWallsTest,ClasspathVisibilityGuardTest,EntityStandardsArchitectureTest' -Dsurefire.failIfNoSpecifiedTests=false test`

## Risk & Rollback
- Risk level: Low — documentation alignment; the enforced behavior already exists on the backend branch.
- Rollback plan: revert this commit; if the exception itself is rejected, revert the `DomainWallsTest` exception map and the five `internal/client` classes in durion-positivity-backend#920 must be redesigned to the replica pattern before merge.

## Checklist
- [ ] Branch name matches `cap/` — branch is `claude/adr-0044-warranty-amendment` (no capability id for this work)
- [ ] PR title starts with `[CAP:]` — no capability id; conventional `docs(adr):` prefix used
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — n/a, none changed here
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDgB2iXDpuQz4W3Eg5S6ma