### PR TITLE
docs(crm): Odoo CRM vs pos-customer comparison, gap spec, and parity plan

### DIFF
--- a/domains/crm/comp-crm-overview.md
+++ b/domains/crm/comp-crm-overview.md
@@ -1,0 +1,97 @@
+# Odoo CRM — Functional Overview (Reference for pos-customer Comparison)
+
+> Source: review of Odoo 19.0 (development series), `addons/crm` (~2,900-line `crm.lead` model + ~15 sibling models) plus the marketing/UTM stack (`addons/mass_mailing`, `addons/utm`), the sales-team base (`addons/sales_team`), and the CRM extension addons (`sale_crm`, `mass_mailing_crm`, `crm_sms`, `crm_iap_enrich`, `crm_iap_mine`, `website_crm`, `website_crm_partner_assign`, `event_crm`). Prepared as reference material for comparing against `durion-positivity-backend/pos-customer`. See also:
+>
+> - `comp-vs-pos-customer-comparison.md` — side-by-side capability map
+> - `spec-pos-customer-crm-gaps.md` — specification for the functionality worth building
+>
+> **Mission mismatch, stated up front.** Odoo CRM is a general-purpose B2B/B2C *sales-pipeline* tool: it exists to capture leads, qualify them into opportunities, route them to salespeople, and forecast revenue. Positivity is an *enterprise tire-service execution* platform: revenue is realized by executing workorders on vehicles, choreographed through the shop-management appointment flow, not by working a deal pipeline. So "Odoo has X, pos-customer doesn't" is often *correct and intentional* — the value of this document is to separate the machinery Positivity genuinely needs (marketing campaigns, segmentation, consent, follow-up, interaction history) from the machinery it does not (opportunity kanban, predictive deal scoring, reseller geo-assignment).
+
+## Architecture in one paragraph
+
+Everything in Odoo CRM reduces to one object: **`crm.lead`**. A "lead" and an "opportunity" are the *same* record discriminated by a `type` field (`'lead'` → `'opportunity'`). That record carries denormalized customer data (company name, contact name, email, phone, address) until it is *converted*, at which point Odoo materializes real `res.partner` records (a company partner plus a child contact) from those fields. Around this single object sit five subsystems: a **pipeline** (`crm.stage` kanban columns + probability + expected/recurring revenue), an **assignment engine** (`crm.team` / `crm.team.member` round-robin with quotas and domains), a **capture-and-dedup** layer (website forms, email aliases, lead mining, IAP enrichment, duplicate detection/merge), a **predictive scoring** model (per-team Naive Bayes over configurable fields), and a **marketing** stack (`mass_mailing` email/SMS + `utm` campaign/source/medium attribution). The unifying party model underneath everything is **`res.partner`**, whose `is_company` boolean and `commercial_partner_id` hierarchy are what let a single mailing or a single dedup rule treat companies and individuals differently.
+
+## 1. The pipeline core — `crm.lead` / `crm.stage`
+
+- **One model for leads and opportunities.** `crm.lead` (`crm/models/crm_lead.py`) is the center of gravity. `type` ∈ {`lead`, `opportunity`}; `active`/`probability` encode the terminal states. Inherits a stack of mixins: `mail.thread` (chatter/message history), `mail.activity.mixin` (scheduled activities), `mail.thread.blacklist`/`mail.thread.phone` (email/phone quality + opt-out), `utm.mixin` (campaign attribution), `format.address.mixin`.
+- **Lifecycle** is: created (as `lead` or directly `opportunity`) → qualified through stages → **won** (`stage_id.is_won AND probability==100`, via `action_set_won`) or **lost** (`active==False AND probability==0`, via `action_set_lost` + a `crm.lead.lost` wizard that attaches a `lost_reason_id`). `won_status` (`won`/`lost`/`pending`) is computed from those two conditions. Restoring a lost lead clears the lost reason and recomputes probability.
+- **Conversion** (`convert_opportunity`, wizards `crm.lead2opportunity.partner[.mass]`) flips `type` to `opportunity`, stamps `date_conversion`, and optionally runs `_create_customer` — which reads `partner_name` (future company) and `contact_name` (future person) and creates a `res.partner` company (`is_company=True`) with a child contact under it. This is the moment a "prospect" becomes a real customer record.
+- **Stages** (`crm.stage`): ordered by `sequence`; `is_won` flags the terminal column (toggling it forces every lead in the stage to 100%); `fold` folds empty kanban columns; `rotting_threshold_days` highlights stale opportunities; `team_ids` can scope a stage to specific teams. Default ladder: **New → Qualified → Proposition → Won**.
+- **Revenue**: `expected_revenue`, `prorated_revenue` (= expected × probability/100). **Recurring/MRR**: `recurring_revenue` + `crm.recurring.plan.number_of_months` → `recurring_revenue_monthly` (monthly recurring revenue) and prorated variants; gated by group `crm.group_use_recurring_revenues`.
+- **Classification**: `priority` (0 Low → 3 Very High), `tag_ids` (M2M `crm.tag`), `lost_reason_id` (M2O `crm.lost.reason`).
+- **Views**: kanban (by stage), list, calendar, pivot/graph (Pipeline Analysis, Forecast, Lost Analysis), cohort. Rainbowman celebration on win.
+
+## 2. Capture and deduplication
+
+- **Website forms** (`website_crm`): `crm.lead.website_form_input_filter` maps a public form submission to a new lead, sets `medium_id`=Website, applies team/user defaults, and chooses lead-vs-opportunity type by team config. Web-visitor page tracking links via `visitor_ids`.
+- **Email alias** (`crm.team.alias_id`, via `mail.alias.mixin`): inbound email to a team's address creates a lead (`crm.lead.message_new`) and assigns it within the team.
+- **Duplicate detection / merge**: `_compute_potential_lead_duplicates` matches on **email domain** (`email_domain_criterion`), **same commercial entity** (`partner_id child_of commercial_partner_id`), and **sanitized phone**. `merge_opportunity` picks a "head" record by `_sort_by_confidence_level` (opportunity > lead, higher stage, higher probability, newer id) and concatenates/first-non-null-merges the rest, folding in followers, messages, attachments, and calendar events. Mass-convert offers a `deduplicate` toggle.
+- **Lead mining** (`crm_iap_mine`, `crm.iap.lead.mining.request`): generates *brand-new* leads from an external company database, filtered by country/state, company size, `industry_ids`, and (for contacts) `role`/`seniority`. Credit-metered via IAP.
+- **IAP enrichment** (`crm_iap_enrich`): autofills an existing lead's company data (name, address, phone, country/state) from the email domain; `iap_enrich_done` flag; auto-cron on create.
+- **Event leads** (`event_crm`): `event.lead.rule` creates leads from event registrations.
+
+## 3. Assignment and routing
+
+- **Basic**: `_compute_team_id` derives a team from user + type; `_handle_salesmen_assignment` round-robins a `user_ids` list; `_get_default_team_id` is a 5-step heuristic over memberships, context, and company.
+- **Rule-based automatic assignment** (the "Lead Assign" engine, entirely in `crm.team` + `crm.team.member`):
+  - `_allocate_leads` assigns **teams** to unassigned live leads by **weighted random** (weight = `assignment_max`), respecting each team's `assignment_domain`, deduplicating+merging as it goes.
+  - `_assign_and_convert_leads` distributes each team's leads to **members** by **round-robin with quota** (`_get_assignment_quota` = `assignment_max`/30 − today's count), in two passes: each member's `assignment_domain_preferred` leads first, then `assignment_domain`. Assignment converts leads to opportunities. Members can `assignment_optout`.
+  - Runs on `_cron_assign_leads` or on demand (manager-only).
+- **Reseller / partner assignment** (`website_crm_partner_assign`): geolocation routing to *external* partners by proximity (lat/long tiers) weighted by `res.partner.partner_weight` (from `grade_id`), excluding `partner_declined_ids`. Portal partners accept (→ convert) or decline. Introduces `res.partner.grade` (reseller tiers) and `res.partner.activation`.
+
+## 4. Activities, scheduling, and interaction history
+
+- **Scheduled activities** via `mail.activity.mixin`: `activity_ids`, `activity_date_deadline`, next-activity sorting. A CRM override links a lead activity to a `calendar.event` meeting (`action_create_calendar_event`, prefilling the partner as attendee); `action_schedule_meeting`/`log_meeting` and next/last-meeting computed fields.
+- **Interaction history** via `mail.thread` (chatter): every lead carries a threaded log of messages, notes, emails sent/received, and tracked field changes (`_track_duration_field='stage_id'` measures time-in-stage). This is Odoo's "communication log" — it is a first-class, per-record audit + conversation stream, not just a consent flag.
+- **Analysis**: `crm.activity.report` (SQL view over `mail_message` joined to `crm_lead` where an activity type is set) powers activity pivot/graph reporting.
+
+## 5. Marketing and campaigns
+
+- **Mailings** (`mailing.mailing`, email; SMS via `mass_mailing_sms`/`mass_mailing_crm_sms`): a single send with `subject`, `body_html`, scheduling (`schedule_type` now/scheduled), and `state` (draft/in_queue/sending/done). Two mutually exclusive **targeting** paradigms:
+  1. **Mailing-list based** — `contact_list_ids` (M2M `mailing.list`) of lightweight `mailing.contact` records (name + email only, *deliberately separate from `res.partner`* to avoid bloating the partner base for large blasts).
+  2. **Model-domain based** — `mailing_model_id` (any model with `_mailing_enabled=True`, including `res.partner` and `crm.lead`) + `mailing_domain`, reusable via a saved `mailing.filter`.
+- **Company-vs-individual targeting lives here.** Because `res.partner` carries `is_company`, a mailing on the `res.partner` model can filter `[('is_company','=',True)]` (companies) vs `[('is_company','=',False)]` (individuals). `mailing.contact` has a `company_name` string but *no* company/individual boolean, so B2B-vs-B2C segmentation is fundamentally a `res.partner`-model concept. On leads, `partner_name` vs `contact_name`/`commercial_partner_id` carry the same distinction.
+- **UTM attribution** (`utm.campaign` / `utm.source` / `utm.medium`): every mailing is auto-tagged with a campaign, a source (auto-named from the subject), and a medium. `utm.campaign` groups related sends, holds A/B config, and aggregates statistics (received/opened/replied/bounced ratios from `mailing.trace`). Leads generated by a mailing link back by `source_id` (`mass_mailing_crm` adds `crm_lead_count` to campaigns and mailings).
+- **A/B testing**: `ab_testing_enabled`, `ab_testing_pc` (% of recipients per variant), `ab_testing_winner_selection` (opened/click/reply ratio — or, CRM-specific, **`crm_lead_count`**: the variant that generated the most leads wins), scheduled by cron.
+- **Consent, two tiers** (a subtle but important design):
+  1. **Per-list opt-out** — `mailing.subscription.opt_out` (+ `opt_out_reason_id` from `mailing.subscription.optout`, `opt_out_datetime`) on the `mailing_subscription` join between a contact and a list. Opting out of one list does not affect others.
+  2. **Global blacklist** — `mail.blacklist` (+ `opt_out_reason_id`), an *address-level* suppression that removes an email/phone from *all* sends. Partners/leads/contacts expose `is_blacklisted` and `email_normalized` via `mail.thread.blacklist`; mailings honor both tiers via `use_exclusion_list` and `_mailing_get_opt_out_list`.
+- **Segmentation primitives**: `mailing.filter` (saved domains), mailing-list membership, `mailing.contact.tag_ids` (reusing `res.partner.category`).
+
+## 6. Segmentation and tags
+
+- **Three separate tag taxonomies**, deliberately not merged: `crm.tag` (leads/opportunities), `res.partner.category` (partners — *hierarchical*, `_parent_store`, "Parent / Child" display), and `utm.tag` (campaigns). `mailing.contact` reuses `res.partner.category`.
+- Lead-side classification also via `priority`, `stage_id`, `won_status`, `lost_reason_id`, and PLS score.
+- Partner-side segmentation via `category_id`, `industry_id`, `is_company`, `commercial_partner_id` grouping, `res.partner.grade` (reseller tier), and `customer_rank`/`supplier_rank` (added by the sale/accounting layer).
+
+## 7. Predictive lead scoring (PLS)
+
+- Naive Bayes over configurable fields, per sales team. `crm.lead.scoring.frequency` stores per-(field, value) `won_count`/`lost_count` (with +0.1 smoothing); `crm.lead.scoring.frequency.field` configures which `crm.lead` fields feed the model (defaults: `phone_state, email_state, state_id, country_id, source_id, lang_id, tag_ids`).
+- `_pls_get_naive_bayes_probabilities` → `automated_probability` (clamped 0.01–99.99; won-stage=100, no-stage=0). A manual `probability` edit overrides the automated value (`is_automated_probability`).
+- Maintained live on every won/lost transition (`_handle_won_lost` → `_pls_increment_frequencies`) and rebuilt nightly in 50k-row batches (`_cron_update_automated_probabilities`).
+
+## 8. The party model underneath — `res.partner`
+
+- **One model for companies and people.** `is_company` (bool) is the discriminator; `company_type` is a UI-only selection mirroring it. Hierarchy via `parent_id`/`child_ids`. The **commercial entity** (`commercial_partner_id`, computed+stored+recursive) is the root company used for grouping, dedup ("same commercial entity"), and invoicing; commercial fields (`vat`, `industry_id`, `company_registry`) sync from the commercial entity down to child contacts (`_commercial_fields`).
+- Address `type` (`contact`/`invoice`/`delivery`/`other`) supports multiple addresses per company. Tags via hierarchical `res.partner.category`. CRM adds `opportunity_ids`/`opportunity_count` (hierarchy-aware) to the partner; `sale`/`account` add `customer_rank`/`supplier_rank`.
+- **On the lead, customer data is denormalized** (`partner_name`, `contact_name`, `commercial_partner_id` as a UX helper, plus email/phone/address) until conversion materializes real partners. This "capture loose, materialize on qualify" pattern is central to Odoo's funnel and is exactly the pattern a service shop does *not* need in the same shape (see the comparison doc).
+
+## 9. Ecosystem map (addon → capability)
+
+| Addon | Adds |
+|---|---|
+| `crm` | `crm.lead`, stages, tags, lost reasons, recurring plans, PLS, dedup/merge, conversion, activity report |
+| `sales_team` | `crm.team`, `crm.team.member`, `crm.tag` base |
+| `sale_crm` | links opportunities to quotations/orders (`order_ids`, `sale_amount_total`), auto-bumps expected revenue from linked SO |
+| `mass_mailing` | `mailing.mailing`, `mailing.list`, `mailing.contact`, `mailing.subscription`(+optout), `mail.blacklist`, `mailing.filter`, campaign stats/A-B |
+| `mass_mailing_crm` / `_sms` | makes `crm.lead` a mailing target; adds `crm_lead_count` A/B winner criterion |
+| `crm_sms` | SMS send action on leads |
+| `utm` | `utm.campaign`, `utm.source`, `utm.medium`, `utm.stage`, `utm.tag`, `utm.mixin` |
+| `crm_iap_enrich` / `crm_iap_mine` | IAP company enrichment; external lead generation |
+| `website_crm` | website form → lead; visitor tracking |
+| `website_crm_partner_assign` | reseller geo-assignment; `res.partner.grade`/`activation` |
+| `event_crm` | event registration → lead rules |
+
+## Overall assessment
+
+A mature, funnel-centric design whose center of gravity is the *pre-sale* motion: capture strangers, qualify them, route them, score them, forecast them, and market to them at scale. Its genuine strengths for Positivity are the **marketing/UTM/consent stack** (§5) and the **company-vs-individual party discrimination** (§8) that makes differentiated campaigns possible — precisely the areas the user flagged. Its opportunity-pipeline, predictive-scoring, and reseller-geo-assignment machinery (§1, §3, §7) is largely orthogonal to a shop where "the pipeline" is really *appointment → estimate → workorder → invoice* and already lives in `pos-shop-manager` + `pos-workorder`. The comparison and specification documents treat those two categories very differently.

--- a/domains/crm/comp-vs-pos-customer-comparison.md
+++ b/domains/crm/comp-vs-pos-customer-comparison.md
@@ -100,7 +100,7 @@
 | Concern | Odoo | pos-customer | Notes / Verdict |
 | --- | --- | --- | --- |
 | Eventing / async integration | ORM + mail bus | Transactional outbox → `customer.events.v1`, replica consumers (`vehicle.events.v1`, `people-contact.events.v1`), manifests + replay, `ProcessedEvent` idempotency | **HAVE** — strong ADR-0044 rails; new campaign facts/commands ride the same outbox. |
-| Multi-channel send infra | Outgoing mail servers, IAP SMS | **Absent** in pos-customer | **BUILD / ELSEWHERE** — needs an email/SMS delivery channel (provider client or a `pos-notifications`/`pos-documents`-style sender). Key architectural decision, spec §0/§2. |
+| Multi-channel send infra | Outgoing mail servers, IAP SMS | **Absent** in pos-customer | **BUILD** in the **new `pos-marketing` module** (ACCEPTED, spec §0.3) — needs an email/SMS delivery channel (provider client or a `pos-notifications`/`pos-documents`-style sender). Provider selection is the remaining open item (spec §2, O-1). |
 | Idempotent redemption ingest | — | `recordRedemption` (dup → 409), `PromotionCounter` `@Version` | **HAVE.** |
 | Permissions model | Security groups | `crm:*` permission taxonomy (party/contact/relationship/promotion_redemption/…) registered to `pos-security-service` | **HAVE** — extend with `crm:campaign:*`, `crm:segment:*`, `crm:consent:*`. Spec each section. |
 
@@ -110,5 +110,5 @@
 2. **Consent enforcement.** Walk a send through the suppression checks: per-channel `CommunicationPreference`, marketing opt-out, global suppression list, quiet hours. Compare against Odoo's two-tier (per-list opt-out + global blacklist) and decide the equivalent tiers for Positivity.
 3. **"Pipeline" boundary.** Confirm explicitly that appointment→estimate→workorder→invoice (shop-manager + workorder) is the sales pipeline and that pos-customer will *not* grow an opportunity kanban — record it as a non-goal so it isn't reintroduced.
 4. **Follow-up vs booking boundary.** Model a "declined brake service" follow-up task and show it hands off to `pos-shop-manager` for the actual re-booking rather than duplicating scheduling.
-5. **Where campaigns live.** Decide whether the campaign/segment/consent capability is a new module (`pos-marketing`/`pos-campaign`) or an extension of `pos-customer`. Weigh ArchUnit module boundaries, the fact that parties/consent/redemptions already live in pos-customer, and the send-infrastructure dependency. (Spec §0 makes a recommendation.)
+5. **Where campaigns live — DECIDED.** Campaign orchestration + send live in a **new `pos-marketing` module**; segments/tags/consent/suppression/interaction-history/prospects stay in `pos-customer` (ACCEPTED 2026-07-28, spec §0.3). The exercise now is to validate the split against ArchUnit boundaries and confirm pos-marketing integrates with pos-customer via gateway REST + `customer.events.v1` only (no compile-time coupling).
 6. **Interaction history retro-fit.** Decide whether the customer interaction log generalizes the existing one-way `PartyNote` projection or is a new entity, and what write API it needs.

