### PR TITLE
docs: point parity story A4 at transferred issue durion#357

### DIFF
--- a/domains/accounting/plan-odoo-parity-pos-accounting.md
+++ b/domains/accounting/plan-odoo-parity-pos-accounting.md
@@ -458,7 +458,7 @@ Any of these may be reopened by product/finance — reopening one reopens only t
 
 | Wave | Story → Issue |
 |---|---|
-| 1 | H1 → #934 · A1 → #935 · C4 → #936 · B1 → #937 · A4(ADR) → #938 |
+| 1 | H1 → #934 · A1 → #935 · C4 → #936 · B1 → #937 · A4(ADR) → durion#357 (transferred from backend #938 — deliverable lives in durion `docs/adr/`) |
 | 2 | A2 → #942 · A3 → #943 · B2 → #944 · E1 → #945 · E2 → #946 |
 | 3 | D1 → #953 · C1 → #954 · C3 → #955 · G1 → #956 · E3 → #957 |
 | 4 | C2 → #958 · F1a(contract) → #959 · F1b(payment adapter) → #962 · F1c(accounting) → #963 · G2 → #960 |


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (planning-doc maintenance, no cap-id)
- Parent STORY (durion): #357
- Child issue: n/a (backend issue #938 was transferred to durion#357)
- Domain: `domain:accounting`

## Contract References
- n/a — documentation-only change, no API/event behavior touched.

## Scope
- What changed: one-line update to `domains/accounting/plan-odoo-parity-pos-accounting.md` §13 — the Wave 1 issue-tracking entry for story A4 (non-goal ADR) now points at durion#357 instead of durion-positivity-backend#938, with a transfer note.
- Why: backend issue #938 was transferred to the durion repo (its deliverable, the non-goal ADR, lives in durion `docs/adr/`); the plan's tracking table must reference the issue's new home.

## Tests
- n/a — markdown-only change.

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, follow-up on the existing parity-plan branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [x] Links to parent + child issues are present
- [ ] Contract guide updated — n/a, no contract semantics changed
- [x] Required CI checks passing (none required for docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6u7pVxgL36kXTFuDnZ5su

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6u7pVxgL36kXTFuDnZ5su)_