### PR TITLE
[CAP:odoo-parity-accounting-w2] Wave 2 accounting docs: POSTING_RULES_SCHEMA, contract guide (AD-012 enforced), error codes

### DIFF
--- a/domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -6,8 +6,8 @@ contract_status: draft
 owner_repo: louisburroughs/durion
 guide_path: domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md
 openapi_source: durion-positivity-backend/pos-accounting/openapi.yaml
-openapi_commit: ca7fadc3
-last_verified_utc: 2026-07-18T01:41:00Z
+openapi_commit: 3ed498c
+last_verified_utc: 2026-07-18T19:29:21Z
 last_updated: 2026-07-18
 api_reference_generated: domains/accounting/.business-rules/BACKEND_API_REFERENCE.generated.md
 traceability:
@@ -53,7 +53,10 @@ These are normative behavior rules for Accounting and are not replaced by OpenAP
 - Payment receipt does not reduce AR until application records are created (`AD-002`).
 - Overpayment becomes customer credit deterministically (`AD-003`).
 - Apply payment flow must be idempotent (`AD-010`) and atomic.
-- Posting is allowed only in open accounting periods (`AD-012`).
+- Posting is allowed only in open accounting periods (`AD-012`, ENFORCED as of Wave 2 B2 backend#944):
+  the period gate covers every posting and reversal path in order hard lock > closed > override.
+  Dates before the org-level hard-lock date are never postable; CLOSED periods accept postings only
+  with `accounting:period:override` plus a non-blank, audit-logged justification.
 - Posting references are canonical and traceable (`AD-011`).
 - Event ingestion status and idempotency outcomes are backend-authoritative (`AD-007`).
 - Refund execution is external to Accounting; Accounting exposes read model views (`AD-001`).
@@ -88,8 +91,10 @@ These links are the authoritative backlog items that implement CAP-251 behavior.
 | Create GL account | `createGLAccount` | POST | `http://localhost:8080/v1/accounting/gl-accounts` | Enforce unique account codes |
 | Manage posting categories | `listPostingCategories` | GET | `http://localhost:8080/v1/accounting/posting-categories` | Pair with create/update/deactivate actions |
 | Resolve posting mapping | `resolveGLMapping` | POST | `http://localhost:8080/v1/accounting/mappings/resolve` | Used by posting config UX and diagnostics |
+| List journal entries | `listJournalEntries` | GET | `http://localhost:8080/v1/accounting/journal-entries` | Supports `entryNumber` filter (Wave 2 A2) |
 | Create journal entry | `createJournalEntry` | POST | `http://localhost:8080/v1/accounting/journal-entries` | Draft creation before post/reverse |
-| Post journal entry | `postJournalEntry` | POST | `http://localhost:8080/v1/accounting/journal-entries/{journalEntryId}/post` | Must satisfy open-period constraint |
+| Post journal entry | `postJournalEntry` | POST | `http://localhost:8080/v1/accounting/journal-entries/{journalEntryId}/post` | Assigns `entryNumber`; period gate applies (422 `PERIOD_CLOSED`/`PERIOD_HARD_LOCKED`); optional body `overrideJustification` with `accounting:period:override` |
+| Reverse journal entry | `reverseJournalEntry` | POST | `http://localhost:8080/v1/accounting/journal-entries/{journalEntryId}/reverse` | Mandatory `reason`; optional `reversalDate` (defaults: original date if OPEN, else today); 409 `JE_ALREADY_REVERSED`/`JE_NOT_POSTED`; period gate applies |
 | Apply payment to invoices | `applyPayment` | POST | `http://localhost:8080/v1/accounting/payments/{paymentId}/applications` | Requires idempotency behavior (`AD-010`) |
 | Reverse payment application | `reversePaymentApplication` | POST | `http://localhost:8080/v1/accounting/payment-applications/{applicationId}/reverse` | Audit trail required |
 | Create credit memo | `createCreditMemo` | POST | `http://localhost:8080/v1/accounting/credit-memos` | Use when negative adjustments would occur |
@@ -102,6 +107,8 @@ These links are the authoritative backlog items that implement CAP-251 behavior.
 | List accounting periods | `listAccountingPeriods` | GET | `http://localhost:8080/v1/accounting/periods` | Requires `accounting:period:view` |
 | Close accounting period | `closeAccountingPeriod` | POST | `http://localhost:8080/v1/accounting/periods/{periodCode}/close` | Requires `accounting:period:close`; 422 lists blocking DRAFT entries |
 | Reopen accounting period | `reopenAccountingPeriod` | POST | `http://localhost:8080/v1/accounting/periods/{periodCode}/reopen` | Requires `accounting:period:reopen`; mandatory justification |
+| View hard-lock date | `getAccountingHardLockDate` | GET | `http://localhost:8080/v1/accounting/periods/hard-lock` | Requires `accounting:period:view`; `hardLockDate: null` when unset |
+| Set hard-lock date | `setAccountingHardLockDate` | PUT | `http://localhost:8080/v1/accounting/periods/hard-lock` | Requires `accounting:period:hard_lock`; mandatory justification; forward-only (422 `HARD_LOCK_DATE_REGRESSION`) |
 
 Headers and auth notes:
 
@@ -178,18 +185,45 @@ Headers and auth notes:
 ### Behavioral Assertions
 
 - Journal entries must be balanced before posting.
-- Posting in closed periods must be rejected.
+- Posting in closed periods must be rejected (see period-gate assertions below).
 - Reversal must preserve traceability to original posting.
+- Posted entries carry `entryNumber` in format `JE-{YYYYMM}-{seq}` (month from `transactionDate`),
+  assigned at POST time only inside the posting transaction (Wave 2 A2 backend#942, decision `D-1`).
+  DRAFT/PENDING and pre-migration entries are unnumbered (`entryNumber: null`). Gapless as a
+  side effect of post-time assignment; **no statutory gapless guarantee is claimed**.
+- `entryNumber` is exposed on journal-entry responses and as an exact-match filter on `listJournalEntries`.
+- Reversal contract (Wave 2 A3 backend#943): `reverseJournalEntry` creates and immediately posts an
+  inverse entry (own `entryNumber`) and transitions the original POSTED → REVERSED race-safely
+  (a lost concurrent-reversal race returns 409). Bidirectional linkage plus `reversedAt` and acting
+  user are recorded; a non-blank `reason` is mandatory.
+- `reversalDate` is optional: it defaults to the original entry's transaction date if that period is
+  OPEN, otherwise to today; the resolved date must pass the period gate.
+- Reversal error codes: `JE_ALREADY_REVERSED` (409), `JE_NOT_POSTED` (409, DRAFT/PENDING entries),
+  `PERIOD_CLOSED` (422), `PERIOD_HARD_LOCKED` (422).
+- Period gate (Wave 2 B2 backend#944, `AD-012` now ENFORCED): both `postJournalEntry` and
+  `reverseJournalEntry` check hard lock > closed > override. A date in a CLOSED period is accepted
+  only when the caller holds `accounting:period:override` and supplies a non-blank
+  `overrideJustification` in the request body; the override is audit-logged. A date strictly before
+  the hard-lock date is never postable — no override path.
+- Reversal emits a `JournalEntryReversed` outbox domain event in the same transaction for downstream
+  read models; API-level events `ACCOUNTING_JOURNAL_ENTRY_POST` / `ACCOUNTING_JOURNAL_ENTRY_REVERSE`
+  are registered.
 
 ### Frontend Usage Notes
 
-- Posting UI should surface period-closed and unbalanced-entry failures explicitly.
-- Traceability view should expose source event and posting reference links.
+- Posting UI should surface period-closed and unbalanced-entry failures explicitly, and distinguish
+  `PERIOD_CLOSED` (recoverable via override or reopen) from `PERIOD_HARD_LOCKED` (terminal).
+- Offer the override-justification input only to callers holding `accounting:period:override`.
+- Traceability view should expose source event and posting reference links; entry lists should show
+  `entryNumber` (blank for unnumbered DRAFT/legacy rows) and support lookup by it.
+- Reversal UX must collect a mandatory reason and treat `reversalDate` as optional with
+  backend-side defaulting.
 
 ### ADR Constraints
 
 - `AD-011` posting references must be canonical and queryable.
-- `AD-012` accounting period enforcement is mandatory.
+- `AD-012` accounting period enforcement is mandatory — ENFORCED across all posting/reversal paths
+  as of Wave 2 B2 (backend#944).
 
 ### Events & Dependencies
 
@@ -311,6 +345,8 @@ Headers and auth notes:
 | List accounting periods | `listAccountingPeriods` | GET | `http://localhost:8080/v1/accounting/periods` |
 | Close accounting period | `closeAccountingPeriod` | POST | `http://localhost:8080/v1/accounting/periods/{periodCode}/close` |
 | Reopen accounting period | `reopenAccountingPeriod` | POST | `http://localhost:8080/v1/accounting/periods/{periodCode}/reopen` |
+| View hard-lock date | `getAccountingHardLockDate` | GET | `http://localhost:8080/v1/accounting/periods/hard-lock` |
+| Set hard-lock date | `setAccountingHardLockDate` | PUT | `http://localhost:8080/v1/accounting/periods/hard-lock` |
 
 ### Behavioral Assertions
 
@@ -323,10 +359,26 @@ Headers and auth notes:
 - Close is rejected with `422 PERIOD_HAS_DRAFT_ENTRIES` listing the DRAFT journal-entry IDs still
   in the period; reopen requires a mandatory justification recorded in the audit trail.
 - Period error codes: `PERIOD_NOT_FOUND` (404), `PERIOD_ALREADY_CLOSED` (409),
-  `PERIOD_ALREADY_OPEN` (409), `PERIOD_HAS_DRAFT_ENTRIES` (422).
-- Permission gating: `accounting:period:view` / `accounting:period:close` / `accounting:period:reopen`.
-- `AD-012` note: the period open-check is live, but full enforcement across every journal-entry
-  posting path lands with Wave-2 story B2 (durion-positivity-backend#944).
+  `PERIOD_ALREADY_OPEN` (409), `PERIOD_HAS_DRAFT_ENTRIES` (422), `PERIOD_CLOSED` (422),
+  `PERIOD_HARD_LOCKED` (422), `HARD_LOCK_DATE_REGRESSION` (422).
+- Permission gating: `accounting:period:view` / `accounting:period:close` / `accounting:period:reopen`
+  / `accounting:period:hard_lock` (set the hard-lock date) / `accounting:period:override`
+  (post/reverse into a CLOSED period with justification).
+- `AD-012` note: ENFORCED as of Wave-2 story B2 (durion-positivity-backend#944). The
+  `AccountingPeriodGate` is the single choke point on `postJournalEntry` and `reverseJournalEntry`,
+  covering every posting path (manual, posting engine, credit memo, payment application, AP
+  transitively). Check order: hard lock > closed > override.
+- Hard lock (backend#944): a single org-level hard-lock date; journal entries dated strictly before
+  it are permanently rejected with `422 PERIOD_HARD_LOCKED` and **no override path**. The date is
+  monotonic-forward-only (backward move → `422 HARD_LOCK_DATE_REGRESSION`); setting it requires a
+  mandatory justification and is audit-logged. `GET /periods/hard-lock` returns `hardLockDate: null`
+  when unset. Events: `ACCOUNTING_PERIOD_HARD_LOCK_VIEW` / `ACCOUNTING_PERIOD_HARD_LOCK_SET`.
+- Closed-period override: `accounting:period:override` plus a non-blank `overrideJustification`
+  allows posting/reversing into a CLOSED period; the override is audit-logged
+  (`PERIOD_OVERRIDE_POST`). Without it the request fails `422 PERIOD_CLOSED`.
+- Posting engine: autoPost events blocked by a closed period become SUSPENDED with
+  `failureReasonCode=PERIOD_CLOSED`; the auto-retry loop skips them, and they are reprocessable
+  after the period is reopened. Reprocess-with-override is a recorded follow-up (not in Wave 2).
 
 ### Frontend Usage Notes
 
@@ -531,11 +583,28 @@ Headers and auth notes:
 - Rule evaluation must produce balanced journal drafts.
 - Idempotent handling must prevent duplicate postings across retries.
 - Reprocessing history must capture attempt outcomes for auditability.
+- Rules definition schema is authoritative in
+  `domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md`.
+- Proportional split lines (Wave 2 E1 backend#945, schema §4): lines sharing a `splitGroup` within a
+  condition split one `amountField` by `factorPercent` (0–100, 4dp); factors must sum to 100 and
+  mixed DEBIT/CREDIT groups are forbidden. Shares round HALF_UP to 2dp with the residual assigned to
+  the largest raw share (first-in-order tie-break), so each group sums exactly to the source amount.
+  Non-split lines behave identically to pre-E1 rules.
+- Condition predicates (Wave 2 E2 backend#946, schema §2.1): whitelist grammar only —
+  `eventType` / `payload.<path>` clauses, operators `== != > >= < <=`, `&&` conjunction,
+  string/number literals; no expression engine or scripting. Missing/non-scalar payload paths make a
+  clause a non-match (safe default), never an error.
+- Publish-time validation: split-group violations and predicate parse errors are aggregated and
+  rejected with `422 UNBALANCED_RULES` carrying per-violation `fieldErrors` locators
+  (e.g. `conditions[1].lines[2].factorPercent`, `conditions[0].condition`). Conditions on
+  already-published pre-E2 versions that do not parse stay WARN + non-match at evaluation time.
 
 ### Frontend Usage Notes
 
 - Rule-management UI should separate draft vs published versions clearly.
 - Reprocessing UI should include failure reason and attempted mapping/rule context.
+- Publish-failure UX should map `UNBALANCED_RULES` `fieldErrors` locators back to the offending
+  condition/line in the rule editor so authors can fix all violations in one pass.
 
 ### ADR Constraints
 
@@ -622,8 +691,8 @@ Headers and auth notes:
 ## Verification Metadata
 
 - OpenAPI source: `durion-positivity-backend/pos-accounting/openapi.yaml`
-- OpenAPI source revision: `ca7fadc3`
-- Last verified UTC: `2026-02-24T14:07:15Z`
+- OpenAPI source revision: `3ed498c`
+- Last verified UTC: `2026-07-18T19:29:21Z`
 - Generated API reference: `domains/accounting/.business-rules/BACKEND_API_REFERENCE.generated.md`
 
 ## References
@@ -633,6 +702,7 @@ Headers and auth notes:
 - `domains/accounting/.business-rules/DOMAIN_NOTES.md`
 - `domains/accounting/.business-rules/CROSS_DOMAIN_INTEGRATION_CONTRACTS.md`
 - `domains/accounting/.business-rules/ERROR_CODES.md`
+- `domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md`
 - `docs/capabilities/CAP-050/CAPABILITY_MANIFEST.yaml`
 - `docs/capabilities/CAP-051/CAPABILITY_MANIFEST.yaml`
 - `docs/capabilities/CAP-052/CAPABILITY_MANIFEST.yaml`

--- a/domains/accounting/.business-rules/ERROR_CODES.md
+++ b/domains/accounting/.business-rules/ERROR_CODES.md
@@ -1,6 +1,6 @@
 # Accounting Domain Error Codes
 
-**Version:** 1.1  
+**Version:** 1.2  
 **Purpose:** Comprehensive error taxonomy for Accounting domain API responses  
 **Domain:** accounting  
 **Owner:** Accounting Domain  
@@ -293,7 +293,7 @@ Error codes follow the format: `{RESOURCE}_{ERROR_TYPE}` (e.g., `MAPPING_NOT_FOU
 
 ---
 
-## Journal Entry Errors (Issue #190, #201)
+## Journal Entry Errors (Issue #190, #201, #943)
 
 ### JE_NOT_FOUND (404)
 **Description:** Journal entry does not exist  
@@ -366,6 +366,53 @@ Error codes follow the format: `{RESOURCE}_{ERROR_TYPE}` (e.g., `MAPPING_NOT_FOU
 
 ---
 
+### JE_ALREADY_REVERSED (409)
+**Description:** Journal entry has already been reversed and cannot be reversed again  
+**HTTP Status:** 409  
+**Use Cases:**
+- Reverse request against an entry already in REVERSED status
+- Lost race between two concurrent reversal requests for the same entry (the conditional POSTED → REVERSED update matched 0 rows)
+
+**Example:**
+```json
+{
+  "errorCode": "JE_ALREADY_REVERSED",
+  "message": "Journal entry 'JE-12345' has already been reversed",
+  "details": {
+    "journalEntryId": "JE-12345",
+    "status": "REVERSED",
+    "reversedAt": "2026-07-17T16:00:00Z",
+    "reversalJournalEntryId": "JE-67890"
+  }
+}
+```
+
+**Recovery:** No action needed; follow `reversalJournalEntryId` to the existing reversal entry
+
+---
+
+### JE_NOT_POSTED (409)
+**Description:** Journal entry is not in POSTED status and cannot be reversed  
+**HTTP Status:** 409  
+**Use Cases:**
+- Reverse request against a DRAFT or PENDING entry (only POSTED entries are reversible)
+
+**Example:**
+```json
+{
+  "errorCode": "JE_NOT_POSTED",
+  "message": "Journal entry 'JE-12345' is not posted and cannot be reversed",
+  "details": {
+    "journalEntryId": "JE-12345",
+    "status": "DRAFT"
+  }
+}
+```
+
+**Recovery:** DRAFT entries should be edited or deleted directly; only POSTED entries are reversed
+
+---
+
 ### JE_INVALID_STATUS (400)
 **Description:** Journal entry status transition invalid  
 **HTTP Status:** 400  
@@ -434,7 +481,7 @@ Error codes follow the format: `{RESOURCE}_{ERROR_TYPE}` (e.g., `MAPPING_NOT_FOU
 
 ---
 
-## Accounting Period Errors (Issue #937)
+## Accounting Period Errors (Issue #937, #944)
 
 ### PERIOD_NOT_FOUND (404)
 **Description:** Accounting period does not exist  
@@ -524,6 +571,76 @@ Error codes follow the format: `{RESOURCE}_{ERROR_TYPE}` (e.g., `MAPPING_NOT_FOU
 
 ---
 
+### PERIOD_CLOSED (422)
+**Description:** Posting (or reversal) date falls in a CLOSED accounting period  
+**HTTP Status:** 422  
+**Use Cases:**
+- Post a journal entry whose transaction date is in a CLOSED period without a valid override
+- Reverse a journal entry with a resolved `reversalDate` in a CLOSED period without a valid override
+- Also used as `failureReasonCode` on posting-engine events SUSPENDED by the period gate (reprocessable after reopen)
+
+**Example:**
+```json
+{
+  "errorCode": "PERIOD_CLOSED",
+  "message": "Accounting period '2026-06' is closed; posting requires accounting:period:override with a justification",
+  "details": {
+    "periodCode": "2026-06",
+    "transactionDate": "2026-06-15",
+    "overridePermission": "accounting:period:override"
+  }
+}
+```
+
+**Recovery:** Use a date in an OPEN period, reopen the period, or (with `accounting:period:override`) retry with a non-blank `overrideJustification` — the override is audit-logged
+
+---
+
+### PERIOD_HARD_LOCKED (422)
+**Description:** Posting (or reversal) date is strictly before the org-level hard-lock date; never overridable  
+**HTTP Status:** 422  
+**Use Cases:**
+- Post or reverse a journal entry dated before the configured `HARD_LOCK_DATE`
+- No override path exists: `accounting:period:override` covers CLOSED periods only, never the hard lock
+
+**Example:**
+```json
+{
+  "errorCode": "PERIOD_HARD_LOCKED",
+  "message": "Transaction date 2026-01-15 is before the accounting hard-lock date 2026-04-01 and can never be posted",
+  "details": {
+    "transactionDate": "2026-01-15",
+    "hardLockDate": "2026-04-01"
+  }
+}
+```
+
+**Recovery:** None for the requested date — history before the hard lock is immutable. Post a correcting entry dated on/after the hard-lock date instead
+
+---
+
+### HARD_LOCK_DATE_REGRESSION (422)
+**Description:** Requested hard-lock date is before the currently stored hard-lock date (monotonic-forward-only)  
+**HTTP Status:** 422  
+**Use Cases:**
+- `PUT /v1/accounting/periods/hard-lock` with a date earlier than the stored `HARD_LOCK_DATE`
+
+**Example:**
+```json
+{
+  "errorCode": "HARD_LOCK_DATE_REGRESSION",
+  "message": "Hard-lock date cannot move backward: requested 2026-03-01 is before current 2026-04-01",
+  "details": {
+    "requestedHardLockDate": "2026-03-01",
+    "currentHardLockDate": "2026-04-01"
+  }
+}
+```
+
+**Recovery:** The hard lock only moves forward; supply a date on or after the current hard-lock date
+
+---
+
 ## Posting Rule Errors (Issue #202)
 
 ### RULES_NOT_FOUND (404)
@@ -550,40 +667,38 @@ Error codes follow the format: `{RESOURCE}_{ERROR_TYPE}` (e.g., `MAPPING_NOT_FOU
 ---
 
 ### UNBALANCED_RULES (422)
-**Description:** Posting rules do not balance (debits ≠ credits)  
+**Description:** Posting rules definition fails publish-time validation (split-group invariants per E1 #945, or condition-predicate grammar per E2 #946)  
 **HTTP Status:** 422  
 **Use Cases:**
-- Attempt to publish rule set with unbalanced conditions
-- Rule validation failure
+- Publish a rule set whose split-group factors do not sum to 100, mix DEBIT/CREDIT in one group, or declare `factorPercent` without `splitGroup` (and vice versa)
+- Publish a rule set with a condition string that does not parse under the whitelist predicate grammar (`POSTING_RULES_SCHEMA.md` §2.1)
+
+All violations found in the definition are returned in one pass as `fieldErrors`, each with a JSON-pointer-style locator into the rules definition.
 
 **Example:**
 ```json
 {
-  "errorCode": "UNBALANCED_RULES",
-  "message": "Posting rule set validation failed: debits and credits do not balance",
-  "details": {
-    "postingRuleSetId": "PRS-12345",
-    "versionNumber": 2,
-    "conditions": [
-      {
-        "condition": "saleType == 'CASH'",
-        "totalDebits": "1000.00",
-        "totalCredits": "1000.00",
-        "balanced": true
-      },
-      {
-        "condition": "saleType == 'CREDIT'",
-        "totalDebits": "500.00",
-        "totalCredits": "450.00",
-        "balanced": false,
-        "difference": "50.00"
-      }
-    ]
-  }
+  "code": "UNBALANCED_RULES",
+  "message": "Cannot publish: posting rules definition violates publish-time invariants (3 violations): ...",
+  "status": 422,
+  "fieldErrors": [
+    {
+      "field": "conditions[0].splitGroup[tax]",
+      "message": "factorPercent values in split group 'tax' must sum to 100 (got 95.0000)"
+    },
+    {
+      "field": "conditions[1].lines[2].factorPercent",
+      "message": "factorPercent requires a splitGroup — a line cannot declare a split factor outside a group"
+    },
+    {
+      "field": "conditions[1].condition",
+      "message": "parse error at position 12: expected comparison operator"
+    }
+  ]
 }
 ```
 
-**Recovery:** Fix rule definition to balance debits and credits per condition
+**Recovery:** Fix every violation listed in `fieldErrors` (locators identify the offending condition, group, or line) and retry the publish
 
 ---
 
@@ -1202,6 +1317,7 @@ public ResponseEntity<ErrorResponse> handleMappingNotFound(MappingNotFoundExcept
 |------|---------|--------|---------|
 | 2026-01-25 | 1.0 | Backend Team | Initial error taxonomy for all accounting issues |
 | 2026-07-17 | 1.1 | Backend Team | Accounting Period errors (PERIOD_NOT_FOUND, PERIOD_ALREADY_CLOSED, PERIOD_ALREADY_OPEN, PERIOD_HAS_DRAFT_ENTRIES) for Wave 1 story B1 (#937) |
+| 2026-07-18 | 1.2 | Backend Team | Wave 2: reversal errors JE_ALREADY_REVERSED, JE_NOT_POSTED (A3 #943); period-gate errors PERIOD_CLOSED, PERIOD_HARD_LOCKED, HARD_LOCK_DATE_REGRESSION (B2 #944); UNBALANCED_RULES refreshed to publish-time fieldErrors locator format (E1 #945 / E2 #946) |
 
 ---
 

--- a/domains/accounting/.business-rules/ERROR_CODES.md
+++ b/domains/accounting/.business-rules/ERROR_CODES.md
@@ -678,9 +678,9 @@ All violations found in the definition are returned in one pass as `fieldErrors`
 **Example:**
 ```json
 {
-  "code": "UNBALANCED_RULES",
+  "errorCode": "UNBALANCED_RULES",
   "message": "Cannot publish: posting rules definition violates publish-time invariants (3 violations): ...",
-  "status": 422,
+  "httpStatus": 422,
   "fieldErrors": [
     {
       "field": "conditions[0].splitGroup[tax]",

--- a/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
+++ b/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
@@ -2,7 +2,9 @@
 
 Authoritative schema for the `rulesDefinition` JSON stored on a
 `PostingRuleVersion` in `pos-accounting`. This document was commissioned by
-questions doc #202 and extended by stories E1 (issue #945, proportional
+the posting-rules item (backend issue 202, "Posting Rule Sets") of the
+accounting questions review (`domains/accounting/accounting-questions.md`)
+and extended by stories E1 (issue #945, proportional
 split lines) and E2 (issue #946, condition predicate grammar). It is the
 single reference for rule authors, the publish-time validator, and the
 evaluator implementation (`PostingRuleEvaluatorImpl` /
@@ -54,7 +56,7 @@ Validation points:
 | --- | --- | --- | --- |
 | `conditions` | array of condition blocks | yes (non-empty for a usable rule set) | Evaluated **in order; first matching condition wins**. Later conditions are ignored once one matches. |
 | `conditions[].condition` | string | no | Match expression (see §2.1). Absent/blank ⇒ always matches (catch-all). |
-| `conditions[].lines` | array of line objects | yes (non-empty) | Journal-entry line templates emitted when the condition matches. A matched condition with no lines is skipped with a warning. |
+| `conditions[].lines` | array of line objects | yes (may be empty) | Journal-entry line templates emitted when the condition matches. An empty array is legal but useless: a matched condition with no lines is skipped with a warning at evaluation time. |
 
 A definition that is empty, `{}`, or has no `conditions` array cannot
 produce a journal entry; evaluation fails with `UNMAPPED_EVENT_TYPE` (the

--- a/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
+++ b/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
@@ -2,11 +2,11 @@
 
 Authoritative schema for the `rulesDefinition` JSON stored on a
 `PostingRuleVersion` in `pos-accounting`. This document was commissioned by
-questions doc #202 and extended by story E1 (issue #945, proportional split
-lines). It is the single reference for rule authors, the publish-time
-validator, and the evaluator implementation
-(`PostingRuleEvaluatorImpl` / `PostingRuleDefinitionValidator` in
-`pos-accounting`).
+questions doc #202 and extended by stories E1 (issue #945, proportional
+split lines) and E2 (issue #946, condition predicate grammar). It is the
+single reference for rule authors, the publish-time validator, and the
+evaluator implementation (`PostingRuleEvaluatorImpl` /
+`PostingRuleDefinitionValidator` / `PredicateParser` in `pos-accounting`).
 
 Related references:
 
@@ -32,8 +32,8 @@ Validation points:
 | Stage | What is checked |
 | --- | --- |
 | create / update draft | none beyond request-shape validation — drafts may hold work in progress |
-| **publish** | definition non-empty; definition parses as JSON (`400 VALIDATION_ERROR` otherwise); **all split-group invariants of §4 (`422 UNBALANCED_RULES` otherwise, every violation listed)** |
-| evaluation (runtime) | condition matching, GL account resolution, journal-entry balance; split-group invariants re-checked defensively (violation ⇒ explicit `INTERNAL_ERROR` posting failure, never a silently adjusted amount) |
+| **publish** | definition non-empty; definition parses as JSON (`400 VALIDATION_ERROR` otherwise); **all split-group invariants of §4 and all condition-predicate grammar rules of §2.1 (`422 UNBALANCED_RULES` otherwise, every violation listed)** |
+| evaluation (runtime) | condition matching, GL account resolution, journal-entry balance; split-group invariants re-checked defensively (violation ⇒ explicit `INTERNAL_ERROR` posting failure, never a silently adjusted amount); unparseable condition text (pre-E2 data only) ⇒ WARN + non-match |
 
 ---
 
@@ -61,18 +61,89 @@ produce a journal entry; evaluation fails with `UNMAPPED_EVENT_TYPE` (the
 publish gate only rejects the fully-empty definition, for compatibility
 with existing stub rule sets).
 
-### 2.1 Condition expressions (current grammar)
+### 2.1 Condition expressions (predicate grammar, E2 — issue #946)
 
 | Expression | Behavior |
 | --- | --- |
 | absent / blank / `"*"` | always matches (default / catch-all rule) |
-| `eventType == '<value>'` | matches when the event's `eventType` equals `<value>` (single-quoted literal) |
-| anything else | **does not match** (logged and skipped — fail-safe) |
+| any predicate of the grammar below | matches when **every** clause matches |
+| anything else | rejected at **publish** (`422 UNBALANCED_RULES`, locator `conditions[i].condition`); if such text somehow reaches a published version (pre-E2 data), it **does not match** at evaluation (logged WARN and skipped — fail-safe) |
 
-> Story E2 will extend this grammar with `payload.<path> <op> <literal>`
-> predicates and `&&` conjunction. That extension appends to this section;
-> the first-match-wins contract and the fail-safe treatment of unrecognized
-> expressions are stable.
+#### Grammar (EBNF — strict whitelist, no expression engine)
+
+```ebnf
+predicate  := clause ( '&&' clause )* ;
+clause     := lhs op literal ;
+lhs        := 'eventType' | 'payload' '.' path ;
+path       := identifier ( '.' identifier )* ;
+identifier := [A-Za-z_][A-Za-z0-9_]* ;
+op         := '==' | '!=' | '>' | '>=' | '<' | '<=' ;
+literal    := "'" characters-except-quote "'" | number ;
+number     := ['+'|'-'] digits ['.' digits] ;
+```
+
+Whitespace between tokens is optional. There are no parentheses, no `||`,
+no arithmetic, no functions, no escape sequences inside string literals,
+and no other identifiers — the grammar is deliberately declarative
+(Odoo's sandboxed-formula addon is the cautionary reference). Parsing is
+strict: trailing garbage, unbalanced quotes, unknown identifiers,
+malformed numbers, and empty clauses are all parse errors reported with
+character position.
+
+#### Operator / literal type rules
+
+| Operator | String literal (`'…'`) | Numeric literal |
+| --- | --- | --- |
+| `==` `!=` | allowed — exact, case-sensitive string comparison | allowed — numeric comparison |
+| `>` `>=` `<` `<=` | **rejected at parse/publish** ("ordering operator requires a numeric literal") | allowed |
+
+Numeric comparison is `BigDecimal`-based and scale-insensitive
+(`100 == 100.00`). The left-hand value is coerced: payload `Number`s and
+numeric strings (e.g. `"150.25"`) both coerce; anything else is
+non-coercible.
+
+#### Evaluation semantics (safe defaults — a clause is false, never an error)
+
+- Clauses are AND-combined with **short-circuit**: the first false clause
+  stops evaluation of the predicate.
+- `eventType` resolves to the event's type; `payload.<path>` navigates the
+  payload map segment by segment.
+- **Missing path, `null` value, or a non-map value mid-path ⇒ clause
+  false** — not an error. This applies to `!=` too: `payload.x != 'A'`
+  does *not* match an event without `payload.x`.
+- Non-scalar terminal values (maps, lists) ⇒ clause false.
+- String comparison requires the resolved value to be a string; numeric
+  comparison requires it to coerce to a number. A type mismatch or
+  non-coercible value ⇒ clause false (again, `!=` included).
+- Evaluation of a published predicate never throws for any event shape.
+
+#### Examples
+
+```text
+payload.paymentMethod == 'CASH'
+payload.amount >= 100.00 && eventType == 'PAYMENT_RECEIVED'
+payload.totals.tax > 0 && payload.paymentMethod != 'GIFT_CARD'
+```
+
+The first two are the canonical E2 acceptance predicates: a CASH payment
+routes to a different account than CARD, and a conjunction can gate on a
+numeric threshold plus the event type.
+
+#### Validation split
+
+| Stage | Behavior |
+| --- | --- |
+| **publish** | every non-catch-all `conditions[].condition` must parse under this grammar (including the ordering-op/numeric-literal rule) or the publish fails `422 UNBALANCED_RULES` with one `fieldErrors` entry per bad condition, locator `conditions[i].condition`. A non-string `condition` node is likewise rejected. |
+| evaluation | catch-all forms match; parsed predicates evaluate with the safe defaults above; unparseable text (possible only in versions published before E2) is a WARN + non-match, exactly the pre-E2 fail-safe |
+
+#### Backward compatibility
+
+The E2 grammar is a strict superset of the pre-E2 condition language:
+`eventType == '<value>'` parses to the same equality match, and the
+catch-all forms (absent / blank / `"*"`) are unchanged. First-match-wins
+ordering over the `conditions` array (§2) is untouched. Existing
+published rule sets — including the E1 split rules — evaluate
+byte-for-byte identically.
 
 ---
 
@@ -289,6 +360,10 @@ identical inputs always produce identical line amounts.
   migration is needed. Should invalid split data ever reach a published
   version by other means, the evaluator fails that event explicitly
   (`INTERNAL_ERROR`) rather than distorting amounts.
-- Future schema extensions land as new numbered sections here (E2 will add
-  §2.1's richer predicate grammar) and must keep this additive,
-  first-match-wins, exact-sum contract intact.
+- The E2 additions (issue #946) are likewise strictly additive: the
+  predicate grammar of §2.1 is a superset of the pre-E2 condition
+  language, and its validation only gates new publishes. Unparseable
+  condition text in versions published before E2 keeps its historical
+  WARN + non-match behavior.
+- Future schema extensions land as new numbered sections here and must
+  keep this additive, first-match-wins, exact-sum contract intact.

--- a/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
+++ b/domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md
@@ -1,0 +1,294 @@
+# Posting Rules Definition Schema
+
+Authoritative schema for the `rulesDefinition` JSON stored on a
+`PostingRuleVersion` in `pos-accounting`. This document was commissioned by
+questions doc #202 and extended by story E1 (issue #945, proportional split
+lines). It is the single reference for rule authors, the publish-time
+validator, and the evaluator implementation
+(`PostingRuleEvaluatorImpl` / `PostingRuleDefinitionValidator` in
+`pos-accounting`).
+
+Related references:
+
+- `ERROR_CODES.md` — `UNBALANCED_RULES` (422) and the other posting-rule
+  error codes
+- `DIMENSION_SCHEMA.md` — dimension keys usable in GL mapping resolution
+- `BACKEND_CONTRACT_GUIDE.md` — posting-rule REST endpoints and lifecycle
+- Plan `plan-odoo-parity-pos-accounting.md` §6 — workstream E (E1 split
+  lines, E2 richer predicates, E3 dry-run endpoint)
+
+---
+
+## 1. Lifecycle context
+
+A `PostingRuleSet` (named, bound to one `eventType`) owns immutable,
+numbered `PostingRuleVersion`s. Each version carries one `rulesDefinition`
+JSON document and moves `DRAFT → PUBLISHED → ARCHIVED`; at most one version
+per rule set is `PUBLISHED` at a time. The posting engine only ever
+evaluates `PUBLISHED` versions.
+
+Validation points:
+
+| Stage | What is checked |
+| --- | --- |
+| create / update draft | none beyond request-shape validation — drafts may hold work in progress |
+| **publish** | definition non-empty; definition parses as JSON (`400 VALIDATION_ERROR` otherwise); **all split-group invariants of §4 (`422 UNBALANCED_RULES` otherwise, every violation listed)** |
+| evaluation (runtime) | condition matching, GL account resolution, journal-entry balance; split-group invariants re-checked defensively (violation ⇒ explicit `INTERNAL_ERROR` posting failure, never a silently adjusted amount) |
+
+---
+
+## 2. Top-level structure
+
+```json
+{
+  "conditions": [
+    {
+      "condition": "eventType == 'billing.invoicePosted'",
+      "lines": [ { …line… }, { …line… } ]
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Semantics |
+| --- | --- | --- | --- |
+| `conditions` | array of condition blocks | yes (non-empty for a usable rule set) | Evaluated **in order; first matching condition wins**. Later conditions are ignored once one matches. |
+| `conditions[].condition` | string | no | Match expression (see §2.1). Absent/blank ⇒ always matches (catch-all). |
+| `conditions[].lines` | array of line objects | yes (non-empty) | Journal-entry line templates emitted when the condition matches. A matched condition with no lines is skipped with a warning. |
+
+A definition that is empty, `{}`, or has no `conditions` array cannot
+produce a journal entry; evaluation fails with `UNMAPPED_EVENT_TYPE` (the
+publish gate only rejects the fully-empty definition, for compatibility
+with existing stub rule sets).
+
+### 2.1 Condition expressions (current grammar)
+
+| Expression | Behavior |
+| --- | --- |
+| absent / blank / `"*"` | always matches (default / catch-all rule) |
+| `eventType == '<value>'` | matches when the event's `eventType` equals `<value>` (single-quoted literal) |
+| anything else | **does not match** (logged and skipped — fail-safe) |
+
+> Story E2 will extend this grammar with `payload.<path> <op> <literal>`
+> predicates and `&&` conjunction. That extension appends to this section;
+> the first-match-wins contract and the fail-safe treatment of unrecognized
+> expressions are stable.
+
+---
+
+## 3. Line objects
+
+```json
+{
+  "side": "DEBIT",
+  "amountField": "payload.amount",
+  "description": "Accounts Receivable",
+
+  "postingCategoryId": "0196…uuid",
+  "mappingKeyId": "0196…uuid",
+
+  "glAccountId": "0196…uuid",
+
+  "factorPercent": 60,
+  "splitGroup": "revenue"
+}
+```
+
+| Field | Type | Required | Semantics |
+| --- | --- | --- | --- |
+| `side` | `"DEBIT"` \| `"CREDIT"` (case-insensitive) | no — defaults to `DEBIT` | Which side of the journal entry this line posts to. |
+| `amountField` | string dot-path | effectively yes | Path into the event resolved per §3.1. Missing/unresolvable ⇒ amount `0`. **Mandatory (non-blank) on split-group lines.** |
+| `description` | string | no | Copied onto the generated journal-entry line. |
+| `postingCategoryId` + `mappingKeyId` | UUIDs | one of the two account forms | Preferred account form: resolved through the GL mapping tables (exact match → fallback → category default), with the event's `payload.dimensions` map as resolution context. Both must be present together. |
+| `glAccountId` | UUID | one of the two account forms | Direct GL account reference for simple rules without mapping tables. Used only when the category+key pair is absent. |
+| `factorPercent` | decimal, `0 ≤ f ≤ 100`, **max 4 decimal places** | only on split lines | This line's share of the split group's amount, in percent (E1, §4). |
+| `splitGroup` | non-blank string | only on split lines | Marker grouping this line with the other lines of the same split group **within the same condition** (E1, §4). |
+
+If any line's GL account cannot be resolved, the whole condition is treated
+as unresolved (no partial entries) and evaluation continues/fails exactly as
+before E1.
+
+### 3.1 Amount resolution
+
+`amountField` is a dot-path into the event. A leading `payload.` prefix is
+stripped and the remainder navigates the event's payload map, so
+`payload.amount`, `amount`, and `payload.totals.tax` are all valid forms.
+The resolved node may be a JSON number or a numeric string; both parse to an
+exact `BigDecimal`. Unresolvable paths and non-numeric values resolve to
+`0`.
+
+**No rounding is applied to non-split lines** — the resolved value passes
+through unchanged (journal-entry columns store up to 4 decimal places).
+Rounding only happens inside split groups (§4.2).
+
+### 3.2 Balance requirement
+
+The generated journal entry must balance: total debits = total credits
+within a `0.0001` tolerance. An unbalanced result fails evaluation with
+`UNBALANCED_JOURNAL`. The rules author is responsible for making sides
+balance (e.g. one credit line carrying the same `amountField` that a debit
+split group decomposes).
+
+---
+
+## 4. Proportional split groups (E1, issue #945)
+
+Odoo reference: repartition lines / `_distribute_delta_amount_smoothly`.
+Split groups decompose **one** resolved amount across several lines of the
+same journal-entry side, with a deterministic guarantee that the pieces sum
+**exactly** to the source amount.
+
+### 4.1 Invariants (enforced at publish, re-checked at evaluation)
+
+Within one condition, all lines carrying the same `splitGroup` value form a
+split group. Each group must satisfy:
+
+1. Every member declares `factorPercent` (decimal, `0–100`, at most 4
+   decimal places) — a member without a factor is invalid.
+2. A line with `factorPercent` but no `splitGroup` (orphan factor) is
+   invalid.
+3. `splitGroup` must be a non-blank string.
+4. Every member declares the **same, non-blank** `amountField`.
+5. Every member has the **same `side`** — mixed DEBIT/CREDIT groups are
+   rejected. (Decision: a split group models one single-sided economic
+   amount; mixing sides would make both the sum-to-source guarantee and the
+   residual placement ambiguous. Balance the entry with separate lines or a
+   second split group on the other side.)
+6. The members' `factorPercent` values sum to **exactly 100** (exact
+   decimal equality — no tolerance). A single-line group is legal only with
+   `factorPercent = 100`.
+
+Split-group names are scoped to their condition: the same `splitGroup`
+value in two different conditions denotes two independent groups. Multiple
+independent groups may coexist in one condition, and split lines may be
+freely interleaved with plain lines (which behave exactly as in §3).
+
+Publishing a definition that violates any invariant fails with **HTTP 422,
+error code `UNBALANCED_RULES`**; the response lists *every* violation as a
+`fieldErrors` entry whose `field` locates the offending line or group, e.g.
+`conditions[0].lines[2].factorPercent` or `conditions[0].splitGroup[tax]`.
+
+### 4.2 Distribution algorithm (deterministic)
+
+For each split group, in first-appearance order:
+
+1. Resolve the group's shared `amountField` **once** → `A`.
+2. Raw share per member `i`: `rawᵢ = A × factorᵢ / 100`, computed exactly
+   (the ÷100 is a decimal-point shift — no division rounding).
+3. Rounded share: `roundedᵢ = round(rawᵢ, 2 dp, HALF_UP)` (currency scale).
+4. Residual: `r = A − Σ roundedᵢ`. `r` may be positive or negative and can
+   exceed one cent for adversarial factor sets.
+5. The **entire** residual is added to the member with the **largest
+   absolute raw share**; on a tie, the **first such line in rule order**
+   receives it (deterministic tie-break).
+
+Result: `Σ` of the group's final line amounts `= A` exactly, always. If
+`A` itself carries more than 2 decimal places, the sub-cent part travels
+with the residual onto the largest line (journal-entry columns hold 4 dp),
+preserving the exact-sum guarantee.
+
+### 4.3 Worked examples
+
+**60 / 40 over 100.00**
+
+| Line | factor | raw | rounded | residual | final |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 60 | 60.00 | 60.00 | — | **60.00** |
+| 2 | 40 | 40.00 | 40.00 | — | **40.00** |
+
+Σ rounded = 100.00 = A ⇒ residual 0. Final 60.00 + 40.00 = 100.00.
+
+**33.33 / 33.33 / 33.34 over 100.00**
+
+| Line | factor | raw | rounded | final |
+| --- | --- | --- | --- | --- |
+| 1 | 33.33 | 33.33 | 33.33 | **33.33** |
+| 2 | 33.33 | 33.33 | 33.33 | **33.33** |
+| 3 | 33.34 | 33.34 | 33.34 | **33.34** |
+
+Exact raws ⇒ residual 0. Σ = 100.00.
+
+**33.33 / 33.33 / 33.34 over 0.01**
+
+| Line | factor | raw | rounded | final |
+| --- | --- | --- | --- | --- |
+| 1 | 33.33 | 0.003333 | 0.00 | 0.00 |
+| 2 | 33.33 | 0.003333 | 0.00 | 0.00 |
+| 3 | 33.34 | 0.003334 | 0.00 | **0.01** |
+
+Σ rounded = 0.00; residual = +0.01 → line 3 (largest raw share).
+Σ final = 0.01 = A.
+
+**33.33 / 33.33 / 33.34 over 99.99**
+
+| Line | factor | raw | rounded | final |
+| --- | --- | --- | --- | --- |
+| 1 | 33.33 | 33.326667 | 33.33 | 33.33 |
+| 2 | 33.33 | 33.326667 | 33.33 | 33.33 |
+| 3 | 33.34 | 33.336666 | 33.34 | **33.33** |
+
+Σ rounded = 100.00; residual = −0.01 → line 3 (largest raw share):
+33.34 − 0.01 = 33.33. Σ final = 99.99 = A.
+
+**Tie-break: 50 / 50 over 0.01**
+
+Raws 0.005 / 0.005 both round HALF_UP to 0.01 (Σ = 0.02); residual = −0.01.
+Raw shares tie, so the **first** line takes the residual: final
+**0.00 / 0.01**, Σ = 0.01 = A. This ordering is part of the contract —
+identical inputs always produce identical line amounts.
+
+### 4.4 Full example rule
+
+```json
+{
+  "conditions": [
+    {
+      "condition": "eventType == 'workexec.laborCharged'",
+      "lines": [
+        {
+          "side": "DEBIT",
+          "amountField": "payload.amount",
+          "splitGroup": "labor",
+          "factorPercent": 60,
+          "glAccountId": "01960003-0000-7000-8000-00000000c0a1",
+          "description": "Labor cost — shop floor"
+        },
+        {
+          "side": "DEBIT",
+          "amountField": "payload.amount",
+          "splitGroup": "labor",
+          "factorPercent": 40,
+          "glAccountId": "01960003-0000-7000-8000-00000000c0a2",
+          "description": "Labor cost — overhead pool"
+        },
+        {
+          "side": "CREDIT",
+          "amountField": "payload.amount",
+          "glAccountId": "01960003-0000-7000-8000-00000000c0a3",
+          "description": "Accrued labor"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 5. Versioning and backward compatibility
+
+- The E1 additions are **strictly additive**: definitions without
+  `factorPercent`/`splitGroup` are byte-for-byte unaffected — same
+  matching, same amount passthrough (no rounding), same account
+  resolution, same generated entries.
+- Published versions are immutable; changing rules means creating a new
+  `DRAFT` version and publishing it (which archives the previous published
+  version). Split-group validation therefore only ever gates *new*
+  publishes.
+- Versions published **before** E1 cannot contain split fields, so no
+  migration is needed. Should invalid split data ever reach a published
+  version by other means, the evaluator fails that event explicitly
+  (`INTERNAL_ERROR`) rather than distorting amounts.
+- Future schema extensions land as new numbered sections here (E2 will add
+  §2.1's richer predicate grammar) and must keep this additive,
+  first-match-wins, exact-sum contract intact.

--- a/domains/accounting/plan-odoo-parity-pos-accounting.md
+++ b/domains/accounting/plan-odoo-parity-pos-accounting.md
@@ -470,4 +470,10 @@ Any of these may be reopened by product/finance — reopening one reopens only t
 Status — Wave 1 (H1 #934 · A1 #935 · C4 #936 · B1 #937 · A4 durion#357/ADR-0047): implemented
 2026-07-17; see the linked issues and ADR-0047 for delivery details.
 
+Status — Wave 2 (A2 #942 · A3 #943 · B2 #944 · E1 #945 · E2 #946): implemented 2026-07-18 on branch
+`claude/wave-2-odoo-pos-accounting-31vunc`, PR pending. Notes: reprocess-with-override (reprocessing a
+PERIOD_CLOSED-suspended event into a still-closed period using `accounting:period:override`) is deferred
+as a recorded follow-up — B2 ships reprocess-after-reopen only. E2's predicate grammar unblocks E3
+(dry-run, Wave 3 #957).
+
 Tax-plan issues: see `plan-odoo-parity-pos-tax.md` §6. F3/G3 remain backlog (no issues by design).


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:odoo-parity-accounting-w2`
- Child issue: companion to louisburroughs/durion-positivity-backend Wave-2 PR (closes backend #942–#946)
- Domain: `domain:accounting`

## Scope
- **NEW `domains/accounting/.business-rules/POSTING_RULES_SCHEMA.md`** — the schema doc commissioned by questions doc #202: complete posting-rules JSON schema (reverse-engineered from the evaluator) + E1 split-line semantics with worked residual examples + E2 predicate grammar (EBNF, op/type rules, safe defaults, backward compat). Review-verified factually consistent with the shipped evaluator/validator code.
- `ERROR_CODES.md`: `JE_ALREADY_REVERSED`/`JE_NOT_POSTED` (409), `PERIOD_CLOSED`/`PERIOD_HARD_LOCKED`/`HARD_LOCK_DATE_REGRESSION` (422); `UNBALANCED_RULES` example refreshed to the fieldErrors locator format; changelog 1.2.
- `BACKEND_CONTRACT_GUIDE.md`: AD-012 marked ENFORCED (gate order, override semantics); CAP-051 numbering/reversal contract; CAP-054 hard-lock ops + enforcement assertions; CAP-278 split/predicate capabilities; API-lookup rows verified against regenerated openapi (3ed498c).
- Parity plan §13: Wave 2 status note (implemented; reprocess-with-override deferred; E3 unblocked).

## Tests
- n/a (documentation-only; behavioral evidence in the backend PR)

## Risk & Rollback
- Low (docs only); rollback = revert

## Checklist
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to companion PR present
- [x] Contract guide updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSdDFcpFUKDvqefyTXhaLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSdDFcpFUKDvqefyTXhaLs)_