--- a/domains/crm/comp-vs-pos-customer-comparison.md
+++ b/domains/crm/comp-vs-pos-customer-comparison.md
@@ -1,0 +1,114 @@
+# Odoo CRM vs pos-customer — Capability Comparison Map
+
+> Purpose: a working checklist for comparing `durion-positivity-backend/pos-customer` against Odoo 19's CRM stack (`addons/crm` + `mass_mailing` + `utm` + siblings). Odoo detail is in `comp-crm-overview.md`. pos-customer references come from `pos-customer/README.md`, `src/main/java/com/positivity/customer/internal/**`, `src/main/resources/db/migration/`, and the CRM business-rules pack (`domains/crm/.business-rules/`) as of 2026-07-28.
+>
+> The two systems have different missions — Odoo is a general-purpose **sales-pipeline** CRM (capture → qualify → forecast → market); pos-customer is a **customer-master / party registry** for an enterprise tire-service platform where revenue is realized by executing workorders, choreographed through `pos-shop-manager` and `pos-workorder`. **"Gap" below means "Odoo has machinery pos-customer doesn't"; the right-most column judges whether Positivity actually wants it,** given that sales run through the workorder modules, product lists live in `pos-catalog`, promotions live in `pos-price`, and campaigns must distinguish commercial parties from individual parties.
+
+## Legend for the "Verdict" column
+
+- **BUILD** — genuine gap Positivity should close (detailed in `spec-pos-customer-crm-gaps.md`).
+- **BUILD (adapted)** — build the capability, but reshaped to the service-shop model, not Odoo's shape.
+- **ELSEWHERE** — the capability exists on the platform, just not in pos-customer (points to the owning service).
+- **NON-GOAL** — intentionally not wanted; record the reason so it isn't re-litigated.
+- **HAVE** — pos-customer already does this (sometimes better than Odoo).
+
+## 1. Party / contact model
+
+| Concern | Odoo (`res.partner`) | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Company vs individual | One `res.partner` model; `is_company` boolean; `commercial_partner_id` computed hierarchy root | Two subtypes: `CommercialParty` + `PersonParty` (TABLE_PER_CLASS), `PartyType` enum {PERSON, COMMERCIAL, UNKNOWN} | Both express the split; pos-customer's is explicit-typed. **HAVE.** This split is exactly what differentiated campaigns will key on. |
+| Company hierarchy | `parent_id`/`child_ids`, recursive commercial entity | `CommercialParty.parentParty`/`childParties` self-reference | **HAVE** (commercial only; persons don't nest). |
+| Person identity ownership | Names/emails/phones on the partner itself | **Not owned here** — `PersonParty.personId` links to `pos-people-contact` (ADR-0015); local read-only replica `ext_people_contact_person` | Architectural divergence: Positivity centralizes person identity in `pos-people-contact`. Relevant to campaigns: recipient contact points must be resolved via the replica. **HAVE (by design).** |
+| Contact tags / categories | `res.partner.category` (hierarchical) | **Absent** — only `AccountTier` (6 levels) + `AccountStatus` | No general tag/segment taxonomy on parties. **BUILD** (segmentation, spec §3). |
+| Multiple structured addresses | Address `type` (contact/invoice/delivery/other), full address fields | `primaryAddress` is a single free-text `String`; `billingAddressId` is a bare UUID reference | pos-customer has no structured/multi-address model. **BUILD (adapted)** if campaigns need mail/geo targeting; otherwise defer. |
+| External identifiers | `ref`, `vat` | `CommercialParty.externalIdentifiers` `Map<String,String>`, `taxId` | **HAVE** (richer key/value map). |
+| Duplicate detection & merge | Lead-level dedup + partner data-merge | First-class: `checkPartyDuplicates`, `mergeParties`, `PartyAlias` redirection, `MergeAudit`, `409 PARTY_MERGED` | **HAVE** — arguably stronger and more auditable than Odoo's partner merge. |
+| Account tiers / grading | `res.partner.grade` (reseller weight); `customer_rank` | `AccountTier` engine (STANDARD→ENTERPRISE) via `AccountTierService` scoring on revenue/contracts/age | Different intent (loyalty tier vs reseller weight). **HAVE** (a Positivity strength; feeds segmentation). |
+| Billing configuration on party | On invoicing layer | `BillingRulesEmbeddable` (poRequired, taxExempt, creditHold, creditLimit, paymentTerms, invoiceDeliveryMethod…) | **HAVE** — no Odoo-CRM equivalent; a service-B2B strength. |
+
+## 2. Leads and the sales funnel
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Lead object | `crm.lead` (denormalized prospect; `type='lead'`) | **Absent** — parties are created already-as-customers | Positivity has no "stranger capture" object. |
+| Lead capture (web form / email alias) | `website_crm`, team `alias_id` | **Absent**; `pos-inquiry` module is an empty placeholder | Fleet/individual inquiry capture is real but unbuilt. **BUILD (adapted)** — lightweight "prospect party" + convert, spec §5. Note `pos-inquiry` exists as a reserved home. |
+| Lead → opportunity conversion | `convert_opportunity` materializes `res.partner` | N/A | **NON-GOAL** in Odoo's shape (no denormalized-then-materialize funnel); the adapted prospect→customer flow in spec §5 replaces it. |
+| Opportunity pipeline / kanban stages | `crm.stage`, `probability`, `expected_revenue`, forecast | **Absent** | The Positivity "pipeline" is *appointment → estimate → workorder → invoice*, owned by `pos-shop-manager` + `pos-workorder`. **ELSEWHERE / NON-GOAL** — do **not** import an opportunity kanban into pos-customer. |
+| Recurring revenue / MRR | `crm.recurring.plan`, `recurring_revenue_monthly` | **Absent** | Fleet service contracts are the analog, but they live with billing/pricing, not CRM. **NON-GOAL** for pos-customer. |
+| Lost/won reasons | `crm.lost.reason`, `action_set_won/lost` | Only `MergeAudit.mergeReason` | Won/lost is meaningless without opportunities. For *declined recommended service* (the real shop analog) see follow-up, spec §4. **BUILD (adapted)** as decline-reason on service opportunities, not lost-reason on deals. |
+| Sales team / salesperson / territory | `crm.team`, `crm.team.member`, ownership | **Absent** — only audit `createdBy`/`modifiedBy` | No account-owner/CSR-assignment concept. **BUILD (light)** if account ownership is wanted (spec §6, optional); otherwise NON-GOAL. |
+| Rule-based lead assignment / round-robin | Weighted-random team + quota member assignment | **Absent** | Tied to lead routing; **NON-GOAL** (no leads to route at volume). |
+| Reseller geo-assignment | `website_crm_partner_assign` | **Absent** | **NON-GOAL** (Positivity operates its own shops, not a reseller channel). |
+| Predictive lead scoring (PLS) | Per-team Naive Bayes | **Absent** (tier scoring is deterministic classification, not ML) | **NON-GOAL** as deal-scoring. A *service-due / churn-risk* signal is a different, optional idea (spec §7, backlog). |
+
+## 3. Marketing and campaigns — **the headline gap**
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Campaign object | `utm.campaign` (+ `crm_lead_count`, stats) | **Absent** — no `campaign` entity anywhere in the backend (grep-clean across all `pos-*`) | **BUILD** — spec §1. Must be **differentiated by audience type: COMMERCIAL vs INDIVIDUAL parties** (user requirement). |
+| Mass mailing (email) | `mailing.mailing` (targeting, schedule, A/B, stats) | **Absent** | **BUILD** — spec §2 (send orchestration; delivery via a provider/`pos-documents`-style channel). |
+| Mass SMS | `mass_mailing_sms` | **Absent** | **BUILD** — same campaign engine, SMS channel; honor per-channel consent. |
+| Audience targeting — list based | `mailing.list` + `mailing.contact` (lightweight, separate from partners) | **Absent** | **BUILD (adapted)** — static + dynamic segments over *party* attributes; no need for a separate lightweight-contact table since identity is centralized. Spec §3. |
+| Audience targeting — model-domain | `mailing_domain` over `res.partner`/`crm.lead`; saved `mailing.filter` | **Absent** | **BUILD** — segment predicate builder over party type, tier, tags, vehicle/service history, geography. Spec §3. |
+| Company-vs-individual segmentation | `is_company` domain filter on `res.partner` mailings | Party subtype exists but no targeting layer consumes it | The split is *present in data* but *unused for marketing*. **BUILD** — audience type is a first-class campaign dimension. Spec §1/§3. |
+| Product/offer linkage | Loose (mailing content); promotions elsewhere | Redemptions recorded (`PromotionRedemption`) but no campaign→offer link | **BUILD (adapted)** — campaign references a `pos-price` promotion offer and/or `pos-catalog` product list; redemption attribution closes the loop. Spec §1/§8. |
+| UTM source/medium attribution | `utm.source`/`utm.medium`/`utm.mixin` | **Absent** | **BUILD (light)** — campaign code carried onto workorder/redemption for attribution; full UTM URL-cookie capture is a **NON-GOAL**. Spec §8. |
+| A/B testing | `ab_testing_*` on mailings | **Absent** | **NON-GOAL** for v1 (revisit after base campaigns ship). |
+| Campaign statistics | `mailing.trace` → sent/open/click/reply/bounce | **Absent** | **BUILD (adapted)** — send/delivery outcomes + redemption/revenue attribution; open/click tracking depends on the email provider (spec §8). |
+
+## 4. Consent, opt-out, and suppression
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Per-party channel preference | Via mixins/blacklist | `CommunicationPreference`: email/sms/phone/marketing preference (OPT_IN/OPT_OUT/NOT_APPLICABLE), `consentFlags` map, `@Version` | **HAVE** — a solid base to build marketing consent on. |
+| Marketing opt-in specifically | `mailing.subscription.opt_out` per list + global blacklist | `marketingPreference` single flag; `BillingPreferences.marketingOptOut`/`doNotContact` on snapshot | Present but coarse (one global marketing flag). **BUILD** — per-channel + per-audience/campaign-type consent, quiet hours. Spec §4. |
+| Opt-out reasons | `mailing.subscription.optout` (reason catalog) | **Absent** | **BUILD (light)** — capture reason on opt-out for compliance. Spec §4. |
+| Global suppression list | `mail.blacklist` (address-level, all sends) | **Absent** — no hard suppression separate from preference | **BUILD** — a suppression list the send pipeline must consult (bounces, complaints, legal DNC). Spec §4. |
+| Consent history / audit | Chatter + tracking | `consentFlags` snapshot only (no history); `updateSource` field | **BUILD (light)** — consent-change audit trail (who/when/source), needed for CAN-SPAM/TCPA defensibility. Spec §4. |
+| Double opt-in | Subscription-management page | **Absent** | **NON-GOAL** v1; backlog. |
+
+## 5. Activities, follow-up, and interaction history
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Scheduled activities / tasks | `mail.activity.mixin` (assignee, due date, type) | **Absent** as first-class tasks | **BUILD (adapted)** — CSR/service follow-up tasks: *declined-service follow-up*, *service-due reminder*, *fleet check-in*. Spec §4/§6. |
+| Meetings / calendar | `calendar.event` link | **Absent** (appointments live in `pos-shop-manager`) | **ELSEWHERE** — booking is shop-manager's job; CRM follow-up should *hand off* to it, not duplicate it. |
+| Interaction / communication log | `mail.thread` chatter (messages, emails, tracked changes) per record | **Absent** — `CommunicationPreference` stores *consent*, not *history*. `PartyNote` exists but is a one-way projection from workorder events (no write API, no author/type/thread) | Big gap: no record of *what we sent the customer or said to them*. **BUILD (adapted)** — customer interaction/touch history (campaign sends, calls, follow-ups). Spec §4. |
+| Field-change / stage audit | `mail.tracking` + `_track_duration_field` | Audit events via `@EmitEvent` to `pos-event-receiver`; `updatedAt`/`modifiedBy` | **HAVE** (platform audit rail differs but exists). |
+
+## 6. Segmentation and reporting
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Tag taxonomies | `crm.tag`, `res.partner.category`, `utm.tag` | **Absent** (tier/status only) | **BUILD** — party tags/labels feeding segments. Spec §3. |
+| Saved segments / filters | `mailing.filter`, `ir.filters` | **Absent** | **BUILD** — named, reusable, static-or-dynamic segments. Spec §3. |
+| Pipeline / forecast analysis | pivot/graph on `crm.lead` | **Absent** (no pipeline) | **NON-GOAL**; service-throughput analytics belong to shop-manager/workorder reporting. |
+| Campaign analysis | `utm.campaign` stats, `crm.activity.report` | **Absent** | **BUILD (adapted)** — campaign reach/redemption/attributed-revenue report. Spec §8. |
+| Customer 360 / snapshot | Partner form + smart buttons | `CrmSnapshotDTO` (account + contacts + vehicles + billing prefs) | **HAVE** — richer consolidated read model than Odoo's form; extend it with campaign/consent/interaction summaries (spec §4/§8). |
+
+## 7. Promotions / offers (cross-service)
+
+| Concern | Odoo | pos-customer / platform | Notes / Verdict |
+| --- | --- | --- | --- |
+| Promotion / discount offers | Coupons/loyalty in `sale`/`loyalty` addons | **`pos-price`** owns `PromotionOffer` (promo code, discount type/value, dates, usage limit, storeCode) + eligibility rules + `applyPromotion` | **ELSEWHERE** (`pos-price`). Campaigns should *reference* these offers, not redefine discounts. Spec §1/§8. |
+| Product lists / catalogs | Pricelists, product templates | **`pos-catalog`** owns product master + price books | **ELSEWHERE** (`pos-catalog`). A campaign targeting "winter tires" references a catalog product list. |
+| Redemption tracking | Coupon usage | **`pos-customer`** already records `PromotionRedemption` (idempotent, per promotion+workorder) + `PromotionCounter` | **HAVE** — the attribution sink already exists; campaigns plug into it. |
+| Eligibility by audience | Loyalty rules | `pos-price` eligibility rules (estimate/line context) | Audience-type eligibility (commercial vs individual) may need a rule input; coordinate with pricing. Spec §1 note. |
+
+## 8. Integration and platform mechanics
+
+| Concern | Odoo | pos-customer | Notes / Verdict |
+| --- | --- | --- | --- |
+| Eventing / async integration | ORM + mail bus | Transactional outbox → `customer.events.v1`, replica consumers (`vehicle.events.v1`, `people-contact.events.v1`), manifests + replay, `ProcessedEvent` idempotency | **HAVE** — strong ADR-0044 rails; new campaign facts/commands ride the same outbox. |
+| Multi-channel send infra | Outgoing mail servers, IAP SMS | **Absent** in pos-customer | **BUILD / ELSEWHERE** — needs an email/SMS delivery channel (provider client or a `pos-notifications`/`pos-documents`-style sender). Key architectural decision, spec §0/§2. |
+| Idempotent redemption ingest | — | `recordRedemption` (dup → 409), `PromotionCounter` `@Version` | **HAVE.** |
+| Permissions model | Security groups | `crm:*` permission taxonomy (party/contact/relationship/promotion_redemption/…) registered to `pos-security-service` | **HAVE** — extend with `crm:campaign:*`, `crm:segment:*`, `crm:consent:*`. Spec each section. |
+
+## 9. Suggested comparison exercises (to pressure-test the spec)
+
+1. **Differentiated campaign walk-through.** Take one "commercial winter-tire fleet promo" and one "individual oil-change reminder." Trace how each selects its audience (segment predicate over `PartyType` + tier + vehicle/service history), which consent flags gate it, which `pos-price` offer it references, and how a resulting workorder redemption attributes back to the campaign. Confirm the model cleanly separates COMMERCIAL and INDIVIDUAL audiences end-to-end.
+2. **Consent enforcement.** Walk a send through the suppression checks: per-channel `CommunicationPreference`, marketing opt-out, global suppression list, quiet hours. Compare against Odoo's two-tier (per-list opt-out + global blacklist) and decide the equivalent tiers for Positivity.
+3. **"Pipeline" boundary.** Confirm explicitly that appointment→estimate→workorder→invoice (shop-manager + workorder) is the sales pipeline and that pos-customer will *not* grow an opportunity kanban — record it as a non-goal so it isn't reintroduced.
+4. **Follow-up vs booking boundary.** Model a "declined brake service" follow-up task and show it hands off to `pos-shop-manager` for the actual re-booking rather than duplicating scheduling.
+5. **Where campaigns live.** Decide whether the campaign/segment/consent capability is a new module (`pos-marketing`/`pos-campaign`) or an extension of `pos-customer`. Weigh ArchUnit module boundaries, the fact that parties/consent/redemptions already live in pos-customer, and the send-infrastructure dependency. (Spec §0 makes a recommendation.)
+6. **Interaction history retro-fit.** Decide whether the customer interaction log generalizes the existing one-way `PartyNote` projection or is a new entity, and what write API it needs.

--- a/domains/crm/plan-odoo-parity-pos-customer.md
+++ b/domains/crm/plan-odoo-parity-pos-customer.md
@@ -55,7 +55,7 @@ Non-negotiable constraints. Every story must be validated against them before me
 
 Spec §3, §4, §8. No external dependencies; unblocks everything else. Migrations start at **V17**.
 
-### Story A1 — Party tags
+### Story A1 — Party tags (#1136)
 - **Change**: `PartyTag` (`tagId`, `name` unique, `category` nullable, `color`, `active`) + `PartyTagAssignment` (`partyId`, `tagId`, `assignedBy`, `assignedAt`, `source` enum MANUAL/CAMPAIGN/IMPORT/RULE). Flat taxonomy for v1.
 - **Files**: `internal/entity/PartyTag.java`, `PartyTagAssignment.java`; `internal/repository/*`; `service/PartyTagService.java` + `internal/service/PartyTagServiceImpl.java`; `internal/controller/CrmTagController.java` (`/v1/crm/tags` CRUD) + tag endpoints on `/v1/crm/parties/{partyId}/tags`; DTOs; `V17__party_tags.sql`.
 - **Permissions**: `crm:tag:view`, `crm:tag:manage`, `crm:tag:assign` (add to `CrmPermissionRegistry` + `permissions.yaml`).
@@ -63,7 +63,7 @@ Spec §3, §4, §8. No external dependencies; unblocks everything else. Migratio
 - **AC**: tags CRUD; assign/remove idempotent; assignment emits audit + fact; ArchUnit green.
 - **Effort**: M. **Deps**: none.
 
-### Story A2 — Segment model (static + dynamic)
+### Story A2 — Segment model (static + dynamic) (#1137)
 - **Change**: `Segment` (`segmentId`, `name`, `description`, `audienceType` COMMERCIAL/INDIVIDUAL, `type` STATIC/DYNAMIC, `predicate` JSON for DYNAMIC, audit) + `SegmentMember` (`segmentId`, `partyId`, `contactId?`) for STATIC. Predicate is a **validated boolean tree** (`{attribute, operator, value}` + AND/OR/NOT) over a whitelisted attribute catalog — **not** free SQL.
 - **Attribute catalog (v1, from data pos-customer already holds)**: party (`partyType`, `accountTier`, `accountStatus`, `parentPartyId present`, `externalIdentifier[system]`, tags), billing rules (`taxExempt`, `creditHold`, `paymentTerms`), consent (`marketing <channel> opted-in`), vehicle from `ext_vehicle` (`make/model`, `year range`, `has active vehicle`, `vehicle count ≥ N`). Service-history + geography attributes deferred to A-follow (needs FI-3/FI-4).
 - **Files**: `internal/entity/Segment.java`, `SegmentMember.java`; `internal/domain/SegmentPredicate*.java` (predicate model + validator); `internal/service/SegmentResolutionService*` (query builder over local tables + replicas, paginated + capped); `service/SegmentService.java`; `internal/controller/CrmSegmentController.java` (`/v1/crm/segments` CRUD + `POST /{id}/resolve`); `V18__segments.sql`.
@@ -71,7 +71,7 @@ Spec §3, §4, §8. No external dependencies; unblocks everything else. Migratio
 - **AC**: invalid predicate rejected at save (`422`); resolution deterministic, paginated, consent-filtered; a COMMERCIAL segment never returns person parties (and vice-versa); resolve returns count + masked sample.
 - **Effort**: L. **Deps**: A1 (tag attribute).
 
-### Story A3 — Marketing consent enrichment
+### Story A3 — Marketing consent enrichment (#1138)
 - **Change**: extend `CommunicationPreference` with per-channel marketing consent (`marketingEmailConsent`, `marketingSmsConsent` — OPT_IN/OPT_OUT/UNSET) distinct from operational `emailPreference`/`smsPreference`; add opt-out reason (`OptOutReason` catalog: NOT_INTERESTED, TOO_FREQUENT, NEVER_SIGNED_UP, LEGAL_DNC, …); optional quiet-hours/cadence fields. Add **`CommercialParty.accountMarketingOptOut`** (hard master gate — O-2).
 - **Consent resolution rule (O-2)**: for a COMMERCIAL account, if `accountMarketingOptOut` is set → suppress the whole account; else the **primary business contact's** personal per-channel consent governs account-level sends. Individuals use personal consent directly. Encapsulate in a `MarketingConsentResolver`.
 - **Files**: edit `internal/entity/CommunicationPreference.java`, `CommercialParty.java`; `internal/enums/OptOutReason.java`; `internal/service/MarketingConsentResolver*`; extend comm-pref upsert DTO/endpoints; `V19__marketing_consent.sql`.
@@ -79,13 +79,13 @@ Spec §3, §4, §8. No external dependencies; unblocks everything else. Migratio
 - **AC**: consent resolver returns correct allow/deny per channel for both party types under all account-flag states; migration backfills `marketingPreference` → per-channel consent.
 - **Effort**: M. **Deps**: none (A2 references the consent attribute; sequence A3 before A2 resolve-filtering hardens, but can proceed in parallel with a stub).
 
-### Story A4 — Consent-change audit (`ConsentEvent`)
+### Story A4 — Consent-change audit (`ConsentEvent`) (#1139)
 - **Change**: append-only `ConsentEvent` (`partyId`, `channel`, `oldValue`, `newValue`, `reason`, `source`, `actor`, `at`). Written on every marketing-consent change. Compliance export endpoint.
 - **Files**: `internal/entity/ConsentEvent.java`; repo; hook in `MarketingConsentResolver`/comm-pref service; `GET /v1/crm/parties/{partyId}/consent-history`; `V20__consent_event.sql`.
 - **AC**: every consent change writes exactly one `ConsentEvent`; history queryable + exportable; append-only (no update/delete path).
 - **Effort**: S. **Deps**: A3.
 
-### Story A5 — Suppression list (`SuppressionEntry`)
+### Story A5 — Suppression list (`SuppressionEntry`) (#1140)
 - **Change**: hard address-level block consulted by every send. `SuppressionEntry` (`suppressionId`, `channel`, `addressHash` normalized+hashed, `partyId?`, `reason` HARD_BOUNCE/SPAM_COMPLAINT/LEGAL_DNC/MANUAL/UNSUBSCRIBE_LINK, `source`, `createdAt`). Populated by manual admin action + unsubscribe-link + (later) provider bounce/complaint feed. Read API for the send pipeline.
 - **Files**: `internal/entity/SuppressionEntry.java`; repo; `service/SuppressionService.java`; `internal/controller/CrmSuppressionController.java` (`/v1/crm/suppression` add/list/remove) + a suppression-check read used by pos-marketing (via gateway or `customer.events.v1` replica of suppression facts); `V21__suppression.sql`.
 - **Permissions**: `crm:suppression:view/manage`.
@@ -93,26 +93,26 @@ Spec §3, §4, §8. No external dependencies; unblocks everything else. Migratio
 - **AC**: suppression is honored independent of preference; address hashing consistent with lookup; manual add/remove audited.
 - **Effort**: M. **Deps**: none.
 
-### Story A6 — Interaction / touch history (`CustomerInteraction`)
+### Story A6 — Interaction / touch history (`CustomerInteraction`) (#1141)
 - **Change**: generalize the one-way `PartyNote` into `CustomerInteraction` (`interactionId`, `partyId`, `contactId?`, `type` CAMPAIGN_SEND/EMAIL/SMS/CALL/FOLLOW_UP/NOTE/WORKORDER_NOTE, `channel?`, `direction` OUTBOUND/INBOUND, `campaignId?`, `subject/summary`, `body?` redaction-aware per DECISION-INVENTORY-006, `actor`, `occurredAt`, `sourceEventId`). Written by: campaign-send facts (from `marketing.events.v1`), CSR follow-up actions (WS-D), and the existing workorder `PartyNoteAdded` projection.
 - **Files**: `internal/entity/CustomerInteraction.java`; repo; `service/CustomerInteractionService.java`; migrate `WorkorderEventHandler` `PartyNoteAdded` path to write `CustomerInteraction` (keep `party_note` or fold in); `GET /v1/crm/parties/{partyId}/interactions` (paged, filterable); consume `marketing.events.v1` campaign-send facts into interactions; `V22__customer_interaction.sql`.
 - **Permissions**: `crm:interaction:view`.
 - **AC**: campaign sends appear in party history within event SLA; existing PartyNote projection preserved; redaction applied to `body`.
 - **Effort**: M. **Deps**: A-tier; the `marketing.events.v1` consumer half depends on WS-C (can land as a follow-up).
 
-### Story A7 — Redemption attribution column
+### Story A7 — Redemption attribution column (#1142)
 - **Change**: add `campaignCode` to `PromotionRedemption` (already has `promotionCode`); populate from the redemption-recording path when a campaign code is present; emit on the redemption fact for pos-marketing attribution.
 - **Files**: edit `internal/entity/PromotionRedemption.java`, `RecordRedemptionRequest`, mapper, `PromotionRedemptionServiceImpl`; `V23__redemption_campaign_code.sql`.
 - **AC**: redemptions carry `campaignCode`; existing idempotency (dup → 409) unchanged; attribution fact emitted.
 - **Effort**: S. **Deps**: none.
 
-### Story A8 — Snapshot integration
+### Story A8 — Snapshot integration (#1143)
 - **Change**: extend `CrmSnapshotDTO` with a consent summary (per-channel marketing consent + suppression flags) and a recent-interaction summary.
 - **Files**: edit `dto/snapshot/CrmSnapshotDTO.java`, snapshot builder in `PartyServiceImpl`/`CrmVehicleServiceImpl`; snapshot controller unchanged.
 - **AC**: snapshot exposes contactability + touch summary without raw PII beyond policy; existing consumers unaffected.
 - **Effort**: S. **Deps**: A3, A5, A6.
 
-### Story A-follow — Service-history & geography segment attributes (deferred)
+### Story A-follow — Service-history & geography segment attributes (deferred) (#1144)
 - **Change**: once FI-3 (service-history feed) and FI-4 (structured address) land, add the `last service > N months`, `service-due`, `declined service in last N days`, and region/geo attributes to the A2 predicate catalog + resolver.
 - **AC**: new attributes validate and resolve; documented as available.
 - **Effort**: M. **Deps**: A2, **FI-3** (`#1133`), **FI-4** (`#1135`).
@@ -123,13 +123,13 @@ Spec §3, §4, §8. No external dependencies; unblocks everything else. Migratio
 
 Spec §0.3, §1, §2.1. Stand up the new module, then campaign definition/lifecycle and templates. `marketing.events.v1` + fresh Flyway baseline.
 
-### Story B0 — Module bootstrap
+### Story B0 — Module bootstrap (#1145)
 - **Change**: create `pos-marketing` Maven module under the reactor: `PosMarketingApplication` (root of `com.positivity.marketing`), `internal/{controller,service,repository,entity,dto,config,client,event}`, `service/` public interfaces, `MarketingEventTypes` + `MarketingEventTypeInitializer`, `MarketingPermissionRegistry`, `MarketingApplicationConfig` (security filter, DB, Kafka), `ArchitectureTest`, `application.yml` (`server.port: 0`, Eureka), gateway route `marketing/vN`, Docker/pom wiring, `V1__baseline_marketing_schema.sql` (empty baseline + outbox tables mirroring pos-customer's `event_outbox`/`processed_events`).
 - **Files**: new module tree; add to root `pom.xml` `<modules>`; `pos-api-gateway` route config.
 - **AC**: module builds, registers with Eureka, health endpoint green, ArchUnit passes, permission/event initializers run without blocking startup.
 - **Effort**: M. **Deps**: none (parallel with WS-A).
 
-### Story B1 — Campaign entity + lifecycle
+### Story B1 — Campaign entity + lifecycle (#1146)
 - **Change**: `Campaign` (`campaignId`, `code` unique, `name`, `description`, `audienceType` immutable, `campaignProgramId?`, `status`, `channels` Set<EMAIL,SMS>, `segmentId`, `promotionOfferId?`, `catalogFocusRef?`, `windowStart/End`, `scheduleType`, `scheduledAt?`, template refs, audit). Lifecycle DRAFT→SCHEDULED→SENDING→SENT/CLOSED with PAUSED/CANCELLED; transitions are command endpoints.
 - **Files**: `internal/entity/Campaign.java`, `internal/enums/{AudienceType,CampaignStatus,CampaignChannel,ScheduleType}.java`; repo; `service/CampaignService.java` + impl (state machine + guards); `internal/controller/CampaignController.java` (`/v1/marketing/campaigns` create/get/list/update/schedule/pause/resume/cancel); DTOs; `V2__campaign.sql`.
 - **Permissions**: `marketing:campaign:view/create/edit/schedule/send/manage`.
@@ -137,14 +137,14 @@ Spec §0.3, §1, §2.1. Stand up the new module, then campaign definition/lifecy
 - **AC**: `audienceType` immutable after create; cannot SCHEDULE without a resolvable matching-audience segment + present templates + (if referenced) an ACTIVE offer; illegal transitions rejected.
 - **Effort**: L. **Deps**: B0; segment validation reads pos-customer segment via gateway (A2).
 
-### Story B2 — Message templates
+### Story B2 — Message templates (#1147)
 - **Change**: `MessageTemplate` per channel with token substitution; token catalog validated against `audienceType` (commercial `{{accountName}}` vs individual `{{vehicle...}}`).
 - **Files**: `internal/entity/MessageTemplate.java`; repo; `service/MessageTemplateService.java`; `internal/service/TemplateRenderService*` (token substitution, safe rendering); `/v1/marketing/templates` CRUD; `V3__message_template.sql`.
 - **Permissions**: `marketing:template:view/manage`.
 - **AC**: unknown/invalid tokens rejected at save; render produces channel-appropriate output; SMS length/segment guard.
 - **Effort**: M. **Deps**: B0.
 
-### Story B3 — Audience binding + preview + offer/catalog validation
+### Story B3 — Audience binding + preview + offer/catalog validation (#1148)
 - **Change**: bind a campaign to a segment; `POST /{id}/audience-preview` resolves the segment (via pos-customer gateway REST or a segment replica) and returns per-channel recipient counts **after** consent + suppression filtering, with a masked sample. Validate `promotionOfferId` is ACTIVE at schedule time (read `pos-price`); `catalogFocusRef` resolvable (read `pos-catalog`).
 - **Files**: `internal/client/{CustomerClient,PriceClient,CatalogClient}.java` (load-balanced RestClients); `internal/service/AudienceResolutionService*`; preview DTOs.
 - **AC**: preview counts reflect consent/suppression; COMMERCIAL resolves to account contacts by role, INDIVIDUAL to the person's primary contact; offer/catalog refs validated; no raw PII beyond masked sample.
@@ -156,26 +156,26 @@ Spec §0.3, §1, §2.1. Stand up the new module, then campaign definition/lifecy
 
 Spec §2.2, §8. Async batched send through the **shared platform sender** (O-1); attribution from redemptions.
 
-### Story C1 — CampaignSend model + async dispatch
+### Story C1 — CampaignSend model + async dispatch (#1149)
 - **Change**: `CampaignSend` (`campaignId`, `recipientPartyId`, `contactId`, `channel`, `resolvedAddress` transient/hashed, `status`, `providerMessageId`, `failureReason`, timestamps). Async batched dispatch (outbox/worker), rate-limited, **re-checks consent + suppression at send time**. Idempotent per (campaignId, recipientId, channel). `POST /{id}/send` → `202`.
 - **Files**: `internal/entity/CampaignSend.java`; repo; `internal/service/CampaignSendOrchestrator*` + worker; `internal/config/…` scheduling; DTOs.
 - **@EmitEvent/facts**: `MARKETING_CAMPAIGN_SEND`; emit `campaign.sent`.
 - **AC**: no send to a suppressed/opted-out recipient at dispatch time; every send carries the campaign `code`; re-invoking `/send` never double-sends; provider failures retried with backoff, permanent → `FAILED` without blocking the batch.
 - **Effort**: L. **Deps**: B3, A5.
 
-### Story C2 — Shared sender adapter + outcome feedback
+### Story C2 — Shared sender adapter + outcome feedback (#1150)
 - **Change**: `MessageChannel` interface + adapter to the shared platform sender (per FI-2 contract). Ingest delivery/bounce/complaint outcomes (event or callback) → update `CampaignSend` + push bounce/complaint into CRM suppression (emit to `customer.commands.v1`/suppression API). Emit `campaign.send.delivered/bounced/complained`.
 - **Files**: `internal/client/PlatformSenderClient.java`; `internal/service/DeliveryOutcomeListener*`; suppression feedback path.
 - **AC**: outcomes update send state; bounces/complaints reach CRM suppression (A5); open/click tracked when the sender supports it, degrade gracefully otherwise.
 - **Effort**: L. **Deps**: C1, **FI-2** (`durion#369`), A5.
 
-### Story C3 — Interaction logging of sends (CRM side)
+### Story C3 — Interaction logging of sends (CRM side) (#1151)
 - **Change**: pos-customer consumes `campaign.sent`/send facts from `marketing.events.v1` → writes `CAMPAIGN_SEND` `CustomerInteraction` rows (closes A6's marketing half).
 - **Files**: `internal/service/MarketingEventsListener` (pos-customer), idempotent via `processed_events`.
 - **AC**: each campaign send appears in the recipient's interaction history within SLA; idempotent.
 - **Effort**: S. **Deps**: A6, C1.
 
-### Story C4 — Campaign stats + attribution
+### Story C4 — Campaign stats + attribution (#1152)
 - **Change**: `GET /campaigns/{id}/stats` — reach funnel per channel (targeted → eligible → sent → delivered → opened/clicked → redeemed → attributed workorders/revenue), split by `audienceType`, with a `campaignProgramId` rollup comparing commercial vs individual arms. Attribution: consume redemption facts (with `campaignCode`, A7) → conversion counters, idempotent by `redemptionId`.
 - **Files**: `internal/service/CampaignStatsService*`; `internal/service/RedemptionAttributionListener*` (consume `customer.events.v1` redemption facts); stats DTOs.
 - **Permissions**: `marketing:stats:view`.
@@ -188,14 +188,14 @@ Spec §2.2, §8. Async batched send through the **shared platform sender** (O-1)
 
 Spec §5, §6. Depends on cross-domain facts (FI-3) and is lower priority than A–C.
 
-### Story D1 — FollowUpTask
+### Story D1 — FollowUpTask (#1153)
 - **Change**: `FollowUpTask` (`taskId`, `partyId`, `vehicleId?`, `type` DECLINED_SERVICE_FOLLOWUP/SERVICE_DUE_REMINDER/FLEET_CHECKIN/CAMPAIGN_RESPONSE/GENERAL, `dueDate`, `assignedTo?`, `status` OPEN/DONE/DISMISSED, `sourceWorkorderId?`, `reason?`, `outcome?`, `notes`). Created from workorder `serviceLine.declined` facts (one per declined line, idempotent) and from `VehicleCarePreference` service-due. Completing a task can deep-link to `pos-shop-manager` appointment creation (hand-off, never books).
 - **Files**: `internal/entity/FollowUpTask.java`; repo; `service/FollowUpTaskService.java`; consume declined-service facts in a listener (idempotent via `processing_log`); `/v1/crm/parties/{partyId}/follow-ups` + CSR queue `/v1/crm/follow-ups?assignedTo=&status=`; `V24__follow_up_task.sql`.
 - **Permissions**: `crm:followup:view/manage`.
 - **AC**: a declined-service event yields exactly one task; completion records outcome and links the resulting appointment/workorder when booked.
 - **Effort**: M. **Deps**: **FI-3** (`#1133`) for the declined-service + care-preference feed.
 
-### Story D2 — Prospect lifecycle + Inquiry capture
+### Story D2 — Prospect lifecycle + Inquiry capture (#1154)
 - **Change**: add `lifecycleStage` (PROSPECT → ACTIVE → DORMANT) to the party; `Inquiry` entity in **pos-customer** (`inquiryId`, `channel`, `audienceType`, captured contact fields, `vehicleOfInterest?`, `serviceOfInterest?`, `campaignCode?`, `status` NEW→CONTACTED→CONVERTED→CLOSED, `partyId?`, `assignedTo?`). Public inbound "request service / fleet quote" endpoint (rate-limited, captcha, no auth) fronted through the gateway. Conversion reuses `checkPartyDuplicates` + create-party, optional shop-manager hand-off. **Not** in `pos-inquiry` (supplier-scoped).
 - **Files**: edit `AbstractParty`/status handling for `lifecycleStage`; `internal/entity/Inquiry.java`; repo; `service/InquiryService.java`; `internal/controller/{InquiryController, PublicInquiryController}.java`; `V25__prospect_inquiry.sql`.
 - **Permissions**: `crm:inquiry:view/manage`; public capture endpoint unauthenticated but rate-limited.

--- a/domains/crm/plan-odoo-parity-pos-customer.md
+++ b/domains/crm/plan-odoo-parity-pos-customer.md
@@ -1,6 +1,6 @@
 ## Odoo Parity Plan — pos-customer (CRM)
 
-> Status: DRAFT · Created 2026-07-28 · Branch: `claude/odoo-crm-pos-customer-comparison-pc1ky6`
+> Status: **ACCEPTED** · Created 2026-07-28 · Accepted 2026-07-28 · Branch: `claude/odoo-crm-pos-customer-comparison-pc1ky6`
 >
 > Goal: bring the Durion CRM surface to functional parity with the Odoo 19 CRM capabilities that matter for an **enterprise tire-service management** platform — without importing the parts of Odoo's sales funnel that do not fit a service shop. Revenue is realized through the workorder flow (`pos-shop-manager` → `pos-workorder` → `pos-invoice`); this plan builds the **demand-generation and customer-relationship layer** that feeds it: marketing campaigns (differentiated commercial vs individual), segmentation, marketing-grade consent, interaction history, follow-up, and lightweight prospect capture.
 >
@@ -249,8 +249,22 @@ Critical path: Wave 1 (A2/A3/A5) → B3 → C1 → C2(FI-2) → C4. FI-2 is the 
 ## 9. Issue tracking
 
 - **Cross-domain prerequisites (created):** FI-1 `durion-positivity-backend#1134`, FI-2 `durion#369`, FI-3 `durion-positivity-backend#1133`, FI-4 `durion-positivity-backend#1135`.
-- **Implementation stories (to be created):** A1–A8 + A-follow, B0–B3, C1–C4, D1–D2 — file as capability stories under a CRM/marketing capability in `durion-positivity-backend` (and the `pos-marketing` bootstrap). Suggested labels: `[STORY]`, domain `crm`/`marketing`, wave tag.
-- **Module addition:** `pos-marketing` (B0) requires a reactor `pom.xml` change + gateway route + CI wiring — call out in the PR description.
+- **Implementation stories (created 2026-07-28, all in `durion-positivity-backend`):**
+
+  | Story | Issue | Story | Issue |
+  | --- | --- | --- | --- |
+  | A1 Party tags | #1136 | B0 pos-marketing bootstrap | #1145 |
+  | A2 Segment model | #1137 | B1 Campaign + lifecycle | #1146 |
+  | A3 Marketing consent enrichment | #1138 | B2 Message templates | #1147 |
+  | A4 Consent-change audit | #1139 | B3 Audience binding + preview | #1148 |
+  | A5 Suppression list | #1140 | C1 CampaignSend + dispatch | #1149 |
+  | A6 Interaction history | #1141 | C2 Shared sender adapter | #1150 |
+  | A7 Redemption `campaignCode` | #1142 | C3 Log sends to interactions | #1151 |
+  | A8 Snapshot integration | #1143 | C4 Stats + attribution | #1152 |
+  | A-follow Service-history/geo attrs | #1144 | D1 FollowUpTask | #1153 |
+  |  |  | D2 Prospect + Inquiry | #1154 |
+
+- **Module addition:** `pos-marketing` (B0, #1145) requires a reactor `pom.xml` change + gateway route + CI wiring — call out in the PR description.
 
 ---
 

--- a/domains/crm/plan-odoo-parity-pos-customer.md
+++ b/domains/crm/plan-odoo-parity-pos-customer.md
@@ -1,0 +1,264 @@
+## Odoo Parity Plan — pos-customer (CRM)
+
+> Status: DRAFT · Created 2026-07-28 · Branch: `claude/odoo-crm-pos-customer-comparison-pc1ky6`
+>
+> Goal: bring the Durion CRM surface to functional parity with the Odoo 19 CRM capabilities that matter for an **enterprise tire-service management** platform — without importing the parts of Odoo's sales funnel that do not fit a service shop. Revenue is realized through the workorder flow (`pos-shop-manager` → `pos-workorder` → `pos-invoice`); this plan builds the **demand-generation and customer-relationship layer** that feeds it: marketing campaigns (differentiated commercial vs individual), segmentation, marketing-grade consent, interaction history, follow-up, and lightweight prospect capture.
+>
+> Sources: `spec-pos-customer-crm-gaps.md` (the accepted specification this plan executes), `comp-crm-overview.md`, `comp-vs-pos-customer-comparison.md`, code survey of `pos-customer` (2026-07-28), surrounding modules (`pos-price`, `pos-catalog`, `pos-workorder`, `pos-shop-manager`, `pos-people-contact`), CRM business rules (`domains/crm/.business-rules/`), platform ADRs.
+>
+> **Companion cross-domain issues (already created):** FI-1 `durion-positivity-backend#1134` (pricing eligibility), FI-2 `durion#369` (shared sender contract), FI-3 `durion-positivity-backend#1133` (workorder→CRM facts), FI-4 `durion-positivity-backend#1135` (structured address). Several stories below depend on these.
+
+---
+
+## 0. Ground rules for the executing agent team
+
+Non-negotiable constraints. Every story must be validated against them before merge.
+
+1. **Module split (spec §0.3, ACCEPTED).** Two homes:
+   - **[CRM] `pos-customer`** — party-native data campaigns *consume*: tags, segments, marketing consent, suppression, consent audit, interaction history, prospects, redemption attribution, service-history projection.
+   - **[MKT] `pos-marketing`** — NEW bounded-context module owning campaign definition, audience binding, message templates, send orchestration, and campaign analytics. Standard `pos-{domain}` layout under `com.positivity.marketing`; own Postgres schema + Flyway baseline; **no compile-time dependency on pos-customer** — integration is gateway REST + `customer.events.v1` events only.
+2. **ADR-0044 event-only domain walls.** Cross-service flows are Kafka events + local `ext_*` replicas, never new synchronous repository reads across modules. Reuse the pos-customer outbox (`event_outbox`/`OutboxPublisher`/`OutboxEventWriter`) + `ProcessedEvent`/`processing_log` idempotency rails. pos-marketing stands up its own equivalent outbox for `marketing.events.v1`.
+3. **ADR-0013/0027**: UUID v7 IDs (`@UUIDv7Id`), UUID-typed identifiers in DTOs/services. **ADR-0024**: `createdAt`/`updatedAt` via Spring auditing with injected `Clock`. **ADR-0018**: actor fields from `SecurityContextHelper`, never request body. **ADR-0015**: person identity/contact points stay in `pos-people-contact`; pos-customer reads the `ext_people_contact_person` replica.
+4. **ADR-0017/0042**: canonical status codes (incl. `202` for async command acceptance), `ApiError` envelope, full OpenAPI annotations. Any controller change ⇒ regenerate `openapi.yaml` ⇒ update the Angular SDK (per `durion/CLAUDE.md`).
+5. **Module conventions** (`CLAUDE.md`/`AGENTS.md`): entities in `internal/entity`, public API behind `service/` interfaces (ArchUnit-enforced), `@EmitEvent` + `{Module}EventTypes` registry entry for every mutating endpoint, permissions in the code-first `{Module}PermissionRegistry` registered to `pos-security-service`, Spotless/Checkstyle/SpotBugs(High)/ArchUnit green, ArchUnit re-run after any package change.
+6. **Flyway**: pos-customer migrations continue the V-series after the current max **V16** (start at **V17**); pos-marketing starts a fresh **V1** baseline. No cross-service FKs; enums stored as smallint ordinals with CHECK constraints per existing pattern.
+7. **CRM domain decisions** (`AGENT_GUIDE.md`): `partyId` canonical (DECISION-INVENTORY-001); CRM owns contactability + contact roles + redemption records; CRM does **not** own workorder/invoice/payment lifecycle or promotion *policy* (discounts stay in `pos-price`, product lists in `pos-catalog`, booking in `pos-shop-manager`).
+8. **Positivity naming:** `workorder` is one word everywhere.
+
+**Where Odoo is the reference vs where Durion already wins.** Adopt from Odoo: the two-tier consent model (per-channel opt-out + global address-level suppression), campaign/UTM-style attribution, `is_company`-driven audience differentiation, saved segments (static list + dynamic filter), interaction history (chatter analog). Keep Durion's approach (do NOT import): the opportunity pipeline (it lives in shop-manager + workorder), predictive deal scoring, reseller geo-assignment, denormalized-lead-then-materialize funnel, and the separate lightweight `mailing.contact` table (identity is centralized in pos-people-contact — target parties directly).
+
+---
+
+## 1. Gap register (evidence-based)
+
+| # | Gap vs Odoo (spec ref) | Current state (evidence) | Workstream |
+| --- | --- | --- | --- |
+| G1 | No campaign object of any kind | `campaign` grep-clean across all `pos-*`; only per-party `marketingPreference` flag | B, C (new `pos-marketing`) |
+| G2 | No mass email/SMS send | No send infra in pos-customer; no provider client | C (+ FI-2) |
+| G3 | No audience segmentation | Only `AccountTier` (6 levels) + `AccountStatus`; no tags, lists, or filters | A |
+| G4 | No party tags | `AccountTier`/`AccountStatus` only | A |
+| G5 | Marketing consent is one coarse flag | `CommunicationPreference.marketingPreference` (single String OPT_IN/OPT_OUT/NA); `consentFlags` map | A |
+| G6 | No hard suppression list | Preference only; no address-level block; no bounce/complaint sink | A (+ FI-2 feed) |
+| G7 | No consent-change audit | `consentFlags` snapshot + `updateSource`; no history entity | A |
+| G8 | No interaction/touch history | `PartyNote` is one-way workorder projection, no write API, no author/type/thread | A |
+| G9 | No campaign attribution | `PromotionRedemption.promotionCode` present; no `campaignCode` | A (col) + C (analytics) |
+| G10 | No service-history signal for segments/follow-up | Consumes only `ContactPreferenceUpdated` + `PartyNoteAdded` | D (+ FI-3) |
+| G11 | No follow-up/task object | None; declined-service and service-due have no home | D |
+| G12 | No prospect/inquiry capture | Parties created already-as-customers; `pos-inquiry` is supplier-scoped | D |
+| G13 | Structured address absent | `primaryAddress` is a free-text `String` | Prereq FI-4 (pos-people-contact) |
+| G14 | Audience-type offer eligibility unverified | `pos-price` eligibility exists; audience/campaign predicate unconfirmed | Prereq FI-1 (pos-price) |
+| — | Opportunity pipeline / PLS / reseller assignment | Absent | **Non-goal** (spec §10) — do not build |
+
+---
+
+## 2. Workstream A — pos-customer CRM data foundations  **[CRM]**
+
+Spec §3, §4, §8. No external dependencies; unblocks everything else. Migrations start at **V17**.
+
+### Story A1 — Party tags
+- **Change**: `PartyTag` (`tagId`, `name` unique, `category` nullable, `color`, `active`) + `PartyTagAssignment` (`partyId`, `tagId`, `assignedBy`, `assignedAt`, `source` enum MANUAL/CAMPAIGN/IMPORT/RULE). Flat taxonomy for v1.
+- **Files**: `internal/entity/PartyTag.java`, `PartyTagAssignment.java`; `internal/repository/*`; `service/PartyTagService.java` + `internal/service/PartyTagServiceImpl.java`; `internal/controller/CrmTagController.java` (`/v1/crm/tags` CRUD) + tag endpoints on `/v1/crm/parties/{partyId}/tags`; DTOs; `V17__party_tags.sql`.
+- **Permissions**: `crm:tag:view`, `crm:tag:manage`, `crm:tag:assign` (add to `CrmPermissionRegistry` + `permissions.yaml`).
+- **Events/@EmitEvent**: `CRM_TAG_CREATE/UPDATE/DELETE`, `CRM_PARTY_TAG_ASSIGN/REMOVE`; emit `party.tag.changed` on `customer.events.v1` via outbox.
+- **AC**: tags CRUD; assign/remove idempotent; assignment emits audit + fact; ArchUnit green.
+- **Effort**: M. **Deps**: none.
+
+### Story A2 — Segment model (static + dynamic)
+- **Change**: `Segment` (`segmentId`, `name`, `description`, `audienceType` COMMERCIAL/INDIVIDUAL, `type` STATIC/DYNAMIC, `predicate` JSON for DYNAMIC, audit) + `SegmentMember` (`segmentId`, `partyId`, `contactId?`) for STATIC. Predicate is a **validated boolean tree** (`{attribute, operator, value}` + AND/OR/NOT) over a whitelisted attribute catalog — **not** free SQL.
+- **Attribute catalog (v1, from data pos-customer already holds)**: party (`partyType`, `accountTier`, `accountStatus`, `parentPartyId present`, `externalIdentifier[system]`, tags), billing rules (`taxExempt`, `creditHold`, `paymentTerms`), consent (`marketing <channel> opted-in`), vehicle from `ext_vehicle` (`make/model`, `year range`, `has active vehicle`, `vehicle count ≥ N`). Service-history + geography attributes deferred to A-follow (needs FI-3/FI-4).
+- **Files**: `internal/entity/Segment.java`, `SegmentMember.java`; `internal/domain/SegmentPredicate*.java` (predicate model + validator); `internal/service/SegmentResolutionService*` (query builder over local tables + replicas, paginated + capped); `service/SegmentService.java`; `internal/controller/CrmSegmentController.java` (`/v1/crm/segments` CRUD + `POST /{id}/resolve`); `V18__segments.sql`.
+- **Permissions**: `crm:segment:view/manage/resolve`.
+- **AC**: invalid predicate rejected at save (`422`); resolution deterministic, paginated, consent-filtered; a COMMERCIAL segment never returns person parties (and vice-versa); resolve returns count + masked sample.
+- **Effort**: L. **Deps**: A1 (tag attribute).
+
+### Story A3 — Marketing consent enrichment
+- **Change**: extend `CommunicationPreference` with per-channel marketing consent (`marketingEmailConsent`, `marketingSmsConsent` — OPT_IN/OPT_OUT/UNSET) distinct from operational `emailPreference`/`smsPreference`; add opt-out reason (`OptOutReason` catalog: NOT_INTERESTED, TOO_FREQUENT, NEVER_SIGNED_UP, LEGAL_DNC, …); optional quiet-hours/cadence fields. Add **`CommercialParty.accountMarketingOptOut`** (hard master gate — O-2).
+- **Consent resolution rule (O-2)**: for a COMMERCIAL account, if `accountMarketingOptOut` is set → suppress the whole account; else the **primary business contact's** personal per-channel consent governs account-level sends. Individuals use personal consent directly. Encapsulate in a `MarketingConsentResolver`.
+- **Files**: edit `internal/entity/CommunicationPreference.java`, `CommercialParty.java`; `internal/enums/OptOutReason.java`; `internal/service/MarketingConsentResolver*`; extend comm-pref upsert DTO/endpoints; `V19__marketing_consent.sql`.
+- **Permissions**: reuse `crm:contact_preference:edit/view`; add `crm:consent:view/manage`.
+- **AC**: consent resolver returns correct allow/deny per channel for both party types under all account-flag states; migration backfills `marketingPreference` → per-channel consent.
+- **Effort**: M. **Deps**: none (A2 references the consent attribute; sequence A3 before A2 resolve-filtering hardens, but can proceed in parallel with a stub).
+
+### Story A4 — Consent-change audit (`ConsentEvent`)
+- **Change**: append-only `ConsentEvent` (`partyId`, `channel`, `oldValue`, `newValue`, `reason`, `source`, `actor`, `at`). Written on every marketing-consent change. Compliance export endpoint.
+- **Files**: `internal/entity/ConsentEvent.java`; repo; hook in `MarketingConsentResolver`/comm-pref service; `GET /v1/crm/parties/{partyId}/consent-history`; `V20__consent_event.sql`.
+- **AC**: every consent change writes exactly one `ConsentEvent`; history queryable + exportable; append-only (no update/delete path).
+- **Effort**: S. **Deps**: A3.
+
+### Story A5 — Suppression list (`SuppressionEntry`)
+- **Change**: hard address-level block consulted by every send. `SuppressionEntry` (`suppressionId`, `channel`, `addressHash` normalized+hashed, `partyId?`, `reason` HARD_BOUNCE/SPAM_COMPLAINT/LEGAL_DNC/MANUAL/UNSUBSCRIBE_LINK, `source`, `createdAt`). Populated by manual admin action + unsubscribe-link + (later) provider bounce/complaint feed. Read API for the send pipeline.
+- **Files**: `internal/entity/SuppressionEntry.java`; repo; `service/SuppressionService.java`; `internal/controller/CrmSuppressionController.java` (`/v1/crm/suppression` add/list/remove) + a suppression-check read used by pos-marketing (via gateway or `customer.events.v1` replica of suppression facts); `V21__suppression.sql`.
+- **Permissions**: `crm:suppression:view/manage`.
+- **Events**: emit `party.suppressed`/`party.unsuppressed` on `customer.events.v1` so pos-marketing can maintain a suppression replica for fast send-time checks.
+- **AC**: suppression is honored independent of preference; address hashing consistent with lookup; manual add/remove audited.
+- **Effort**: M. **Deps**: none.
+
+### Story A6 — Interaction / touch history (`CustomerInteraction`)
+- **Change**: generalize the one-way `PartyNote` into `CustomerInteraction` (`interactionId`, `partyId`, `contactId?`, `type` CAMPAIGN_SEND/EMAIL/SMS/CALL/FOLLOW_UP/NOTE/WORKORDER_NOTE, `channel?`, `direction` OUTBOUND/INBOUND, `campaignId?`, `subject/summary`, `body?` redaction-aware per DECISION-INVENTORY-006, `actor`, `occurredAt`, `sourceEventId`). Written by: campaign-send facts (from `marketing.events.v1`), CSR follow-up actions (WS-D), and the existing workorder `PartyNoteAdded` projection.
+- **Files**: `internal/entity/CustomerInteraction.java`; repo; `service/CustomerInteractionService.java`; migrate `WorkorderEventHandler` `PartyNoteAdded` path to write `CustomerInteraction` (keep `party_note` or fold in); `GET /v1/crm/parties/{partyId}/interactions` (paged, filterable); consume `marketing.events.v1` campaign-send facts into interactions; `V22__customer_interaction.sql`.
+- **Permissions**: `crm:interaction:view`.
+- **AC**: campaign sends appear in party history within event SLA; existing PartyNote projection preserved; redaction applied to `body`.
+- **Effort**: M. **Deps**: A-tier; the `marketing.events.v1` consumer half depends on WS-C (can land as a follow-up).
+
+### Story A7 — Redemption attribution column
+- **Change**: add `campaignCode` to `PromotionRedemption` (already has `promotionCode`); populate from the redemption-recording path when a campaign code is present; emit on the redemption fact for pos-marketing attribution.
+- **Files**: edit `internal/entity/PromotionRedemption.java`, `RecordRedemptionRequest`, mapper, `PromotionRedemptionServiceImpl`; `V23__redemption_campaign_code.sql`.
+- **AC**: redemptions carry `campaignCode`; existing idempotency (dup → 409) unchanged; attribution fact emitted.
+- **Effort**: S. **Deps**: none.
+
+### Story A8 — Snapshot integration
+- **Change**: extend `CrmSnapshotDTO` with a consent summary (per-channel marketing consent + suppression flags) and a recent-interaction summary.
+- **Files**: edit `dto/snapshot/CrmSnapshotDTO.java`, snapshot builder in `PartyServiceImpl`/`CrmVehicleServiceImpl`; snapshot controller unchanged.
+- **AC**: snapshot exposes contactability + touch summary without raw PII beyond policy; existing consumers unaffected.
+- **Effort**: S. **Deps**: A3, A5, A6.
+
+### Story A-follow — Service-history & geography segment attributes (deferred)
+- **Change**: once FI-3 (service-history feed) and FI-4 (structured address) land, add the `last service > N months`, `service-due`, `declined service in last N days`, and region/geo attributes to the A2 predicate catalog + resolver.
+- **AC**: new attributes validate and resolve; documented as available.
+- **Effort**: M. **Deps**: A2, **FI-3** (`#1133`), **FI-4** (`#1135`).
+
+---
+
+## 3. Workstream B — pos-marketing module + campaign core  **[MKT]**
+
+Spec §0.3, §1, §2.1. Stand up the new module, then campaign definition/lifecycle and templates. `marketing.events.v1` + fresh Flyway baseline.
+
+### Story B0 — Module bootstrap
+- **Change**: create `pos-marketing` Maven module under the reactor: `PosMarketingApplication` (root of `com.positivity.marketing`), `internal/{controller,service,repository,entity,dto,config,client,event}`, `service/` public interfaces, `MarketingEventTypes` + `MarketingEventTypeInitializer`, `MarketingPermissionRegistry`, `MarketingApplicationConfig` (security filter, DB, Kafka), `ArchitectureTest`, `application.yml` (`server.port: 0`, Eureka), gateway route `marketing/vN`, Docker/pom wiring, `V1__baseline_marketing_schema.sql` (empty baseline + outbox tables mirroring pos-customer's `event_outbox`/`processed_events`).
+- **Files**: new module tree; add to root `pom.xml` `<modules>`; `pos-api-gateway` route config.
+- **AC**: module builds, registers with Eureka, health endpoint green, ArchUnit passes, permission/event initializers run without blocking startup.
+- **Effort**: M. **Deps**: none (parallel with WS-A).
+
+### Story B1 — Campaign entity + lifecycle
+- **Change**: `Campaign` (`campaignId`, `code` unique, `name`, `description`, `audienceType` immutable, `campaignProgramId?`, `status`, `channels` Set<EMAIL,SMS>, `segmentId`, `promotionOfferId?`, `catalogFocusRef?`, `windowStart/End`, `scheduleType`, `scheduledAt?`, template refs, audit). Lifecycle DRAFT→SCHEDULED→SENDING→SENT/CLOSED with PAUSED/CANCELLED; transitions are command endpoints.
+- **Files**: `internal/entity/Campaign.java`, `internal/enums/{AudienceType,CampaignStatus,CampaignChannel,ScheduleType}.java`; repo; `service/CampaignService.java` + impl (state machine + guards); `internal/controller/CampaignController.java` (`/v1/marketing/campaigns` create/get/list/update/schedule/pause/resume/cancel); DTOs; `V2__campaign.sql`.
+- **Permissions**: `marketing:campaign:view/create/edit/schedule/send/manage`.
+- **@EmitEvent/facts**: `MARKETING_CAMPAIGN_CREATE/UPDATE/SCHEDULE/...`; emit `campaign.scheduled` on `marketing.events.v1`.
+- **AC**: `audienceType` immutable after create; cannot SCHEDULE without a resolvable matching-audience segment + present templates + (if referenced) an ACTIVE offer; illegal transitions rejected.
+- **Effort**: L. **Deps**: B0; segment validation reads pos-customer segment via gateway (A2).
+
+### Story B2 — Message templates
+- **Change**: `MessageTemplate` per channel with token substitution; token catalog validated against `audienceType` (commercial `{{accountName}}` vs individual `{{vehicle...}}`).
+- **Files**: `internal/entity/MessageTemplate.java`; repo; `service/MessageTemplateService.java`; `internal/service/TemplateRenderService*` (token substitution, safe rendering); `/v1/marketing/templates` CRUD; `V3__message_template.sql`.
+- **Permissions**: `marketing:template:view/manage`.
+- **AC**: unknown/invalid tokens rejected at save; render produces channel-appropriate output; SMS length/segment guard.
+- **Effort**: M. **Deps**: B0.
+
+### Story B3 — Audience binding + preview + offer/catalog validation
+- **Change**: bind a campaign to a segment; `POST /{id}/audience-preview` resolves the segment (via pos-customer gateway REST or a segment replica) and returns per-channel recipient counts **after** consent + suppression filtering, with a masked sample. Validate `promotionOfferId` is ACTIVE at schedule time (read `pos-price`); `catalogFocusRef` resolvable (read `pos-catalog`).
+- **Files**: `internal/client/{CustomerClient,PriceClient,CatalogClient}.java` (load-balanced RestClients); `internal/service/AudienceResolutionService*`; preview DTOs.
+- **AC**: preview counts reflect consent/suppression; COMMERCIAL resolves to account contacts by role, INDIVIDUAL to the person's primary contact; offer/catalog refs validated; no raw PII beyond masked sample.
+- **Effort**: L. **Deps**: B1, A2/A3/A5; **FI-1** (`#1134`) for audience-specific offer eligibility (soft dep — preview works without it).
+
+---
+
+## 4. Workstream C — Send orchestration + attribution  **[MKT]**
+
+Spec §2.2, §8. Async batched send through the **shared platform sender** (O-1); attribution from redemptions.
+
+### Story C1 — CampaignSend model + async dispatch
+- **Change**: `CampaignSend` (`campaignId`, `recipientPartyId`, `contactId`, `channel`, `resolvedAddress` transient/hashed, `status`, `providerMessageId`, `failureReason`, timestamps). Async batched dispatch (outbox/worker), rate-limited, **re-checks consent + suppression at send time**. Idempotent per (campaignId, recipientId, channel). `POST /{id}/send` → `202`.
+- **Files**: `internal/entity/CampaignSend.java`; repo; `internal/service/CampaignSendOrchestrator*` + worker; `internal/config/…` scheduling; DTOs.
+- **@EmitEvent/facts**: `MARKETING_CAMPAIGN_SEND`; emit `campaign.sent`.
+- **AC**: no send to a suppressed/opted-out recipient at dispatch time; every send carries the campaign `code`; re-invoking `/send` never double-sends; provider failures retried with backoff, permanent → `FAILED` without blocking the batch.
+- **Effort**: L. **Deps**: B3, A5.
+
+### Story C2 — Shared sender adapter + outcome feedback
+- **Change**: `MessageChannel` interface + adapter to the shared platform sender (per FI-2 contract). Ingest delivery/bounce/complaint outcomes (event or callback) → update `CampaignSend` + push bounce/complaint into CRM suppression (emit to `customer.commands.v1`/suppression API). Emit `campaign.send.delivered/bounced/complained`.
+- **Files**: `internal/client/PlatformSenderClient.java`; `internal/service/DeliveryOutcomeListener*`; suppression feedback path.
+- **AC**: outcomes update send state; bounces/complaints reach CRM suppression (A5); open/click tracked when the sender supports it, degrade gracefully otherwise.
+- **Effort**: L. **Deps**: C1, **FI-2** (`durion#369`), A5.
+
+### Story C3 — Interaction logging of sends (CRM side)
+- **Change**: pos-customer consumes `campaign.sent`/send facts from `marketing.events.v1` → writes `CAMPAIGN_SEND` `CustomerInteraction` rows (closes A6's marketing half).
+- **Files**: `internal/service/MarketingEventsListener` (pos-customer), idempotent via `processed_events`.
+- **AC**: each campaign send appears in the recipient's interaction history within SLA; idempotent.
+- **Effort**: S. **Deps**: A6, C1.
+
+### Story C4 — Campaign stats + attribution
+- **Change**: `GET /campaigns/{id}/stats` — reach funnel per channel (targeted → eligible → sent → delivered → opened/clicked → redeemed → attributed workorders/revenue), split by `audienceType`, with a `campaignProgramId` rollup comparing commercial vs individual arms. Attribution: consume redemption facts (with `campaignCode`, A7) → conversion counters, idempotent by `redemptionId`.
+- **Files**: `internal/service/CampaignStatsService*`; `internal/service/RedemptionAttributionListener*` (consume `customer.events.v1` redemption facts); stats DTOs.
+- **Permissions**: `marketing:stats:view`.
+- **AC**: a campaign-tied redemption is attributed to exactly that campaign; no double counting (idempotent by `redemptionId`); commercial vs individual arms separately measurable.
+- **Effort**: M. **Deps**: C1, A7.
+
+---
+
+## 5. Workstream D — Follow-up tasks & prospect capture  **[CRM]**
+
+Spec §5, §6. Depends on cross-domain facts (FI-3) and is lower priority than A–C.
+
+### Story D1 — FollowUpTask
+- **Change**: `FollowUpTask` (`taskId`, `partyId`, `vehicleId?`, `type` DECLINED_SERVICE_FOLLOWUP/SERVICE_DUE_REMINDER/FLEET_CHECKIN/CAMPAIGN_RESPONSE/GENERAL, `dueDate`, `assignedTo?`, `status` OPEN/DONE/DISMISSED, `sourceWorkorderId?`, `reason?`, `outcome?`, `notes`). Created from workorder `serviceLine.declined` facts (one per declined line, idempotent) and from `VehicleCarePreference` service-due. Completing a task can deep-link to `pos-shop-manager` appointment creation (hand-off, never books).
+- **Files**: `internal/entity/FollowUpTask.java`; repo; `service/FollowUpTaskService.java`; consume declined-service facts in a listener (idempotent via `processing_log`); `/v1/crm/parties/{partyId}/follow-ups` + CSR queue `/v1/crm/follow-ups?assignedTo=&status=`; `V24__follow_up_task.sql`.
+- **Permissions**: `crm:followup:view/manage`.
+- **AC**: a declined-service event yields exactly one task; completion records outcome and links the resulting appointment/workorder when booked.
+- **Effort**: M. **Deps**: **FI-3** (`#1133`) for the declined-service + care-preference feed.
+
+### Story D2 — Prospect lifecycle + Inquiry capture
+- **Change**: add `lifecycleStage` (PROSPECT → ACTIVE → DORMANT) to the party; `Inquiry` entity in **pos-customer** (`inquiryId`, `channel`, `audienceType`, captured contact fields, `vehicleOfInterest?`, `serviceOfInterest?`, `campaignCode?`, `status` NEW→CONTACTED→CONVERTED→CLOSED, `partyId?`, `assignedTo?`). Public inbound "request service / fleet quote" endpoint (rate-limited, captcha, no auth) fronted through the gateway. Conversion reuses `checkPartyDuplicates` + create-party, optional shop-manager hand-off. **Not** in `pos-inquiry` (supplier-scoped).
+- **Files**: edit `AbstractParty`/status handling for `lifecycleStage`; `internal/entity/Inquiry.java`; repo; `service/InquiryService.java`; `internal/controller/{InquiryController, PublicInquiryController}.java`; `V25__prospect_inquiry.sql`.
+- **Permissions**: `crm:inquiry:view/manage`; public capture endpoint unauthenticated but rate-limited.
+- **AC**: prospect parties excluded from active-customer default queries; inquiry converts to a party without duplicating scheduling; campaign attribution captured.
+- **Effort**: L. **Deps**: none hard (attribution ties to A7); ship after A–C.
+
+---
+
+## 6. Workstream E — Cross-domain prerequisites (tracked issues)
+
+These are owned outside this plan's core modules but gate specific stories. Already filed:
+
+| Issue | Enables | Gating story |
+| --- | --- | --- |
+| **FI-1** `durion-positivity-backend#1134` — pos-price audience/campaign eligibility | audience-specific offers | B3 (soft), full offer gating |
+| **FI-2** `durion#369` — shared sender contract + outcome feedback | actual email/SMS send + bounce/complaint suppression | C2 (hard) |
+| **FI-3** `durion-positivity-backend#1133` — workorder service-completion + declined-service facts | service-history segments, service-due + declined follow-ups | A-follow, D1 (hard) |
+| **FI-4** `durion-positivity-backend#1135` — structured address in pos-people-contact | region/geo segmentation | A-follow (hard) |
+
+---
+
+## 7. Sequencing (waves for the agent team)
+
+- **Wave 1 — CRM foundations [CRM] (no external deps):** A1 tags, A3 consent enrichment, A5 suppression, A4 consent audit, A7 redemption `campaignCode`, then A2 segments, A6 interaction history, A8 snapshot. Ships standalone customer value; unblocks everything.
+- **Wave 2 — Campaign core [MKT]:** B0 module bootstrap (parallelizable with Wave 1), then B1 campaign, B2 templates, B3 audience binding + preview. Depends on Wave 1 (segments/consent/suppression) + FI-1 (soft).
+- **Wave 3 — Send + attribution [MKT]:** C1 send model, C2 sender adapter (needs FI-2), C3 interaction logging, C4 stats + attribution. Depends on Wave 2 + FI-2.
+- **Wave 4 — Follow-up & prospects [CRM]:** D1 follow-up tasks (needs FI-3), D2 prospect/inquiry; plus A-follow segment attributes (needs FI-3/FI-4).
+- **Backlog (spec §7, §10):** service-due/churn signal, A/B testing, double opt-in, account ownership (§6.2), open/click deep analytics.
+
+Critical path: Wave 1 (A2/A3/A5) → B3 → C1 → C2(FI-2) → C4. FI-2 is the main external blocker for actual sending; Waves 1–2 and campaign definition/preview proceed without it.
+
+---
+
+## 8. Decisions (resolved 2026-07-28; supersede the spec's open questions)
+
+| ID | Decision |
+| --- | --- |
+| O-1 | Send via the **shared platform sender**; pos-marketing owns orchestration only; sender owns transport + bounce/complaint webhooks and relays outcomes back (FI-2). |
+| O-2 | Commercial consent = `CommercialParty.accountMarketingOptOut` **hard master gate** + **primary business contact's** personal per-channel consent for account-level sends; individuals use personal consent. |
+| O-3 | `pos-price` eligibility *can* take audience/campaign input; confirm/implement via FI-1. |
+| O-4 | Workorder **will emit** service-completion facts to pos-customer (FI-3). |
+| O-5 | Structured address built in **pos-people-contact** for **persons + organizations** (FI-4); pos-customer reads via replica. |
+| O-6 | Prospect/inquiry capture lives in **pos-customer**, not `pos-inquiry` (supplier-scoped). |
+| O-7 | Workorder **will emit** `serviceLine.declined` facts (FI-3, combined with O-4). |
+| O-8 | Campaigns live in a **new `pos-marketing` module**. |
+
+**Non-goals (do not build):** opportunity pipeline/kanban/probability/forecast, recurring-revenue/MRR on a lead, predictive (Naive-Bayes) lead scoring, reseller geo-assignment, rule-based lead round-robin, lead mining/IAP enrichment, A/B testing (v1), full UTM URL/cookie web attribution, double opt-in portal (v1), a separate lightweight `mailing.contact` table.
+
+---
+
+## 9. Issue tracking
+
+- **Cross-domain prerequisites (created):** FI-1 `durion-positivity-backend#1134`, FI-2 `durion#369`, FI-3 `durion-positivity-backend#1133`, FI-4 `durion-positivity-backend#1135`.
+- **Implementation stories (to be created):** A1–A8 + A-follow, B0–B3, C1–C4, D1–D2 — file as capability stories under a CRM/marketing capability in `durion-positivity-backend` (and the `pos-marketing` bootstrap). Suggested labels: `[STORY]`, domain `crm`/`marketing`, wave tag.
+- **Module addition:** `pos-marketing` (B0) requires a reactor `pom.xml` change + gateway route + CI wiring — call out in the PR description.
+
+---
+
+## 10. Acceptance for the plan as a whole
+
+The plan is "done" when, per wave:
+
+1. **Wave 1**: a CSR can tag parties, define static/dynamic segments over party/tier/tag/vehicle data, manage per-channel marketing consent with a commercial master gate, add suppression entries, and view a party's interaction history + consent audit — all behind `crm:*` permissions with events on `customer.events.v1`.
+2. **Wave 2**: a marketer can create a commercial or individual campaign, bind it to a matching-audience segment, attach templates, and preview a consent/suppression-filtered audience — in the new `pos-marketing` module.
+3. **Wave 3**: a scheduled campaign sends through the shared sender, honors consent/suppression at dispatch, records per-recipient outcomes, logs sends to CRM interaction history, and attributes workorder redemptions back to the campaign — split by commercial vs individual.
+4. **Wave 4**: declined-service and service-due generate follow-up tasks that hand off to booking; new prospects/inquiries onboard into parties with campaign attribution.

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -1,0 +1,440 @@
+# Specification — CRM Functionality Missing from pos-customer
+
+> Status: DRAFT · Created 2026-07-28 · Companion docs: `comp-crm-overview.md` (Odoo CRM reference), `comp-vs-pos-customer-comparison.md` (capability map).
+>
+> Purpose: define, in enough detail to drive a subsequent implementation plan, the CRM capabilities that `pos-customer` (and the platform around it) is missing versus Odoo CRM — **scoped to what an enterprise tire-service management system actually needs.** This is a specification of *what to build and why*, not a task-by-task plan. The plan (`plan-odoo-parity-pos-customer.md`) will be derived from this.
+>
+> Sources: code survey of `pos-customer` (2026-07-28), Odoo 19 CRM survey (`comp-crm-overview.md`), CRM business-rules pack (`domains/crm/.business-rules/AGENT_GUIDE.md`, `DOMAIN_NOTES.md`, `CROSS_DOMAIN_INTEGRATION_CONTRACTS.md`), platform ADRs, and the surrounding modules (`pos-price`, `pos-catalog`, `pos-workorder`, `pos-shop-manager`, `pos-people-contact`, `pos-inquiry`).
+
+---
+
+## 0. Scope, framing, and the module-placement decision
+
+### 0.1 Framing — Positivity's "pipeline" is not Odoo's
+
+Odoo CRM optimizes the **pre-sale funnel**: capture strangers → qualify opportunities → route to salespeople → forecast → market. Positivity is a **service-execution** platform: revenue is realized by executing workorders on vehicles. The real "pipeline" is:
+
+```
+inquiry/appointment  →  estimate  →  workorder (WIP)  →  invoice
+   (pos-shop-manager)   (pos-workorder) (pos-workorder)  (pos-invoice)
+```
+
+That pipeline already exists and is owned by `pos-shop-manager` (appointments, scheduling, operational context) and `pos-workorder` (estimate → WIP → complete → invoice, promotion application). **Therefore this spec deliberately does not add an opportunity/kanban/probability/forecast pipeline to pos-customer** (see §10 Non-Goals). What Positivity genuinely lacks, and what this spec covers, is the **demand-generation and customer-relationship layer that feeds that pipeline**: marketing campaigns, audience segmentation, marketing-grade consent, interaction history, follow-up, and lightweight prospect capture.
+
+### 0.2 The five capability groups worth building
+
+| # | Capability | Why Positivity needs it | Owning surface (see §0.3) |
+|---|---|---|---|
+| A | **Marketing campaigns** differentiated by **commercial vs individual** audience | Drive repeat service (oil-change reminders to individuals; fleet tire programs to commercial accounts) | new `pos-marketing` |
+| B | **Segmentation, tags, and audiences** over party/vehicle/service data | Target the right customers; power A | `pos-customer` (data) + `pos-marketing` (audience binding) |
+| C | **Marketing consent, suppression, and interaction history** | Legal defensibility (CAN-SPAM/TCPA), don't spam, know what we sent | `pos-customer` |
+| D | **Follow-up / declined-service tasks** | Convert declined recommendations and service-due into bookings | `pos-customer` (hand off to `pos-shop-manager`) |
+| E | **Prospect/inquiry capture** (adapted lead capture) | Onboard new fleet accounts and web inquiries | `pos-inquiry` or `pos-customer` |
+
+### 0.3 DECISION REQUIRED — where do campaigns live?
+
+pos-customer already owns the party master, communication preferences, and promotion-redemption ledger — the *data* campaigns target and attribute against. But full campaign orchestration (audience resolution, scheduled multi-channel sends, delivery tracking, per-recipient state) is a distinct lifecycle with its own heavy dependency: **outbound message delivery infrastructure (email/SMS), which pos-customer does not have.**
+
+**Recommendation: a new `pos-marketing` module** owns campaign definition, audience binding, send orchestration, and campaign analytics; **pos-customer** owns the CRM-native data that campaigns *consume* (segments, tags, consent, suppression, interaction history, prospects). Rationale:
+
+- Respects ADR-0026 / ArchUnit domain walls: pos-customer stays a party registry; marketing send-lifecycle is its own bounded context.
+- The delivery-infrastructure dependency (SMTP/SMS provider) is isolated in the new module, not bolted onto the customer master.
+- pos-marketing reads party/segment/consent data via the existing `CrmSnapshotDTO` + `customer.events.v1` replica pattern (ADR-0044), exactly like other consumers.
+- Keeps consent/suppression enforcement authoritative in pos-customer (the system of record for party contactability) while pos-marketing *asks before sending*.
+
+**Alternative (smaller, faster):** put a thin campaign definition + attribution model directly in pos-customer and delegate only raw message delivery to a channel service. Acceptable for a v1 that only ships promo-code campaigns with redemption attribution (no per-recipient open/click tracking). Chosen trade-off is the user's call; this spec is written so either placement works — each entity below is tagged **[CRM]** (pos-customer) or **[MKT]** (pos-marketing/campaign owner).
+
+### 0.4 Platform ground rules every story must honor
+
+1. **ADR-0044 event-only domain walls.** Cross-service data flows via Kafka events + local `ext_*` replicas, not new synchronous repository reads. pos-marketing consumes `customer.events.v1` (party/consent/segment facts); attribution flows back via `customer.events.v1` redemption/workorder facts. Reuse the outbox (`event_outbox`/`OutboxPublisher`) + `ProcessedEvent` idempotency rails already in pos-customer.
+2. **ADR-0013/0027** UUID v7 IDs (`@UUIDv7Id`), UUID-typed identifiers in DTOs. **ADR-0024** `createdAt`/`updatedAt` via Spring auditing with injected `Clock`. **ADR-0018** actor fields from `SecurityContextHelper`, never request body.
+3. **ADR-0017/0042** canonical status codes (incl. `202` for async command acceptance), `ApiError` envelope, full OpenAPI annotations. Controller change ⇒ regenerate `openapi.yaml` ⇒ update Angular SDK.
+4. **Module conventions** (`CLAUDE.md` / `AGENTS.md`): entities in `internal/entity`, public API behind `service/` interfaces (ArchUnit-enforced), `@EmitEvent` + `{Module}EventTypes` registry entry for every mutating endpoint, permissions in the `{Module}PermissionRegistry` (code-first) registered to `pos-security-service`, Flyway migrations, Spotless/Checkstyle/SpotBugs/ArchUnit green.
+5. **CRM domain decisions** (`AGENT_GUIDE.md`): `partyId` is canonical (DECISION-INVENTORY-001); CRM owns contact roles + contactability + redemption records; CRM does **not** own workorder/invoice/payment lifecycle or promotion *policy* enforcement.
+6. **Positivity naming:** `workorder` is one word everywhere.
+
+### 0.5 Cross-service ownership guardrails (do not violate)
+
+- **Discounts/offers stay in `pos-price`** (`PromotionOffer`, eligibility rules, `applyPromotion`). Campaigns *reference* an offer id; they never define discount math.
+- **Product lists stay in `pos-catalog`** (product master, price books). A campaign that promotes "winter tires" references a catalog product/collection id; it never copies product data.
+- **Booking/scheduling stays in `pos-shop-manager`.** Follow-up tasks *hand off* to appointment creation; they don't schedule.
+- **Person identity/contact points stay in `pos-people-contact`.** Recipient email/phone are resolved from the `ext_people_contact_person` replica, not stored anew.
+- **Redemption recording stays in pos-customer** (`PromotionRedemption`) — it is the attribution sink campaigns plug into.
+
+---
+
+## 1. Capability A — Marketing Campaigns (commercial vs individual)  **[MKT]**
+
+The headline capability. A **Campaign** is a planned, audience-targeted, multi-channel outreach that promotes a service/product offer over a time window, measured by reach and by attributed workorder redemptions.
+
+### 1.1 Core requirement: audience-type differentiation
+
+Every campaign declares an **`audienceType`** that fundamentally shapes it:
+
+- **`COMMERCIAL`** — targets `CommercialParty` accounts (fleets, dealers, municipalities). Messaging is B2B: account-level, routed to account **contacts** by role (e.g. `PRIMARY_BUSINESS_CONTACT`, `OPERATIONS`, `BILLING`), volume/contract framing, PO-aware. Offers tend to be fleet/volume programs.
+- **`INDIVIDUAL`** — targets `PersonParty` customers. Messaging is B2C: personal, vehicle-specific (oil change due, tire rotation, seasonal), single-recipient.
+
+This is not merely a filter — it changes recipient resolution (account-contact fan-out vs single person), consent semantics (a commercial account's operations contact vs an individual's personal opt-in), offer eligibility, and reporting. A campaign is **exactly one** audience type; "both" is modeled as two campaigns (optionally grouped by a shared `campaignProgramId`).
+
+> Rationale for hard split (user requirement): commercial and individual outreach differ in legal basis (business vs personal consent), channel norms, cadence, and success metric (contract renewal vs repeat visit). Conflating them produces mis-targeted, non-compliant sends.
+
+### 1.2 Entity — `Campaign` **[MKT]**
+
+| Field | Type | Notes |
+|---|---|---|
+| `campaignId` | UUID v7 | PK |
+| `code` | String, unique | Human/attribution code (e.g. `WINTER-FLEET-2026`); carried onto redemptions/workorders for attribution (§8) |
+| `name`, `description` | String | |
+| `audienceType` | enum `COMMERCIAL` \| `INDIVIDUAL` | §1.1; immutable after creation |
+| `campaignProgramId` | UUID, nullable | Optional grouping of a commercial+individual pair |
+| `status` | enum (§1.3) | lifecycle |
+| `channels` | Set<enum EMAIL, SMS> | which channels this campaign sends on |
+| `segmentId` | UUID → `[CRM]` Segment (§3) | audience definition |
+| `promotionOfferId` | UUID, nullable | reference to `pos-price` offer (§1.5) |
+| `catalogFocusRef` | String/UUID, nullable | reference to `pos-catalog` product/collection the campaign promotes |
+| `windowStart`, `windowEnd` | Instant | active window |
+| `scheduleType` | enum `IMMEDIATE` \| `SCHEDULED` | |
+| `scheduledAt` | Instant, nullable | |
+| `messageTemplateIds` | per channel | §2 |
+| audit | `createdAt/updatedAt/createdBy` | ADR-0024/0018 |
+
+### 1.3 Lifecycle (state machine)
+
+```
+DRAFT → SCHEDULED → SENDING → SENT → (CLOSED)
+   └──────────────→ CANCELLED
+DRAFT → (edit freely)   SCHEDULED/SENDING → PAUSED → SENDING
+```
+
+- **DRAFT**: fully editable; audience preview allowed.
+- **SCHEDULED**: validated (segment resolvable, offer active, templates present, consent gate reviewed); frozen except cancel/pause.
+- **SENDING**: batch dispatch in progress (async, `202`).
+- **SENT / CLOSED**: dispatch complete; window may still be open for attribution.
+- **PAUSED / CANCELLED**: operator control; cancelled campaigns retain audit + partial stats.
+
+Transitions are `@EmitEvent` command endpoints; SENDING/SENT emit facts on `marketing.events.v1`.
+
+### 1.4 Endpoints **[MKT]** (`/v1/marketing/campaigns`)
+
+| Method | Path | Purpose | Permission | @EmitEvent |
+|---|---|---|---|---|
+| POST | `/` | Create campaign (DRAFT) | `marketing:campaign:create` | `MARKETING_CAMPAIGN_CREATE` |
+| GET | `/{id}` | Get campaign | `marketing:campaign:view` | — |
+| GET | `/` | List/filter (audienceType, status, window) | `marketing:campaign:view` | — |
+| PUT | `/{id}` | Update DRAFT | `marketing:campaign:edit` | `MARKETING_CAMPAIGN_UPDATE` |
+| POST | `/{id}/audience-preview` | Resolve segment → recipient count + sample, post-consent-filter | `marketing:campaign:view` | `MARKETING_CAMPAIGN_AUDIENCE_PREVIEW` |
+| POST | `/{id}/schedule` | DRAFT→SCHEDULED | `marketing:campaign:schedule` | `MARKETING_CAMPAIGN_SCHEDULE` |
+| POST | `/{id}/send` | Trigger send (→202) | `marketing:campaign:send` | `MARKETING_CAMPAIGN_SEND` |
+| POST | `/{id}/pause` · `/resume` · `/cancel` | Control | `marketing:campaign:manage` | respective |
+| GET | `/{id}/stats` | Reach/redemption/attribution (§8) | `marketing:campaign:view` | — |
+
+### 1.5 Offer & catalog linkage
+
+- `promotionOfferId` references a `pos-price` `PromotionOffer` (validate it exists + is ACTIVE at schedule time via a load-balanced read or a replicated offer fact). The campaign never defines discount type/value.
+- If audience-type-specific eligibility is required (e.g. a fleet-only offer), coordinate with `pos-price` so its eligibility rules can accept an `audienceType`/`partyType` or `campaignCode` input. **Open question O-3.**
+- `catalogFocusRef` references a `pos-catalog` product or collection for content assembly (e.g. campaign body lists the promoted tire lines). Read-only reference.
+
+### 1.6 Acceptance criteria (representative)
+
+- A campaign cannot be SCHEDULED without a resolvable segment whose `audienceType` matches the campaign's.
+- Audience preview returns counts **after** consent/suppression filtering (§4), split by channel, and never exposes raw PII beyond a masked sample.
+- A COMMERCIAL campaign resolves recipients as account contacts by role; an INDIVIDUAL campaign resolves to the person's own primary contact point.
+- Sending is idempotent per (campaignId, recipientId, channel); re-invoking `/send` never double-sends.
+
+---
+
+## 2. Capability A' — Message templates & multi-channel send  **[MKT]**
+
+### 2.1 Templates — `MessageTemplate`
+
+Per-channel content with token substitution (`{{firstName}}`, `{{vehicleYearMakeModel}}`, `{{promoCode}}`, `{{shopName}}`, `{{offerDetails}}`). Email: subject + HTML/text body; SMS: 1-3 segment text with link. Templates validate available tokens against the campaign's `audienceType` (commercial tokens like `{{accountName}}` vs individual `{{vehicle...}}`).
+
+### 2.2 Send orchestration
+
+- Audience resolution → per-recipient **`CampaignSend`** rows (`campaignId`, `recipientPartyId`, `contactId`, `channel`, `resolvedAddress` [transient/hashed], `status`, `providerMessageId`, `failureReason`, timestamps).
+- Dispatch is **async & batched** (reuse the outbox/worker pattern), rate-limited, and **re-checks consent + suppression at send time** (not just at preview — consent can change between schedule and send).
+- **Channel delivery is provider-backed.** Decision O-1: use an email/SMS provider client (SES/SendGrid/Twilio-style) behind a `MessageChannel` interface, or route through an existing platform sender. This module owns the *orchestration*; the raw transport may be a thin adapter. Bounces/complaints feed the suppression list (§4.3).
+- Provider webhooks (delivered/bounced/complained/opened/clicked) update `CampaignSend` and feed §8 stats. Open/click tracking is provider-dependent — degrade gracefully if unavailable (v1 may track only sent/delivered/bounced + redemption).
+
+### 2.3 Acceptance criteria
+
+- No `CampaignSend` is dispatched to a recipient who is suppressed or opted-out for that channel/audience type at dispatch time.
+- Every send carries the campaign `code` so downstream redemption/workorder can attribute it (§8).
+- Provider failures are retried with backoff; permanent failures mark the send `FAILED` with reason and do not block the batch.
+
+---
+
+## 3. Capability B — Segmentation, tags, audiences
+
+Campaigns are only as good as their targeting. pos-customer today has no tags and no reusable segments — only `AccountTier` + `AccountStatus`.
+
+### 3.1 Entity — `PartyTag` and `PartyTagAssignment`  **[CRM]**
+
+- `PartyTag`: `tagId`, `name` (unique), `category` (optional grouping, e.g. `INTEREST`, `LIFECYCLE`, `SOURCE`), `color`, `active`. Optionally hierarchical (parent/child) mirroring `res.partner.category`; **recommend flat for v1**.
+- `PartyTagAssignment`: `(partyId, tagId)`, `assignedBy`, `assignedAt`, optional `source` (MANUAL/CAMPAIGN/IMPORT/RULE). Tags apply to both party subtypes.
+- Endpoints under `/v1/crm/parties/{partyId}/tags` (list/add/remove) + `/v1/crm/tags` (catalog CRUD). Permissions `crm:tag:{view,manage,assign}`.
+
+### 3.2 Entity — `Segment`  **[CRM]** (recommend) or **[MKT]**
+
+A **named, reusable audience definition**. Two flavors (Odoo parity: `mailing.list` static vs `mailing.filter` dynamic):
+
+- **STATIC** — an explicit membership set (`SegmentMember(segmentId, partyId, contactId?)`), e.g. an imported list of fleet prospects.
+- **DYNAMIC** — a **predicate** evaluated against party + related data at resolution time.
+
+`Segment` fields: `segmentId`, `name`, `description`, `audienceType` (COMMERCIAL/INDIVIDUAL — a segment is single-type so it can only feed matching campaigns), `type` (STATIC/DYNAMIC), `predicate` (structured JSON for DYNAMIC), audit.
+
+### 3.3 Segment predicate model (DYNAMIC)
+
+A safe, validated predicate tree (**not** free SQL) over a fixed attribute catalog. Attributes span data pos-customer owns or replicates:
+
+| Attribute source | Examples |
+|---|---|
+| Party | `partyType`, `accountTier`, `accountStatus`, `parentPartyId present`, `externalIdentifier[system]`, tags |
+| Billing rules | `taxExempt`, `creditHold`, `paymentTerms` |
+| Consent (§4) | `marketing email opted-in`, `channel allowed` (segments should pre-filter, though send-time re-checks anyway) |
+| Vehicle (from `ext_vehicle`) | `owns make/model`, `vehicle year range`, `has active vehicle`, `vehicle count ≥ N` (fleet size) |
+| Service history (needs data — see O-4) | `last service > N months` (win-back), `service-due` (care preference interval elapsed), `declined service in last N days` |
+| Geography | shop/location association, region (needs structured address — O-5) |
+
+- Predicate = boolean tree of `{attribute, operator, value}` leaves with AND/OR/NOT.
+- Resolution is a query builder over local tables + replicas; must paginate and cap.
+- **Some high-value attributes (service history, structured geography) require data pos-customer doesn't hold today** — see Open Questions O-4/O-5. v1 can ship with the party/tier/tag/vehicle attributes it already has and add service-history predicates when the data feed exists.
+
+### 3.4 Endpoints (`/v1/crm/segments`)
+
+CRUD + `POST /{id}/resolve` (returns count + paginated sample, consent-filtered). Permissions `crm:segment:{view,manage,resolve}`.
+
+### 3.5 Acceptance criteria
+
+- A DYNAMIC segment predicate only references whitelisted attributes/operators; invalid predicates are rejected at save (`422`), never executed.
+- Segment resolution is deterministic and paginated; resolving a COMMERCIAL segment never returns person parties and vice-versa.
+- Tag assignment/removal emits audit events and is idempotent.
+
+---
+
+## 4. Capability C — Marketing consent, suppression, interaction history  **[CRM]**
+
+pos-customer has a solid base (`CommunicationPreference` with per-channel preference + `consentFlags` + `@Version`) but three gaps: (a) marketing consent is a single coarse flag, (b) no hard suppression list, (c) no record of what we actually sent/said.
+
+### 4.1 Enrich consent — extend `CommunicationPreference`
+
+- Model **per-channel marketing consent** separately from transactional contactability: `marketingEmailConsent`, `marketingSmsConsent` (OPT_IN/OPT_OUT/UNSET) — distinct from the operational `emailPreference`/`smsPreference`.
+- For **COMMERCIAL** accounts, consent may be held at the account level and/or per contact-role; define whether an operations contact's consent is personal or account-delegated. **Open question O-2.**
+- Add **quiet-hours / cadence** guidance (optional v1): max marketing touches per party per window, do-not-disturb hours (respect timezone).
+- Capture **opt-out reason** (catalog `OptOutReason`: NOT_INTERESTED, TOO_FREQUENT, NEVER_SIGNED_UP, LEGAL_DNC, …) — Odoo parity with `mailing.subscription.optout`.
+
+### 4.2 Consent change audit — `ConsentEvent`
+
+Append-only history: `(partyId, channel, oldValue, newValue, reason, source, actor, at)`. Required for CAN-SPAM/TCPA defensibility ("prove they opted in / when they opted out"). Feeds the snapshot and a compliance export.
+
+### 4.3 Suppression list — `SuppressionEntry`
+
+A hard, address-level block consulted by **every** send, independent of preference (Odoo's `mail.blacklist`):
+
+- `suppressionId`, `channel`, `addressHash` (email/phone normalized+hashed), `partyId?`, `reason` (HARD_BOUNCE, SPAM_COMPLAINT, LEGAL_DNC, MANUAL, UNSUBSCRIBE_LINK), `source`, `createdAt`.
+- Populated by provider bounce/complaint webhooks (§2.2), unsubscribe-link clicks, and manual admin action.
+- pos-marketing must query suppression (via CRM read/replica) at send time; suppressed addresses are never contacted.
+
+### 4.4 Interaction / touch history — `CustomerInteraction`
+
+Today pos-customer has **no record of outbound touches**; `PartyNote` is a one-way projection from workorder events with no write API. Generalize into a customer interaction log:
+
+- `interactionId`, `partyId`, `contactId?`, `type` (CAMPAIGN_SEND, EMAIL, SMS, CALL, FOLLOW_UP, NOTE, WORKORDER_NOTE), `channel?`, `direction` (OUTBOUND/INBOUND), `campaignId?`, `subject/summary`, `body?` (redaction-aware per DECISION-INVENTORY-006), `actor`, `occurredAt`, `sourceEventId`.
+- Written by: campaign sends (fact-driven from `marketing.events.v1`), CSR follow-up actions (§6), and the existing workorder `PartyNoteAdded` projection (migrate `PartyNote` into this or keep as a typed subset).
+- Read endpoint `/v1/crm/parties/{partyId}/interactions` (paged, filterable). Feeds a "customer 360" timeline and the snapshot.
+
+### 4.5 Snapshot integration
+
+Extend `CrmSnapshotDTO` with a consent summary (per-channel marketing consent + suppression flags) and a recent-interaction summary, so downstream consumers (and CSRs) see contactability and touch history at a glance.
+
+### 4.6 Acceptance criteria
+
+- A send is blocked if the recipient is on the suppression list for that channel, regardless of preference.
+- Every marketing consent change writes a `ConsentEvent`; the history is queryable and exportable.
+- An unsubscribe link resolves to a per-channel opt-out + suppression entry + `ConsentEvent`, with an opt-out reason where provided.
+- Campaign sends appear in the party's interaction history within the event-processing SLA.
+
+---
+
+## 5. Capability E — Prospect / inquiry capture (adapted lead capture)  **[pos-inquiry or CRM]**
+
+Positivity has no "stranger" object — parties are created already-as-customers, and `pos-inquiry` is an empty placeholder. New fleet accounts and web "request a quote" inquiries have no home.
+
+### 5.1 Adapted model — **do not** import `crm.lead`
+
+Instead of Odoo's denormalized-lead-then-materialize funnel, model a lightweight **prospect state on the party** plus an inquiry capture:
+
+- Add `PARTY_STATUS = PROSPECT` (or a `lifecycleStage` field: `PROSPECT → ACTIVE → DORMANT`) so a party can exist pre-first-service without polluting active-customer queries.
+- **`Inquiry`** (in `pos-inquiry`, which is reserved for exactly this): `inquiryId`, `channel` (WEB_FORM, PHONE, WALK_IN, REFERRAL, CAMPAIGN), `audienceType`, captured contact fields, `vehicleOfInterest?`, `serviceOfInterest?`, `campaignCode?` (attribution), `status` (NEW → CONTACTED → CONVERTED → CLOSED), `partyId?` (once linked/created), `assignedTo?`.
+- **Conversion**: an inquiry converts by creating/linking a party (reuse `checkPartyDuplicates` + `createCommercialAccount`/person create) and optionally handing off to `pos-shop-manager` to book an appointment. No opportunity/stage machinery.
+
+### 5.2 Web form / email capture
+
+- A public "request service / fleet quote" entry point posts an `Inquiry` (rate-limited, captcha, no auth). This is the Positivity analog of Odoo's `website_crm` form + team alias.
+- Fleet inquiries (COMMERCIAL) route to an account-onboarding queue; individual inquiries can auto-suggest the nearest shop.
+
+### 5.3 Verdict / scope
+
+**BUILD (light, adapted).** This is genuinely useful but lower priority than campaigns/consent. It can ship after A–C. If `pos-inquiry` ownership is unclear, the minimal version is just the `PROSPECT` lifecycle stage + `campaignCode` attribution on party creation, deferring the full inquiry object. **Open question O-6.**
+
+---
+
+## 6. Capability D — Follow-up tasks & (optional) account ownership  **[CRM]**
+
+The service-shop analog of Odoo's activities/next-actions and lost-reason — reshaped around *declined recommendations* and *service-due*, not deal stages.
+
+### 6.1 `FollowUpTask`
+
+- `taskId`, `partyId`, `vehicleId?`, `type` (DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, GENERAL), `dueDate`, `assignedTo?` (CSR), `status` (OPEN/DONE/DISMISSED), `sourceWorkorderId?`, `reason?` (decline reason), `outcome?`, `notes`.
+- **Created from workorder events**: when a recommended service line is declined on a workorder, `pos-workorder` emits a fact → pos-customer creates a `DECLINED_SERVICE_FOLLOWUP` task (parity with Odoo lost-reason, but at line granularity and actionable). Requires a workorder event (**O-7**).
+- **Created from service-due**: `VehicleCarePreference` interval elapsed (care-preference feature referenced in DECISION-INVENTORY-012) → `SERVICE_DUE_REMINDER` task and/or campaign audience membership.
+- **Hand-off, not scheduling**: completing a task can deep-link to `pos-shop-manager` appointment creation. pos-customer never books.
+- Endpoints `/v1/crm/parties/{partyId}/follow-ups` + a CSR work-queue view `/v1/crm/follow-ups?assignedTo=&status=`. Permissions `crm:followup:{view,manage}`.
+
+### 6.2 Account ownership (optional)
+
+Odoo has salesperson/team ownership; Positivity may want a CSR/account-manager assignment on commercial accounts (`accountOwnerUserId` on `CommercialParty` + reassignment audit). **Optional, low priority** — only if the business wants named account managers. Otherwise NON-GOAL.
+
+### 6.3 Acceptance criteria
+
+- A declined-service workorder event produces exactly one follow-up task (idempotent via `processing_log`).
+- Completing a follow-up records an outcome and, when it books service, links the resulting appointment/workorder for closed-loop reporting.
+
+---
+
+## 7. Capability (backlog) — Service-opportunity / churn signal
+
+Odoo's PLS predicts *deal* win probability — not applicable. The Positivity-relevant analog is a **service-due / churn-risk signal**: which customers are overdue for service or lapsing. This is derivable from vehicle care preferences + service history rather than ML.
+
+- **Backlog / NON-GOAL for v1.** Once service-history data (O-4) is available, a simple rules-based "next-service-due" and "at-risk (no visit in N months)" scoring can drive campaign segments (§3) and follow-up tasks (§6). No Naive-Bayes/ML needed. Record as a fast-follow, not a v1 deliverable.
+
+---
+
+## 8. Capability A'' — Campaign attribution & analytics  **[MKT]**
+
+Closing the loop from send → workorder → revenue is what makes campaigns worth running in a service shop.
+
+### 8.1 Attribution mechanism
+
+- Every campaign has a `code`; every send references it. When a promoted offer is redeemed, the campaign code must land on the **`PromotionRedemption`** record (pos-customer already stores `promotionCode`; add/populate `campaignCode`). Since redemptions are keyed to a `workorderId`, this yields **attributed workorder revenue per campaign**.
+- Alternative/additional: campaign-specific promo codes (one offer, per-campaign codes) so attribution is exact.
+- pos-marketing consumes redemption facts from `customer.events.v1` (or reads the redemption list) to compute attributed conversions/revenue.
+
+### 8.2 Campaign stats — `GET /campaigns/{id}/stats`
+
+Reach funnel per channel + attribution:
+
+```
+targeted → eligible(after consent/suppression) → sent → delivered → (opened/clicked) → redeemed → attributed workorders / revenue
+```
+
+- Delivery metrics from `CampaignSend` + provider webhooks; open/click where the provider supports it.
+- Conversion metrics from redemption attribution (§8.1).
+- Split by `audienceType`; a `campaignProgramId` rollup compares the commercial vs individual arms.
+
+### 8.3 Attribution facts flow (ADR-0044)
+
+`pos-workorder`/pos-customer emit redemption facts → pos-marketing updates campaign conversion counters (idempotent). No synchronous cross-service joins.
+
+### 8.4 Acceptance criteria
+
+- A workorder redemption tied to a campaign's offer/code is attributed to exactly that campaign in stats within the event SLA.
+- Stats never double-count a redemption; attribution is idempotent by `redemptionId`.
+- Commercial and individual arms of a program are separately measurable.
+
+---
+
+## 9. Consolidated data model, permissions, events
+
+### 9.1 New/changed entities
+
+| Entity | Owner | New/Change |
+|---|---|---|
+| `PartyTag`, `PartyTagAssignment` | [CRM] | new |
+| `Segment`, `SegmentMember` | [CRM] | new |
+| `CommunicationPreference` (marketing consent fields, quiet hours) | [CRM] | change |
+| `ConsentEvent` | [CRM] | new (append-only) |
+| `SuppressionEntry` | [CRM] | new |
+| `CustomerInteraction` | [CRM] | new (generalizes `PartyNote`) |
+| `FollowUpTask` | [CRM] | new |
+| `AbstractParty.lifecycleStage` (PROSPECT/ACTIVE/DORMANT) | [CRM] | change |
+| `PromotionRedemption.campaignCode` | [CRM] | change (attribution) |
+| `Campaign`, `CampaignSend` | [MKT] | new |
+| `MessageTemplate` | [MKT] | new |
+| `Inquiry` | pos-inquiry | new |
+
+### 9.2 Permissions (code-first registries)
+
+- CRM: `crm:tag:{view,manage,assign}`, `crm:segment:{view,manage,resolve}`, `crm:consent:{view,manage}`, `crm:suppression:{view,manage}`, `crm:interaction:view`, `crm:followup:{view,manage}`.
+- Marketing: `marketing:campaign:{view,create,edit,schedule,send,manage}`, `marketing:template:{view,manage}`, `marketing:stats:view`.
+- Split CSR vs Marketing-manager access per DECISION-INVENTORY-007 (least privilege; e.g. CSR can view consent + create follow-ups but not send campaigns).
+
+### 9.3 Events (ADR-0044)
+
+- **New facts** `marketing.events.v1`: `campaign.scheduled`, `campaign.sent`, `campaign.send.delivered/bounced/complained`, `campaign.converted`.
+- **CRM facts** on `customer.events.v1`: `party.tag.changed`, `party.consent.changed`, `party.suppressed`, `segment.changed`, `interaction.logged` (for consumers/replicas).
+- **Consumed by CRM**: workorder `serviceLine.declined` (→ follow-up task, **O-7**), `promotion.redeemed`/existing redemption path (→ attribution).
+- **Consumed by MKT**: `customer.events.v1` party/segment/consent facts (audience replica), redemption facts (attribution).
+- Reuse outbox + `ProcessedEvent` idempotency.
+
+### 9.4 Flyway
+
+New tables in pos-customer migrations (continue the V-series after current max V16) and a fresh migration baseline in the new pos-marketing module. No cross-service FKs.
+
+---
+
+## 10. Non-goals (record so they aren't re-litigated)
+
+| Odoo capability | Why it's a non-goal for Positivity |
+|---|---|
+| Opportunity/deal **pipeline, kanban stages, probability, forecast** | The sales pipeline is appointment→estimate→workorder→invoice, owned by shop-manager + workorder. Do not add an opportunity kanban to pos-customer. |
+| **Recurring-revenue/MRR** on a lead | Fleet service contracts belong to billing/pricing, not CRM. |
+| **Predictive (Naive-Bayes) lead scoring** | No deal funnel to score; the useful analog (service-due/churn) is rules-based and backlog (§7). |
+| **Reseller geo-assignment** (`website_crm_partner_assign`) | Positivity runs its own shops, not a reseller channel. |
+| **Rule-based lead round-robin assignment** | No high-volume lead routing; account ownership (§6.2) is the only ownership concept, and it's optional. |
+| **Lead mining / IAP enrichment** (`crm_iap_mine/enrich`) | External prospect-buying is out of scope for a service shop. |
+| **A/B testing** of mailings (v1) | Ship base campaigns first; revisit. |
+| **Full UTM URL/cookie web attribution** | Campaign-code attribution onto redemptions is sufficient; web-analytics UTM capture is out of scope. |
+| **Double opt-in subscription portal** (v1) | Consent capture + unsubscribe suffices for v1; backlog. |
+| Separate lightweight **`mailing.contact`** table | Identity is centralized in pos-people-contact; target parties directly. |
+
+---
+
+## 11. Open questions / cross-domain contracts needed
+
+| # | Question | Owner(s) | Blocks |
+|---|---|---|---|
+| O-1 | Email/SMS **delivery provider & transport** — dedicated provider client vs a shared platform sender? Owns bounce/complaint webhooks? | Platform/Positivity-integrations + Marketing | §2 send, §4.3 suppression |
+| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |
+| O-3 | Can `pos-price` **eligibility rules accept an `audienceType`/`campaignCode`** input for audience-specific offers? | Pricing | §1.5 |
+| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 |
+| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |
+| O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |
+| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 |
+| O-8 | **Module placement** confirmation — new `pos-marketing` module vs campaign-in-pos-customer (§0.3). | Architecture | §0.3, all [MKT] items |
+
+---
+
+## 12. Suggested build sequencing (for the plan to formalize)
+
+Waves are dependency-ordered; each is independently shippable.
+
+- **Wave 1 — CRM data foundations [CRM]:** `PartyTag`(+assignment), `Segment` (static + dynamic over already-available party/tier/tag/vehicle attributes), marketing-consent enrichment on `CommunicationPreference`, `SuppressionEntry`, `ConsentEvent`, `CustomerInteraction` (generalize `PartyNote`). Snapshot integration. *No external dependencies; unblocks everything.*
+- **Wave 2 — Campaign core [MKT]:** `Campaign` + lifecycle, `MessageTemplate`, audience binding to segments, audience preview (consent-filtered), attribution `campaignCode` on redemptions. Resolves O-8 first. *Depends on Wave 1 + O-1 for actual send.*
+- **Wave 3 — Send + attribution [MKT]:** `CampaignSend`, provider channel adapter(s), async batched dispatch with send-time consent/suppression re-check, provider webhooks → suppression + delivery stats, `GET /stats` with redemption attribution. *Depends on O-1, O-3.*
+- **Wave 4 — Follow-up & prospects [CRM/inquiry]:** `FollowUpTask` (declined-service + service-due), `Inquiry`/`PROSPECT` lifecycle, hand-off to shop-manager. *Depends on O-4, O-6, O-7.*
+- **Backlog:** service-due/churn signal (§7), A/B testing, double opt-in, structured address (O-5), account ownership (§6.2).
+
+---
+
+## 13. Summary — what "augmenting customer functionality" means here
+
+pos-customer is a strong **customer master** (parties, hierarchy, contacts, consent base, tiers, redemptions, merge, event rails) that lacks the **relationship-and-demand layer** on top of it. The gap versus Odoo is not the sales pipeline (Positivity has that in shop-manager + workorder) — it is:
+
+1. **Marketing campaigns differentiated by commercial vs individual audience** (the headline), referencing `pos-price` offers and `pos-catalog` product lists, attributed via the existing redemption ledger.
+2. **Segmentation, tags, and audiences** to target them.
+3. **Marketing-grade consent, suppression, and interaction history** to send them lawfully and remember what we sent.
+4. **Follow-up tasks** for declined service and service-due, handing off to booking.
+5. **Lightweight prospect/inquiry capture** for onboarding new (especially fleet) customers.
+
+Everything else in Odoo CRM's funnel is intentionally out of scope (§10).

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -29,13 +29,13 @@ That pipeline already exists and is owned by `pos-shop-manager` (appointments, s
 | B | **Segmentation, tags, and audiences** over party/vehicle/service data | Target the right customers; power A | `pos-customer` (data) + `pos-marketing` (audience binding) |
 | C | **Marketing consent, suppression, and interaction history** | Legal defensibility (CAN-SPAM/TCPA), don't spam, know what we sent | `pos-customer` |
 | D | **Follow-up / declined-service tasks** | Convert declined recommendations and service-due into bookings | `pos-customer` (hand off to `pos-shop-manager`) |
-| E | **Prospect/inquiry capture** (adapted lead capture) | Onboard new fleet accounts and web inquiries | `pos-inquiry` or `pos-customer` |
+| E | **Prospect/inquiry capture** (adapted lead capture) | Onboard new fleet accounts and web inquiries | `pos-customer` (not `pos-inquiry` — that module is for supplier inquiries) |
 
 ### 0.3 DECISION (ACCEPTED) — a new `pos-marketing` module owns campaigns
 
 **Decision:** campaign functionality lives in a **new `pos-marketing` bounded-context module**, not inside pos-customer. `pos-marketing` owns campaign definition, audience binding, send orchestration, message templates, and campaign analytics. `pos-customer` remains the customer master and owns the CRM-native data campaigns *consume* — segments, tags, marketing consent, suppression, interaction history, and prospects.
 
-> Status: **ACCEPTED** (2026-07-28). This resolves open question O-8 and is binding on the plan derived from this spec. Every item below tagged **[MKT]** is built in `pos-marketing`; every **[CRM]** item is built in `pos-customer` (or `pos-inquiry` where noted).
+> Status: **ACCEPTED** (2026-07-28). This resolves open question O-8 and is binding on the plan derived from this spec. Every item below tagged **[MKT]** is built in `pos-marketing`; every **[CRM]** item is built in `pos-customer`.
 
 pos-customer already owns the party master, communication preferences, and promotion-redemption ledger — the *data* campaigns target and attribute against. But full campaign orchestration (audience resolution, scheduled multi-channel sends, delivery tracking, per-recipient state) is a distinct lifecycle with its own heavy dependency — **outbound message delivery infrastructure (email/SMS), which pos-customer does not have** — and belongs in its own module.
 
@@ -137,7 +137,7 @@ Transitions are `@EmitEvent` command endpoints; SENDING/SENT emit facts on `mark
 ### 1.5 Offer & catalog linkage
 
 - `promotionOfferId` references a `pos-price` `PromotionOffer` (validate it exists + is ACTIVE at schedule time via a load-balanced read or a replicated offer fact). The campaign never defines discount type/value.
-- If audience-type-specific eligibility is required (e.g. a fleet-only offer), coordinate with `pos-price` so its eligibility rules can accept an `audienceType`/`partyType` or `campaignCode` input. **Open question O-3.**
+- If audience-type-specific eligibility is required (e.g. a fleet-only offer), `pos-price` eligibility rules *can* accept an `audienceType`/`partyType` or `campaignCode` input — whether they *do* today is unverified. **Resolved (O-3): raise a follow-up issue** on `pos-price` to confirm/implement an audience-type / campaign-code eligibility predicate (see §11.1, FI-1).
 - `catalogFocusRef` references a `pos-catalog` product or collection for content assembly (e.g. campaign body lists the promoted tire lines). Read-only reference.
 
 ### 1.6 Acceptance criteria (representative)
@@ -159,7 +159,7 @@ Per-channel content with token substitution (`{{firstName}}`, `{{vehicleYearMake
 
 - Audience resolution → per-recipient **`CampaignSend`** rows (`campaignId`, `recipientPartyId`, `contactId`, `channel`, `resolvedAddress` [transient/hashed], `status`, `providerMessageId`, `failureReason`, timestamps).
 - Dispatch is **async & batched** (reuse the outbox/worker pattern), rate-limited, and **re-checks consent + suppression at send time** (not just at preview — consent can change between schedule and send).
-- **Channel delivery is provider-backed.** Decision O-1: use an email/SMS provider client (SES/SendGrid/Twilio-style) behind a `MessageChannel` interface, or route through an existing platform sender. This module owns the *orchestration*; the raw transport may be a thin adapter. Bounces/complaints feed the suppression list (§4.3).
+- **Channel delivery routes through the shared platform sender.** Resolved (O-1): pos-marketing does **not** integrate an email/SMS provider directly — it hands each rendered message to the platform's shared notification/sender service behind a `MessageChannel` interface and owns only the *orchestration* (audience, batching, state, retry policy). The shared sender owns transport, provider credentials, and bounce/complaint webhooks; it must relay delivery/bounce/complaint outcomes back to pos-marketing (event or callback) so `CampaignSend` state and the suppression list (§4.3) stay current. Confirm the shared sender's contract exists / gaps — see §11.1, FI-2.
 - Provider webhooks (delivered/bounced/complained/opened/clicked) update `CampaignSend` and feed §8 stats. Open/click tracking is provider-dependent — degrade gracefully if unavailable (v1 may track only sent/delivered/bounced + redemption).
 
 ### 2.3 Acceptance criteria
@@ -199,12 +199,15 @@ A safe, validated predicate tree (**not** free SQL) over a fixed attribute catal
 | Billing rules | `taxExempt`, `creditHold`, `paymentTerms` |
 | Consent (§4) | `marketing email opted-in`, `channel allowed` (segments should pre-filter, though send-time re-checks anyway) |
 | Vehicle (from `ext_vehicle`) | `owns make/model`, `vehicle year range`, `has active vehicle`, `vehicle count ≥ N` (fleet size) |
-| Service history (needs data — see O-4) | `last service > N months` (win-back), `service-due` (care preference interval elapsed), `declined service in last N days` |
-| Geography | shop/location association, region (needs structured address — O-5) |
+| Service history (needs a new data feed — resolved O-4) | `last service > N months` (win-back), `service-due` (care preference interval elapsed), `declined service in last N days` |
+| Geography (needs structured address — resolved O-5) | shop/location association, region |
 
 - Predicate = boolean tree of `{attribute, operator, value}` leaves with AND/OR/NOT.
 - Resolution is a query builder over local tables + replicas; must paginate and cap.
-- **Some high-value attributes (service history, structured geography) require data pos-customer doesn't hold today** — see Open Questions O-4/O-5. v1 can ship with the party/tier/tag/vehicle attributes it already has and add service-history predicates when the data feed exists.
+- **Two attribute groups depend on data pos-customer doesn't hold today, now resolved with follow-up work:**
+  - *Service history* (resolved O-4): `pos-workorder`/workexec **will emit** service-completion and declined-service facts, which pos-customer consumes into a local projection (powers win-back, service-due, and declined-service predicates and the §6 follow-up tasks). Follow-up issue §11.1 FI-3.
+  - *Structured geography* (resolved O-5): a **structured address will be built in `pos-people-contact`** (the person/contact-point authority), replacing free-text `primaryAddress`; pos-customer reads it via the `ext_people_contact_person` replica / snapshot for region/geo segmentation. Follow-up issue §11.1 FI-4.
+- **v1 can still ship** with the party/tier/tag/vehicle attributes pos-customer already has, adding the service-history and geography predicates as those feeds land.
 
 ### 3.4 Endpoints (`/v1/crm/segments`)
 
@@ -225,7 +228,7 @@ pos-customer has a solid base (`CommunicationPreference` with per-channel prefer
 ### 4.1 Enrich consent — extend `CommunicationPreference`
 
 - Model **per-channel marketing consent** separately from transactional contactability: `marketingEmailConsent`, `marketingSmsConsent` (OPT_IN/OPT_OUT/UNSET) — distinct from the operational `emailPreference`/`smsPreference`.
-- For **COMMERCIAL** accounts, consent may be held at the account level and/or per contact-role; define whether an operations contact's consent is personal or account-delegated. **Open question O-2.**
+- **COMMERCIAL consent model (resolved, O-2):** marketing consent is held **personally by the primary business contact** — that contact's own per-channel `marketingEmailConsent`/`marketingSmsConsent` governs account-level campaign sends — **plus an account-level marketing flag** on `CommercialParty` (`accountMarketingOptOut`) that acts as a master gate: when the account flag is opted-out, no contact on the account is marketed regardless of personal consent. Individual (person) parties use their own personal per-channel consent directly. *(Assumption pending confirmation: the account-level flag is a hard master switch, not merely a default; and only the primary business contact's personal consent — not every account contact's — is consulted for account-level sends.)*
 - Add **quiet-hours / cadence** guidance (optional v1): max marketing touches per party per window, do-not-disturb hours (respect timezone).
 - Capture **opt-out reason** (catalog `OptOutReason`: NOT_INTERESTED, TOO_FREQUENT, NEVER_SIGNED_UP, LEGAL_DNC, …) — Odoo parity with `mailing.subscription.optout`.
 
@@ -262,16 +265,18 @@ Extend `CrmSnapshotDTO` with a consent summary (per-channel marketing consent + 
 
 ---
 
-## 5. Capability E — Prospect / inquiry capture (adapted lead capture)  **[pos-inquiry or CRM]**
+## 5. Capability E — Prospect / inquiry capture (adapted lead capture)  **[CRM]**
 
-Positivity has no "stranger" object — parties are created already-as-customers, and `pos-inquiry` is an empty placeholder. New fleet accounts and web "request a quote" inquiries have no home.
+Positivity has no customer-facing "stranger" object — parties are created already-as-customers. New fleet accounts and web "request a quote" inquiries have no home.
+
+> **Placement note (resolved O-6):** `pos-inquiry` is **not** the home for this — that module is a holder for *inbound inquiries to suppliers* (procurement), not customer prospects. Customer prospect/inquiry capture is a CRM concern and lives in **`pos-customer`** (with the public inbound web endpoint fronted through the gateway; campaign-attributed inbound may also originate a command from `pos-marketing`). Do not put customer prospects in `pos-inquiry`.
 
 ### 5.1 Adapted model — **do not** import `crm.lead`
 
-Instead of Odoo's denormalized-lead-then-materialize funnel, model a lightweight **prospect state on the party** plus an inquiry capture:
+Instead of Odoo's denormalized-lead-then-materialize funnel, model a lightweight **prospect state on the party** plus an inquiry capture, both in pos-customer:
 
-- Add `PARTY_STATUS = PROSPECT` (or a `lifecycleStage` field: `PROSPECT → ACTIVE → DORMANT`) so a party can exist pre-first-service without polluting active-customer queries.
-- **`Inquiry`** (in `pos-inquiry`, which is reserved for exactly this): `inquiryId`, `channel` (WEB_FORM, PHONE, WALK_IN, REFERRAL, CAMPAIGN), `audienceType`, captured contact fields, `vehicleOfInterest?`, `serviceOfInterest?`, `campaignCode?` (attribution), `status` (NEW → CONTACTED → CONVERTED → CLOSED), `partyId?` (once linked/created), `assignedTo?`.
+- Add a `lifecycleStage` field on the party (`PROSPECT → ACTIVE → DORMANT`) so a party can exist pre-first-service without polluting active-customer queries.
+- **`Inquiry`** (in `pos-customer`): `inquiryId`, `channel` (WEB_FORM, PHONE, WALK_IN, REFERRAL, CAMPAIGN), `audienceType`, captured contact fields, `vehicleOfInterest?`, `serviceOfInterest?`, `campaignCode?` (attribution), `status` (NEW → CONTACTED → CONVERTED → CLOSED), `partyId?` (once linked/created), `assignedTo?`.
 - **Conversion**: an inquiry converts by creating/linking a party (reuse `checkPartyDuplicates` + `createCommercialAccount`/person create) and optionally handing off to `pos-shop-manager` to book an appointment. No opportunity/stage machinery.
 
 ### 5.2 Web form / email capture
@@ -281,7 +286,7 @@ Instead of Odoo's denormalized-lead-then-materialize funnel, model a lightweight
 
 ### 5.3 Verdict / scope
 
-**BUILD (light, adapted).** This is genuinely useful but lower priority than campaigns/consent. It can ship after A–C. If `pos-inquiry` ownership is unclear, the minimal version is just the `PROSPECT` lifecycle stage + `campaignCode` attribution on party creation, deferring the full inquiry object. **Open question O-6.**
+**BUILD (light, adapted) in pos-customer.** This is genuinely useful but lower priority than campaigns/consent. It can ship after A–C. The minimal version is just the `lifecycleStage=PROSPECT` state + `campaignCode` attribution on party creation, deferring the full `Inquiry` object.
 
 ---
 
@@ -292,7 +297,7 @@ The service-shop analog of Odoo's activities/next-actions and lost-reason — re
 ### 6.1 `FollowUpTask`
 
 - `taskId`, `partyId`, `vehicleId?`, `type` (DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, GENERAL), `dueDate`, `assignedTo?` (CSR), `status` (OPEN/DONE/DISMISSED), `sourceWorkorderId?`, `reason?` (decline reason), `outcome?`, `notes`.
-- **Created from workorder events**: when a recommended service line is declined on a workorder, `pos-workorder` emits a fact → pos-customer creates a `DECLINED_SERVICE_FOLLOWUP` task (parity with Odoo lost-reason, but at line granularity and actionable). Requires a workorder event (**O-7**).
+- **Created from workorder events (resolved O-7):** when a recommended service line is declined on a workorder, `pos-workorder` **will emit** a `serviceLine.declined` fact → pos-customer creates a `DECLINED_SERVICE_FOLLOWUP` task (parity with Odoo lost-reason, but at line granularity and actionable). This is the same workorder-events workstream as the service-history feed (O-4) and should likely be **one combined follow-up issue** (§11.1 FI-3).
 - **Created from service-due**: `VehicleCarePreference` interval elapsed (care-preference feature referenced in DECISION-INVENTORY-012) → `SERVICE_DUE_REMINDER` task and/or campaign audience membership.
 - **Hand-off, not scheduling**: completing a task can deep-link to `pos-shop-manager` appointment creation. pos-customer never books.
 - Endpoints `/v1/crm/parties/{partyId}/follow-ups` + a CSR work-queue view `/v1/crm/follow-ups?assignedTo=&status=`. Permissions `crm:followup:{view,manage}`.
@@ -312,7 +317,7 @@ Odoo has salesperson/team ownership; Positivity may want a CSR/account-manager a
 
 Odoo's PLS predicts *deal* win probability — not applicable. The Positivity-relevant analog is a **service-due / churn-risk signal**: which customers are overdue for service or lapsing. This is derivable from vehicle care preferences + service history rather than ML.
 
-- **Backlog / NON-GOAL for v1.** Once service-history data (O-4) is available, a simple rules-based "next-service-due" and "at-risk (no visit in N months)" scoring can drive campaign segments (§3) and follow-up tasks (§6). No Naive-Bayes/ML needed. Record as a fast-follow, not a v1 deliverable.
+- **Backlog / NON-GOAL for v1.** Once the service-history feed (FI-3) is available, a simple rules-based "next-service-due" and "at-risk (no visit in N months)" scoring can drive campaign segments (§3) and follow-up tasks (§6). No Naive-Bayes/ML needed. Record as a fast-follow, not a v1 deliverable.
 
 ---
 
@@ -358,7 +363,8 @@ targeted → eligible(after consent/suppression) → sent → delivered → (ope
 |---|---|---|
 | `PartyTag`, `PartyTagAssignment` | [CRM] | new |
 | `Segment`, `SegmentMember` | [CRM] | new |
-| `CommunicationPreference` (marketing consent fields, quiet hours) | [CRM] | change |
+| `CommunicationPreference` (per-channel marketing consent, quiet hours, opt-out reason) | [CRM] | change |
+| `CommercialParty.accountMarketingOptOut` (account-level master gate, O-2) | [CRM] | change |
 | `ConsentEvent` | [CRM] | new (append-only) |
 | `SuppressionEntry` | [CRM] | new |
 | `CustomerInteraction` | [CRM] | new (generalizes `PartyNote`) |
@@ -367,7 +373,7 @@ targeted → eligible(after consent/suppression) → sent → delivered → (ope
 | `PromotionRedemption.campaignCode` | [CRM] | change (attribution) |
 | `Campaign`, `CampaignSend` | [MKT] | new |
 | `MessageTemplate` | [MKT] | new |
-| `Inquiry` | pos-inquiry | new |
+| `Inquiry` | [CRM] pos-customer | new |
 
 ### 9.2 Permissions (code-first registries)
 
@@ -379,7 +385,7 @@ targeted → eligible(after consent/suppression) → sent → delivered → (ope
 
 - **New facts** `marketing.events.v1`: `campaign.scheduled`, `campaign.sent`, `campaign.send.delivered/bounced/complained`, `campaign.converted`.
 - **CRM facts** on `customer.events.v1`: `party.tag.changed`, `party.consent.changed`, `party.suppressed`, `segment.changed`, `interaction.logged` (for consumers/replicas).
-- **Consumed by CRM**: workorder `serviceLine.declined` (→ follow-up task, **O-7**), `promotion.redeemed`/existing redemption path (→ attribution).
+- **Consumed by CRM**: workorder `serviceLine.declined` + service-completion facts (→ follow-up tasks + service-history projection, FI-3), `promotion.redeemed`/existing redemption path (→ attribution).
 - **Consumed by MKT**: `customer.events.v1` party/segment/consent facts (audience replica), redemption facts (attribution).
 - Reuse outbox + `ProcessedEvent` idempotency.
 
@@ -406,18 +412,31 @@ New tables in pos-customer migrations (continue the V-series after current max V
 
 ---
 
-## 11. Open questions / cross-domain contracts needed
+## 11. Resolved decisions (was: open questions)
 
-| # | Question | Owner(s) | Blocks | Answer |
-|---|---|---|---|---|
-| O-1 | Email/SMS **delivery provider & transport** — dedicated provider client vs a shared platform sender? Owns bounce/complaint webhooks? | Platform/Positivity-integrations + Marketing | §2 send, §4.3 suppression |Assume we will use a shared platform sender|
-| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |Personally, by primary contact and a flag at account level|
-| O-3 | Can `pos-price` **eligibility rules accept an `audienceType`/`campaignCode`** input for audience-specific offers? | Pricing | §1.5 |It can; I don't know if it does.  Make a follow-up issue|
-| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 |Yes, create an issue for emitting these events and consuming them|
-| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |Build a structured address in pos-people-contact, create issue to address this gap|
-| O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |pos-inquiry is a holder for inquiries to suppliers, not prospects|
-| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 | yes - make a follow-up issue to address (closely related to O-4, maybe it's the same issue?)|
-| O-8 | ~~**Module placement** — new `pos-marketing` module vs campaign-in-pos-customer.~~ **RESOLVED (ACCEPTED 2026-07-28): new `pos-marketing` module** (§0.3). | Architecture | — (closed) |chose pos-marketing|
+All eight questions are resolved (answers provided 2026-07-28). Where an answer implies cross-domain work, it is captured as a follow-up issue in §11.1.
+
+| # | Question | Decision | Spec impact |
+|---|---|---|---|
+| O-1 | Email/SMS delivery provider & transport | **Use the shared platform sender**; pos-marketing owns orchestration only, the shared sender owns transport + bounce/complaint webhooks and relays outcomes back. | §2.2 · FI-2 |
+| O-2 | Commercial consent model | **Personal consent of the primary business contact + an account-level `accountMarketingOptOut` master gate** on `CommercialParty`. Individuals use personal per-channel consent. | §4.1, §9.1 |
+| O-3 | Can `pos-price` eligibility accept `audienceType`/`campaignCode`? | **It can; unverified whether it does** → follow-up issue on pos-price. | §1.5 · FI-1 |
+| O-4 | Service-history data feed to pos-customer | **Yes** — emit workorder/service-completion facts and consume them → follow-up issue. | §3.3, §6, §7 · FI-3 |
+| O-5 | Structured address / geography | **Build a structured address in `pos-people-contact`**; pos-customer reads it via the replica → follow-up issue. | §3.3 · FI-4 |
+| O-6 | Prospect/inquiry ownership | **Not `pos-inquiry`** (that is for supplier inquiries) — prospect/inquiry capture lives in **`pos-customer`** (`lifecycleStage=PROSPECT` + `Inquiry`). | §5, §9.1 |
+| O-7 | Declined-service event from pos-workorder | **Yes** — `serviceLine.declined` fact drives follow-up tasks; **same workstream as O-4**, combine into one issue. | §6.1 · FI-3 |
+| O-8 | Module placement | **New `pos-marketing` module** (ACCEPTED). | §0.3 |
+
+### 11.1 Follow-up issues to create
+
+Cross-domain work the answers call for, to be raised as tracked issues before/with the plan. Repos: platform/coordination issues in `durion`; service-specific work in `durion-positivity-backend`.
+
+| ID | Title | Repo / target module | Scope |
+|---|---|---|---|
+| FI-1 | pos-price: audience-type / campaign-code eligibility predicate | `durion-positivity-backend` · pos-price | Confirm current eligibility-rule inputs; add `audienceType`/`partyType`/`campaignCode` predicate support so campaigns can bind audience-specific offers (spec §1.5). |
+| FI-2 | Shared platform sender contract for marketing (email + SMS) | `durion` (coordination) → owning sender service | Define/confirm the shared sender API pos-marketing calls, and the delivery/bounce/complaint outcome feedback (event or callback) that updates `CampaignSend` + suppression (spec §2.2, §4.3). |
+| FI-3 | Workorder → CRM facts: service-completion + declined-service | `durion-positivity-backend` · pos-workorder (emit) + pos-customer (consume) | Emit service-completion and `serviceLine.declined` facts; pos-customer consumes into a service-history projection powering win-back/service-due/declined segments (§3.3) and follow-up tasks (§6). **Combines O-4 and O-7.** |
+| FI-4 | Structured address in pos-people-contact | `durion-positivity-backend` · pos-people-contact (own) + pos-customer (replica read) | Model a structured address (replace free-text `primaryAddress`); expose it on the person replica/snapshot for region/geo segmentation (§3.3). Confirm whether it also covers commercial/organization addresses. |
 
 ---
 

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -1,6 +1,6 @@
 # Specification — CRM Functionality Missing from pos-customer
 
-> Status: DRAFT · Created 2026-07-28 · Companion docs: `comp-crm-overview.md` (Odoo CRM reference), `comp-vs-pos-customer-comparison.md` (capability map).
+> Status: **ACCEPTED** · Created 2026-07-28 · Accepted 2026-07-28 · Companion docs: `comp-crm-overview.md` (Odoo CRM reference), `comp-vs-pos-customer-comparison.md` (capability map), `plan-odoo-parity-pos-customer.md` (implementation plan).
 >
 > Purpose: define, in enough detail to drive a subsequent implementation plan, the CRM capabilities that `pos-customer` (and the platform around it) is missing versus Odoo CRM — **scoped to what an enterprise tire-service management system actually needs.** This is a specification of *what to build and why*, not a task-by-task plan. The plan (`plan-odoo-parity-pos-customer.md`) will be derived from this.
 >
@@ -447,8 +447,8 @@ Waves are dependency-ordered; each is independently shippable.
 - **Wave 1 — CRM data foundations [CRM]:** `PartyTag`(+assignment), `Segment` (static + dynamic over already-available party/tier/tag/vehicle attributes), marketing-consent enrichment on `CommunicationPreference`, `SuppressionEntry`, `ConsentEvent`, `CustomerInteraction` (generalize `PartyNote`). Snapshot integration. *No external dependencies; unblocks everything.*
 - **Wave 2 — Campaign core [MKT]:** stand up the `pos-marketing` module (§0.3 bootstrap), then `Campaign` + lifecycle, `MessageTemplate`, audience binding to segments, audience preview (consent-filtered), attribution `campaignCode` on redemptions. *Depends on Wave 1 + O-1 for actual send.*
 - **Wave 3 — Send + attribution [MKT]:** `CampaignSend`, provider channel adapter(s), async batched dispatch with send-time consent/suppression re-check, provider webhooks → suppression + delivery stats, `GET /stats` with redemption attribution. *Depends on O-1, O-3.*
-- **Wave 4 — Follow-up & prospects [CRM/inquiry]:** `FollowUpTask` (declined-service + service-due), `Inquiry`/`PROSPECT` lifecycle, hand-off to shop-manager. *Depends on O-4, O-6, O-7.*
-- **Backlog:** service-due/churn signal (§7), A/B testing, double opt-in, structured address (O-5), account ownership (§6.2).
+- **Wave 4 — Follow-up, prospects & geo segmentation [CRM/inquiry]:** `FollowUpTask` (declined-service + service-due), `Inquiry`/`PROSPECT` lifecycle, hand-off to shop-manager, and the service-history + **structured-address/region** segment attributes. *Depends on O-4 (FI-3), O-5 (FI-4 — structured address, prerequisite for geo/region segmentation), O-6, O-7.*
+- **Backlog:** service-due/churn signal (§7), A/B testing, double opt-in, account ownership (§6.2).
 
 ---
 

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -206,7 +206,7 @@ A safe, validated predicate tree (**not** free SQL) over a fixed attribute catal
 - Resolution is a query builder over local tables + replicas; must paginate and cap.
 - **Two attribute groups depend on data pos-customer doesn't hold today, now resolved with follow-up work:**
   - *Service history* (resolved O-4): `pos-workorder`/workexec **will emit** service-completion and declined-service facts, which pos-customer consumes into a local projection (powers win-back, service-due, and declined-service predicates and the §6 follow-up tasks). Follow-up issue §11.1 FI-3.
-  - *Structured geography* (resolved O-5): a **structured address will be built in `pos-people-contact`** (the person/contact-point authority), replacing free-text `primaryAddress`; pos-customer reads it via the `ext_people_contact_person` replica / snapshot for region/geo segmentation. Follow-up issue §11.1 FI-4.
+  - *Structured geography* (resolved O-5): a **structured address will be built in `pos-people-contact`** (the person/contact-point authority) for **both person and commercial/organization parties**, replacing free-text `primaryAddress`; pos-customer reads it via the `ext_people_contact_person` replica / snapshot for region/geo segmentation. Follow-up issue §11.1 FI-4.
 - **v1 can still ship** with the party/tier/tag/vehicle attributes pos-customer already has, adding the service-history and geography predicates as those feeds land.
 
 ### 3.4 Endpoints (`/v1/crm/segments`)
@@ -228,7 +228,7 @@ pos-customer has a solid base (`CommunicationPreference` with per-channel prefer
 ### 4.1 Enrich consent — extend `CommunicationPreference`
 
 - Model **per-channel marketing consent** separately from transactional contactability: `marketingEmailConsent`, `marketingSmsConsent` (OPT_IN/OPT_OUT/UNSET) — distinct from the operational `emailPreference`/`smsPreference`.
-- **COMMERCIAL consent model (resolved, O-2):** marketing consent is held **personally by the primary business contact** — that contact's own per-channel `marketingEmailConsent`/`marketingSmsConsent` governs account-level campaign sends — **plus an account-level marketing flag** on `CommercialParty` (`accountMarketingOptOut`) that acts as a master gate: when the account flag is opted-out, no contact on the account is marketed regardless of personal consent. Individual (person) parties use their own personal per-channel consent directly. *(Assumption pending confirmation: the account-level flag is a hard master switch, not merely a default; and only the primary business contact's personal consent — not every account contact's — is consulted for account-level sends.)*
+- **COMMERCIAL consent model (resolved, O-2):** the account-level marketing flag on `CommercialParty` (`accountMarketingOptOut`) is a **hard master gate** — when set, no contact on the account is marketed regardless of personal consent. When the account is not opted-out, account-level campaign sends are governed by the **primary business contact's personal per-channel consent** (`marketingEmailConsent`/`marketingSmsConsent`); other account contacts' personal consent is not consulted for account-level sends. Individual (person) parties use their own personal per-channel consent directly.
 - Add **quiet-hours / cadence** guidance (optional v1): max marketing touches per party per window, do-not-disturb hours (respect timezone).
 - Capture **opt-out reason** (catalog `OptOutReason`: NOT_INTERESTED, TOO_FREQUENT, NEVER_SIGNED_UP, LEGAL_DNC, …) — Odoo parity with `mailing.subscription.optout`.
 
@@ -431,12 +431,12 @@ All eight questions are resolved (answers provided 2026-07-28). Where an answer 
 
 Cross-domain work the answers call for, to be raised as tracked issues before/with the plan. Repos: platform/coordination issues in `durion`; service-specific work in `durion-positivity-backend`.
 
-| ID | Title | Repo / target module | Scope |
-|---|---|---|---|
-| FI-1 | pos-price: audience-type / campaign-code eligibility predicate | `durion-positivity-backend` · pos-price | Confirm current eligibility-rule inputs; add `audienceType`/`partyType`/`campaignCode` predicate support so campaigns can bind audience-specific offers (spec §1.5). |
-| FI-2 | Shared platform sender contract for marketing (email + SMS) | `durion` (coordination) → owning sender service | Define/confirm the shared sender API pos-marketing calls, and the delivery/bounce/complaint outcome feedback (event or callback) that updates `CampaignSend` + suppression (spec §2.2, §4.3). |
-| FI-3 | Workorder → CRM facts: service-completion + declined-service | `durion-positivity-backend` · pos-workorder (emit) + pos-customer (consume) | Emit service-completion and `serviceLine.declined` facts; pos-customer consumes into a service-history projection powering win-back/service-due/declined segments (§3.3) and follow-up tasks (§6). **Combines O-4 and O-7.** |
-| FI-4 | Structured address in pos-people-contact | `durion-positivity-backend` · pos-people-contact (own) + pos-customer (replica read) | Model a structured address (replace free-text `primaryAddress`); expose it on the person replica/snapshot for region/geo segmentation (§3.3). Confirm whether it also covers commercial/organization addresses. |
+| ID | Issue | Title | Repo / target module | Scope |
+|---|---|---|---|---|
+| FI-1 | durion-positivity-backend#1134 | pos-price: audience-type / campaign-code eligibility predicate | `durion-positivity-backend` · pos-price | Confirm current eligibility-rule inputs; add `audienceType`/`partyType`/`campaignCode` predicate support so campaigns can bind audience-specific offers (spec §1.5). |
+| FI-2 | durion#369 | Shared platform sender contract for marketing (email + SMS) | `durion` (coordination) → owning sender service | Define/confirm the shared sender API pos-marketing calls, and the delivery/bounce/complaint outcome feedback (event or callback) that updates `CampaignSend` + suppression (spec §2.2, §4.3). |
+| FI-3 | durion-positivity-backend#1133 | Workorder → CRM facts: service-completion + declined-service | `durion-positivity-backend` · pos-workorder (emit) + pos-customer (consume) | Emit service-completion and `serviceLine.declined` facts; pos-customer consumes into a service-history projection powering win-back/service-due/declined segments (§3.3) and follow-up tasks (§6). **Combines O-4 and O-7.** |
+| FI-4 | durion-positivity-backend#1135 | Structured address in pos-people-contact (persons + organizations) | `durion-positivity-backend` · pos-people-contact (own) + pos-customer (replica read) | Model a structured address for **both person and organization/commercial parties** (replace free-text `primaryAddress`); expose it on the replica/snapshot for region/geo segmentation (§3.3). Note: pos-people-contact today owns Person only — this broadens it to hold organization addresses too. |
 
 ---
 

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -31,18 +31,24 @@ That pipeline already exists and is owned by `pos-shop-manager` (appointments, s
 | D | **Follow-up / declined-service tasks** | Convert declined recommendations and service-due into bookings | `pos-customer` (hand off to `pos-shop-manager`) |
 | E | **Prospect/inquiry capture** (adapted lead capture) | Onboard new fleet accounts and web inquiries | `pos-inquiry` or `pos-customer` |
 
-### 0.3 DECISION REQUIRED — where do campaigns live?
+### 0.3 DECISION (ACCEPTED) — a new `pos-marketing` module owns campaigns
 
-pos-customer already owns the party master, communication preferences, and promotion-redemption ledger — the *data* campaigns target and attribute against. But full campaign orchestration (audience resolution, scheduled multi-channel sends, delivery tracking, per-recipient state) is a distinct lifecycle with its own heavy dependency: **outbound message delivery infrastructure (email/SMS), which pos-customer does not have.**
+**Decision:** campaign functionality lives in a **new `pos-marketing` bounded-context module**, not inside pos-customer. `pos-marketing` owns campaign definition, audience binding, send orchestration, message templates, and campaign analytics. `pos-customer` remains the customer master and owns the CRM-native data campaigns *consume* — segments, tags, marketing consent, suppression, interaction history, and prospects.
 
-**Recommendation: a new `pos-marketing` module** owns campaign definition, audience binding, send orchestration, and campaign analytics; **pos-customer** owns the CRM-native data that campaigns *consume* (segments, tags, consent, suppression, interaction history, prospects). Rationale:
+> Status: **ACCEPTED** (2026-07-28). This resolves open question O-8 and is binding on the plan derived from this spec. Every item below tagged **[MKT]** is built in `pos-marketing`; every **[CRM]** item is built in `pos-customer` (or `pos-inquiry` where noted).
 
-- Respects ADR-0026 / ArchUnit domain walls: pos-customer stays a party registry; marketing send-lifecycle is its own bounded context.
-- The delivery-infrastructure dependency (SMTP/SMS provider) is isolated in the new module, not bolted onto the customer master.
-- pos-marketing reads party/segment/consent data via the existing `CrmSnapshotDTO` + `customer.events.v1` replica pattern (ADR-0044), exactly like other consumers.
-- Keeps consent/suppression enforcement authoritative in pos-customer (the system of record for party contactability) while pos-marketing *asks before sending*.
+pos-customer already owns the party master, communication preferences, and promotion-redemption ledger — the *data* campaigns target and attribute against. But full campaign orchestration (audience resolution, scheduled multi-channel sends, delivery tracking, per-recipient state) is a distinct lifecycle with its own heavy dependency — **outbound message delivery infrastructure (email/SMS), which pos-customer does not have** — and belongs in its own module.
 
-**Alternative (smaller, faster):** put a thin campaign definition + attribution model directly in pos-customer and delegate only raw message delivery to a channel service. Acceptable for a v1 that only ships promo-code campaigns with redemption attribution (no per-recipient open/click tracking). Chosen trade-off is the user's call; this spec is written so either placement works — each entity below is tagged **[CRM]** (pos-customer) or **[MKT]** (pos-marketing/campaign owner).
+Rationale:
+
+- Respects ADR-0026 / ArchUnit domain walls: pos-customer stays a party registry; the marketing send-lifecycle is its own bounded context with its own schema and Flyway baseline.
+- Isolates the delivery-infrastructure dependency (SMTP/SMS provider) in the new module instead of bolting it onto the customer master.
+- pos-marketing reads party/segment/consent data via the existing `CrmSnapshotDTO` + `customer.events.v1` replica pattern (ADR-0044), exactly like every other consumer — no synchronous reach into pos-customer's tables.
+- Keeps consent/suppression enforcement authoritative in pos-customer (the system of record for party contactability); pos-marketing *asks before sending* and never overrides it.
+
+**Considered and rejected:** a thin campaign model embedded in pos-customer that delegates only raw message delivery. Rejected because it couples an unbounded send-lifecycle (per-recipient state, provider webhooks, retry/backoff, delivery analytics) to the customer master, blurs the domain wall, and would have to be extracted later once open/click tracking and A/B testing arrive. The `[CRM]`/`[MKT]` tags below reflect the accepted split, not an either/or.
+
+**New module bootstrap (`pos-marketing`):** standard `pos-{domain}` layout under `com.positivity.marketing` — `PosMarketingApplication` at root, `service/` public interfaces, `internal/{controller,service,repository,entity,dto,config,client,event}`, `MarketingEventTypes` + `MarketingEventTypeInitializer`, `MarketingPermissionRegistry`, own Postgres schema + Flyway baseline (`V1__baseline_marketing_schema.sql`), ArchUnit `ArchitectureTest`, `server.port: 0` + Eureka registration, gateway route `marketing/vN`. Depends on `pos-events`, `pos-shared-dtos`, `pos-domain-events`, `pos-security-common`; **no** compile-time dependency on pos-customer (integration is REST via gateway + `customer.events.v1` events only).
 
 ### 0.4 Platform ground rules every story must honor
 
@@ -174,7 +180,7 @@ Campaigns are only as good as their targeting. pos-customer today has no tags an
 - `PartyTagAssignment`: `(partyId, tagId)`, `assignedBy`, `assignedAt`, optional `source` (MANUAL/CAMPAIGN/IMPORT/RULE). Tags apply to both party subtypes.
 - Endpoints under `/v1/crm/parties/{partyId}/tags` (list/add/remove) + `/v1/crm/tags` (catalog CRUD). Permissions `crm:tag:{view,manage,assign}`.
 
-### 3.2 Entity — `Segment`  **[CRM]** (recommend) or **[MKT]**
+### 3.2 Entity — `Segment`  **[CRM]**
 
 A **named, reusable audience definition**. Two flavors (Odoo parity: `mailing.list` static vs `mailing.filter` dynamic):
 
@@ -411,7 +417,7 @@ New tables in pos-customer migrations (continue the V-series after current max V
 | O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |
 | O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |
 | O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 |
-| O-8 | **Module placement** confirmation — new `pos-marketing` module vs campaign-in-pos-customer (§0.3). | Architecture | §0.3, all [MKT] items |
+| O-8 | ~~**Module placement** — new `pos-marketing` module vs campaign-in-pos-customer.~~ **RESOLVED (ACCEPTED 2026-07-28): new `pos-marketing` module** (§0.3). | Architecture | — (closed) |
 
 ---
 
@@ -420,7 +426,7 @@ New tables in pos-customer migrations (continue the V-series after current max V
 Waves are dependency-ordered; each is independently shippable.
 
 - **Wave 1 — CRM data foundations [CRM]:** `PartyTag`(+assignment), `Segment` (static + dynamic over already-available party/tier/tag/vehicle attributes), marketing-consent enrichment on `CommunicationPreference`, `SuppressionEntry`, `ConsentEvent`, `CustomerInteraction` (generalize `PartyNote`). Snapshot integration. *No external dependencies; unblocks everything.*
-- **Wave 2 — Campaign core [MKT]:** `Campaign` + lifecycle, `MessageTemplate`, audience binding to segments, audience preview (consent-filtered), attribution `campaignCode` on redemptions. Resolves O-8 first. *Depends on Wave 1 + O-1 for actual send.*
+- **Wave 2 — Campaign core [MKT]:** stand up the `pos-marketing` module (§0.3 bootstrap), then `Campaign` + lifecycle, `MessageTemplate`, audience binding to segments, audience preview (consent-filtered), attribution `campaignCode` on redemptions. *Depends on Wave 1 + O-1 for actual send.*
 - **Wave 3 — Send + attribution [MKT]:** `CampaignSend`, provider channel adapter(s), async batched dispatch with send-time consent/suppression re-check, provider webhooks → suppression + delivery stats, `GET /stats` with redemption attribution. *Depends on O-1, O-3.*
 - **Wave 4 — Follow-up & prospects [CRM/inquiry]:** `FollowUpTask` (declined-service + service-due), `Inquiry`/`PROSPECT` lifecycle, hand-off to shop-manager. *Depends on O-4, O-6, O-7.*
 - **Backlog:** service-due/churn signal (§7), A/B testing, double opt-in, structured address (O-5), account ownership (§6.2).

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -411,12 +411,12 @@ New tables in pos-customer migrations (continue the V-series after current max V
 | # | Question | Owner(s) | Blocks | Answer |
 |---|---|---|---|---|
 | O-1 | Email/SMS **delivery provider & transport** — dedicated provider client vs a shared platform sender? Owns bounce/complaint webhooks? | Platform/Positivity-integrations + Marketing | §2 send, §4.3 suppression |Assume we will use a shared platform sender|
-| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |personally, by primary contact and a flag at account level|
+| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |Personally, by primary contact and a flag at account level|
 | O-3 | Can `pos-price` **eligibility rules accept an `audienceType`/`campaignCode`** input for audience-specific offers? | Pricing | §1.5 |It can; I don't know if it does.  Make a follow-up issue|
-| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 ||
-| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |build a structured address in pos-people-contact, create issue to address|
+| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 |Yes, create an issue for emitting these events and consuming them|
+| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |Build a structured address in pos-people-contact, create issue to address this gap|
 | O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |pos-inquiry is a holder for inquiries to suppliers, not prospects|
-| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 | yes - make a follow-up issue to address|
+| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 | yes - make a follow-up issue to address (closely related to O-4, maybe it's the same issue?)|
 | O-8 | ~~**Module placement** — new `pos-marketing` module vs campaign-in-pos-customer.~~ **RESOLVED (ACCEPTED 2026-07-28): new `pos-marketing` module** (§0.3). | Architecture | — (closed) |chose pos-marketing|
 
 ---

--- a/domains/crm/spec-pos-customer-crm-gaps.md
+++ b/domains/crm/spec-pos-customer-crm-gaps.md
@@ -408,16 +408,16 @@ New tables in pos-customer migrations (continue the V-series after current max V
 
 ## 11. Open questions / cross-domain contracts needed
 
-| # | Question | Owner(s) | Blocks |
-|---|---|---|---|
-| O-1 | Email/SMS **delivery provider & transport** — dedicated provider client vs a shared platform sender? Owns bounce/complaint webhooks? | Platform/Positivity-integrations + Marketing | §2 send, §4.3 suppression |
-| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |
-| O-3 | Can `pos-price` **eligibility rules accept an `audienceType`/`campaignCode`** input for audience-specific offers? | Pricing | §1.5 |
-| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 |
-| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |
-| O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |
-| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 |
-| O-8 | ~~**Module placement** — new `pos-marketing` module vs campaign-in-pos-customer.~~ **RESOLVED (ACCEPTED 2026-07-28): new `pos-marketing` module** (§0.3). | Architecture | — (closed) |
+| # | Question | Owner(s) | Blocks | Answer |
+|---|---|---|---|---|
+| O-1 | Email/SMS **delivery provider & transport** — dedicated provider client vs a shared platform sender? Owns bounce/complaint webhooks? | Platform/Positivity-integrations + Marketing | §2 send, §4.3 suppression |Assume we will use a shared platform sender|
+| O-2 | **Commercial consent model** — is marketing consent held at the account level, per contact-role, or personally by each contact? Legal basis for B2B sends. | CRM + Security/Legal | §4.1 |personally, by primary contact and a flag at account level|
+| O-3 | Can `pos-price` **eligibility rules accept an `audienceType`/`campaignCode`** input for audience-specific offers? | Pricing | §1.5 |It can; I don't know if it does.  Make a follow-up issue|
+| O-4 | **Service-history data feed** — does pos-customer get workorder/service-completion facts to power "last service", "service-due", "declined service" segments? Today it only consumes `ContactPreferenceUpdated` + `PartyNoteAdded`. | Workexec/Workorder + CRM | §3.3, §6, §7 ||
+| O-5 | **Structured address / geography** — needed for geo/region segmentation and mail campaigns; today `primaryAddress` is free text. Build a structured address, or rely on shop/location association? | CRM + Location | §3.3 geo attributes |build a structured address in pos-people-contact, create issue to address|
+| O-6 | **Prospect/inquiry ownership** — does `pos-inquiry` own the Inquiry object, or is a `PROSPECT` lifecycle stage on the party sufficient for v1? | CRM + product | §5 |pos-inquiry is a holder for inquiries to suppliers, not prospects|
+| O-7 | **Declined-service event** — will `pos-workorder` emit a `serviceLine.declined` fact to drive follow-up tasks? | Workorder + CRM | §6.1 | yes - make a follow-up issue to address|
+| O-8 | ~~**Module placement** — new `pos-marketing` module vs campaign-in-pos-customer.~~ **RESOLVED (ACCEPTED 2026-07-28): new `pos-marketing` module** (§0.3). | Architecture | — (closed) |chose pos-marketing|
 
 ---
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:<none>` — this is a domain-analysis + planning docs PR (no code), so no capability id.
- Parent STORY (durion): n/a (this PR *creates* the plan and its story issues)
- Child issues (durion-positivity-backend): stories #1136–#1154; prerequisites #1133, #1134, #1135, and durion#369
- Domain: `domain:crm`

## Contract References
- Contract guide entries (durion): `domains/crm/.business-rules/BACKEND_CONTRACT_GUIDE.md` (existing; not modified)
- No API/event behavior changes in this PR (documentation only).

## Scope
**What changed:** adds the CRM domain-analysis document set under `domains/crm/`:
- `comp-crm-overview.md` — functional overview of the Odoo 19 CRM stack (crm, mass_mailing, utm, siblings) as reference material.
- `comp-vs-pos-customer-comparison.md` — capability comparison map (BUILD / ADAPTED / ELSEWHERE / NON-GOAL / HAVE verdict per capability), tuned to the service-shop model.
- `spec-pos-customer-crm-gaps.md` — accepted specification of the CRM functionality worth building: marketing campaigns differentiated by **commercial vs individual** audience, segmentation/tags, marketing consent + suppression, interaction history, follow-up tasks, and prospect capture. All open questions resolved.
- `plan-odoo-parity-pos-customer.md` — **ACCEPTED** implementation plan: workstreams A–E, per-story change/files/AC/effort/deps, sequencing waves, decisions, and the story-issue registry.

**Why:** establishes the analysis → spec → plan chain (mirroring `domains/accounting`) to drive CRM parity work. Key decisions locked: new `pos-marketing` module owns campaigns; pos-customer owns segments/consent/suppression/interaction-history/prospects; commercial consent = primary-contact personal consent + account-level master gate; structured address in pos-people-contact.

**Note on an unrelated file:** the branch's base commit `aff50e8 "Added warranty domain-document"` (predates this work) adds `.claude/agents/domains/warranty-domain.md`. It is carried along because it is the first commit on this branch; it is unrelated to the CRM docs. Flagging in case it should be split out.

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated (backend)
- [ ] Consumer/UI tests added/updated (frontend)
- How to run: n/a — documentation only, no build/test impact.

## Risk & Rollback
- Risk level: **Low** (docs only; no code, schema, or contract changes).
- Rollback plan: revert the merge commit; no runtime impact.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a (analysis branch `claude/odoo-crm-pos-customer-comparison-pc1ky6`)
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a (no capability id for a planning-docs PR)
- [x] Links to parent + child issues are present (story + prerequisite issues listed above)
- [x] Contract guide updated when contract semantics changed — n/a (no contract change)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dn14hcWnagk6VWPwG4LZS

---
_Generated by [Claude Code](https://claude.ai/code/session_012Dn14hcWnagk6VWPwG4LZS)_