### PR TITLE
docs: Add supplier integration architecture for EDIWheel and beyond

### DIFF
--- a/docs/adr/0044-platform-event-only-domain-walls.adr.md
+++ b/docs/adr/0044-platform-event-only-domain-walls.adr.md
@@ -210,6 +210,33 @@ reconciliation.
   so retries remain safe. Result events from `pos-invoice` remain useful for audit, analytics, and
   downstream consumers, but they are not the settlement authority for warranty.
 
+### 2026-08-10 — Scoped exception: synchronous supplier stock-inquiry reads from pos-supplier
+
+`pos-supplier` (new domain module for outbound supplier connectivity, durion#372, architecture in
+`docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md`) is added to the
+**Domain** class: its cross-module integration is event-only (`supplier.*` topics) with one scoped
+read exception, approved in the supplier integration review (durion#374, §12 decisions 4–5).
+
+- **Decision.** The positivity Product Detail composition service and `pos-order` (procurement
+  flows) MAY call `pos-supplier`'s `SupplierStockService` **read API** synchronously for live vendor
+  stock availability/quote. No other module may call `pos-supplier` synchronously, `pos-supplier`
+  calls no domain module synchronously, and no write path is included in the exception.
+- **Rationale.** Live vendor availability is an inherently synchronous counter flow: the user is
+  quoting or raising a purchase order and needs the vendor's answer now. The freshness requirement
+  is seconds, not minutes — an event-fed replica of external vendor stock cannot meet it, and
+  pre-fetching entire vendor inventories to simulate liveness would be worse than the call.
+- **Degradation contract.** Callers MUST apply the positivity composition semantics
+  (DECISION-POSITIVITY-004/006/007/011): short per-binding timeouts, `SUPPLIER_UNAVAILABLE` status
+  on failure or open breaker, null (never zero) numeric fields when status is non-OK, and `asOf`
+  timestamps on all values. A `pos-supplier` outage MUST degrade the calling screen's supplier
+  component only — never fail the composition.
+- **Enforcement.** Encoded in `DomainWallsTest` (pos-archunit) as a per-consumer exception map
+  entry: {positivity composition module, `pos-order`} → `pos-supplier` read API only, added with
+  the CAP-319 implementation (durion-positivity-backend#1225). Widening the caller set or adding a
+  write path requires a further amendment to this ADR.
+- **Boundaries.** All other supplier data flows (price catalog, stock report, order lifecycle,
+  invoices, shipment, workorder authorization) remain event-only per the main decision.
+
 ---
 
 ## Changes required in other ADRs

--- a/docs/adr/0049-supplier-integration-module-boundary.adr.md
+++ b/docs/adr/0049-supplier-integration-module-boundary.adr.md
@@ -1,0 +1,61 @@
+# ADR-0049: Supplier Integration Module Boundary and Event Contracts (pos-supplier)
+
+**Status:** PROPOSED
+**Date:** 2026-08-10
+**Deciders:** Architecture, Backend Lead, Positivity (Integrations) Domain
+**Affected Issues:** durion#372–#379 (CAP-317..CAP-324), durion#371
+
+---
+
+## Context
+
+- **Current State**: The platform has no outbound supplier connectivity. Tire manufacturers (Michelin first) expose supplier APIs over the EDIWheel standard in multiple norm generations (A2.5/B-series/C1.x XML, C1.2 JSON) plus vendor-proprietary APIs (Michelin S2S workorder authorization, OAuth2). Specs are collected in `docs/ediwheel/`.
+- **The Problem**: Supplier capabilities (price catalog, stock inquiry, ordering, invoices, shipment, fleet workorder authorization) touch many domains — pricing, catalog, inventory, order, accounting, workexec. Without a single owner, vendor wire formats, credentials, and retry logic would leak into every domain module.
+- **Drivers**: Reuse across vendors and deployments; per-deployment configurability; ADR-0044 event-only domain walls; auditability of commercial exchanges.
+- **Scope**: Backend module boundary, canonical model ownership, and the supplier event contract set. Full architecture: `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md`.
+
+---
+
+## Decision
+
+### 1. Single owning module
+
+**Decision:** ✅ **Resolved** — All outbound supplier connectivity lives in one new **domain** module, `pos-supplier`. It owns: the vendor-neutral canonical model (`SupplierPurchaseOrder` transmission state, `SupplierStockInquiry`, `SupplierPriceCatalogEntry`, `SupplierInvoice`, `SupplierShipmentEvent`, `SupplierWorkorderAuthorization`), vendor profiles and endpoint bindings, protocol adapters/codecs, the exchange audit log, and supplier-facing orchestration (outbox, retries, schedules). No other module may hold vendor credentials, speak a vendor wire format, or call a vendor endpoint.
+
+### 2. What pos-supplier does not own
+
+**Decision:** ✅ **Resolved** — Business aggregates stay with their domains: the purchase-order aggregate is **pos-order**; sell prices are **pos-price**; product identity is **pos-catalog**; owned inventory is **pos-inventory**; AP voucher posting is **pos-accounting**; workorder state is **workexec**. `pos-supplier` holds transmission/exchange state only, and vendor references (`SupplierOrderNumber`, `DocumentID`) are attributes, never keys (ADR-0013/0027).
+
+### 3. Event contract set
+
+**Decision:** ✅ **Resolved** — Cross-module integration is event-only per ADR-0044 (envelope and DTOs in `pos-domain-events`; transactional outbox; idempotent consumers). Initial contract set:
+
+| Topic/event | Producer → Consumer | Kind |
+| --- | --- | --- |
+| `supplier.order.requested.v1` | pos-order → pos-supplier | command |
+| `supplier.order.confirmed.v1` / `supplier.order.rejected.v1` | pos-supplier → pos-order | result |
+| `supplier.orderstatus.changed.v1` | pos-supplier → pos-order | fact |
+| `supplier.pricecatalog.updated.v1` | pos-supplier → pos-price / pos-catalog | fact |
+| `supplier.stockreport.updated.v1` | pos-supplier → pos-inventory | fact |
+| `supplier.invoice.received.v1` | pos-supplier → pos-accounting | fact |
+| `supplier.shipment.event.v1` | pos-supplier → order/receiving consumers | fact (append-only) |
+| `supplier.workorderauth.granted.v1` / `.denied.v1` | pos-supplier → workexec | result |
+
+Payload changes within a version are additive-only; breaking changes take a new topic version with dual-publish, per ADR-0044 §3.
+
+### 4. Synchronous surface
+
+**Decision:** ✅ **Resolved** — Exactly one synchronous cross-module read exists: `SupplierStockService` live stock inquiry, callable by the positivity Product Detail composition and pos-order procurement, governed by the ADR-0044 amendment dated 2026-08-10 and enforced in `DomainWallsTest`. Admin/profile/audit controllers are frontend-facing via the gateway (ADR-0011/0014), not cross-module surfaces.
+
+---
+
+## Consequences
+
+**Positive:** vendor onboarding is contained to `pos-supplier` adapters + configuration; domains consume stable canonical events; one place audits every commercial exchange.
+**Negative / accepted:** `pos-supplier` becomes a coupling point for supplier-facing flows; batch consumers must tolerate event lag; an extra hop (event) between business intent and vendor transmission.
+**Follow-ups:** ADR-0050 (vendor profile configuration), ADR-0051 (adapter/codec versioning), ADR-0052 (outbound idempotency); PRICAT precedence ADR after durion#371.
+
+## References
+
+- `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md`
+- ADR-0044 (event-only domain walls, incl. 2026-08-10 amendment), ADR-0026, ADR-0013/0027

--- a/docs/adr/0050-supplier-vendor-profile-configuration.adr.md
+++ b/docs/adr/0050-supplier-vendor-profile-configuration.adr.md
@@ -1,0 +1,57 @@
+# ADR-0050: Supplier Vendor Profile Configuration Model
+
+**Status:** PROPOSED
+**Date:** 2026-08-10
+**Deciders:** Architecture, Backend Lead, Positivity (Integrations) Domain
+**Affected Issues:** durion#372 (CAP-317), durion-positivity-backend#1222
+
+---
+
+## Context
+
+- **Current State**: Every deployment of the platform is expected to wire a custom set of vendors, capabilities, endpoints, norm versions, credentials, and account numbers. The same vendor differs per deployment (accounts, enabled capabilities, sandbox vs production).
+- **The Problem**: Vendor wiring must be data, not code — otherwise each deployment forks the integration layer.
+- **Drivers**: Deployment-level configurability (supplier architecture goal 3); platform secrets policy (no hardcoded credentials); the EDIWheel party model (per-message buyer/consignee identification); the Michelin account model (one credential set + two account numbers per transaction).
+- **Scope**: The persisted configuration model in `pos-supplier` and its rules. Not covered: adapter/codec selection mechanics (ADR-0051).
+
+---
+
+## Decision
+
+### 1. Vendor profile as the unit of configuration
+
+**Decision:** ✅ **Resolved** — A **vendor profile** represents one supplier account in one deployment: profile key (`SupplierRef`), display name, protocol defaults (timeouts, retry), sandbox overlay, and three child collections — auth configs, commercial accounts, and endpoint bindings. One vendor may legitimately have multiple profiles (regions, legal entities). Profiles are DB-persisted with a permission-gated admin API; YAML bootstrap seeds first deployments by idempotent upsert.
+
+### 2. Capability bindings
+
+**Decision:** ✅ **Resolved** — A binding maps one capability to `(protocolFamily, version, baseUrl, path, authRef, optional cron schedule, enabled)`. **Absent binding = capability disabled** for that vendor in that deployment, surfaced as a typed `CAPABILITY_NOT_CONFIGURED` status, never an error leak. Batch capabilities carry their schedule on the binding; environment promotion changes only profile data (sandbox overlay), never code.
+
+### 3. Credentials are references; account numbers are data
+
+**Decision:** ✅ **Resolved** — Auth configs (`BASIC_PLUS_APIKEY`, `OAUTH2_CLIENT_CREDENTIALS`, `BEARER`) store **secret references only** (`env:` / secret-store keys), resolved at call time; plaintext credentials never persist, never serialize into API responses (write-only fields), and never appear in logs or the exchange audit (redacted headers). Commercial **account numbers** are ordinary profile data, distinct from credentials: one credential set authenticates the connection while account numbers identify the commercial parties inside each message.
+
+### 4. Canonical account roles: billing and delivery
+
+**Decision:** ✅ **Resolved** — The profile models two generic account roles:
+
+- **billing** — the invoicing/settlement account number (+ agency code), typically one per profile at legal-entity level, shareable across locations.
+- **delivery** — account numbers per receiving location, stored as a mapping `pos-location UUID → account number (+ agency code)`.
+
+Vendor vocabulary (`billTo`/`shipTo` in Michelin APIs, `BuyerParty`/`Consignee` in EDIWheel XML) exists **only inside adapters**; canonical code, entities, DTOs, events, and UI use billing/delivery. Callers pass a `PartyContext` (billing account + delivery location); a missing delivery mapping for the requested location is a configuration error raised **before any network call**.
+
+### 5. Auditability
+
+**Decision:** ✅ **Resolved** — Profile changes carry standard audit fields (ADR-0018/0024) and are permission-gated deny-by-default (ADR-0040, permissions registered per ADR-0025). Raw exchange-payload access uses a separate, tighter permission than profile administration.
+
+---
+
+## Consequences
+
+**Positive:** vendor onboarding and environment promotion are configuration acts; secrets stay in the secret store; location-aware ordering is validated before money moves.
+**Negative / accepted:** profile schema becomes a contract that adapters depend on; delivery mappings must be maintained as locations change (surfaced in the admin UI as a warning).
+**Open:** retention period for raw exchange payloads (operations/compliance decision, CAP-317 open question).
+
+## References
+
+- `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §7
+- ADR-0049, ADR-0051; platform secrets rule (CLAUDE.md/AGENTS.md)

--- a/docs/adr/0051-supplier-protocol-adapter-versioning.adr.md
+++ b/docs/adr/0051-supplier-protocol-adapter-versioning.adr.md
@@ -1,0 +1,52 @@
+# ADR-0051: Supplier Protocol Adapter and Codec Versioning Policy
+
+**Status:** PROPOSED
+**Date:** 2026-08-10
+**Deciders:** Architecture, Backend Lead, Positivity (Integrations) Domain
+**Affected Issues:** durion#372 (CAP-317), durion-positivity-backend#1221
+
+---
+
+## Context
+
+- **Current State**: The same business service exists in multiple EDIWheel norm generations (order in A2.5 and C1.0; order status in A2.5, C1.0, and C1.1; stock report in B2.1 and C1.0; the emerging C1.2 JSON API), and vendors support different subsets. Non-EDIWheel vendors (Michelin S2S) add proprietary formats.
+- **The Problem**: Multiple protocol versions of the same capability must coexist behind one interface, selectable per vendor per deployment, without forking business logic.
+- **Drivers**: Supplier architecture goals 1–2 (reusable modules, reuse beyond EDIWheel); the high likelihood of implementing several versions of the same service per vendor.
+- **Scope**: Adapter organization, codec registration/resolution, and version-evolution rules inside `pos-supplier`.
+
+---
+
+## Decision
+
+### 1. Adapters per wire-format family, not per vendor
+
+**Decision:** ✅ **Resolved** — One adapter package per protocol family: `EDIWHEEL_A25`, `EDIWHEEL_C1`, `EDIWHEEL_B`, `EDIWHEEL_JSON` (C1.2), `MICHELIN_S2S`, and future families for proprietary distributors. Two vendors speaking the same norm share the adapter with different profile bindings. Adapter code may depend on `spi` and `domain/model` only; vendor wire types never escape `adapter/**` (ArchUnit-enforced).
+
+### 2. Registry keyed by (capability, protocolFamily, version)
+
+**Decision:** ✅ **Resolved** — Codecs register against the triple `(capability, protocolFamily, version)` (e.g. `ORDER_STATUS × EDIWHEEL_C1 × C1_1`). The vendor profile's binding names the triple to use; switching a vendor's order status from C1.0 to C1.1 is a configuration change. Duplicate registrations fail startup; an unbound capability resolves to `CAPABILITY_NOT_CONFIGURED`.
+
+### 3. Version evolution rules
+
+**Decision:** ✅ **Resolved**
+
+- A new norm version = a new codec class in the existing family, registered under the new version key; older codecs remain until no deployment binds them.
+- The canonical model changes only when the **business** capability grows, never to mirror a wire format. Fields a given norm cannot express are recorded per exchange as `unmappedFields` in the exchange audit (diagnosable, never silently dropped).
+- Version-specific quirks (e.g. C1.1 adding `Geolocation`/`ErrorHead` structures) stay inside the codec.
+- Every codec ships golden-file round-trip tests derived from the vendor specs (`docs/ediwheel/`), plus a sandbox smoke test where the vendor offers one.
+
+### 4. Wire-format technology
+
+**Decision:** ✅ **Resolved** — XML norms bind via JAXB models generated or hand-written from the EDIWheel message implementation guidelines; JSON families use Jackson. Codec output is bytes + content-type handed to the shared base client; codecs perform no I/O.
+
+---
+
+## Consequences
+
+**Positive:** vendor #2 on an existing norm is configuration only; new norms are additive codec work; business logic never forks per version.
+**Negative / accepted:** the registry triple becomes a stable public naming scheme (renames are migrations); golden-file fixtures need upkeep as vendors revise norms.
+
+## References
+
+- `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §6, §10
+- ADR-0049, ADR-0050

--- a/docs/adr/0052-supplier-outbound-idempotency-duplicate-order-prevention.adr.md
+++ b/docs/adr/0052-supplier-outbound-idempotency-duplicate-order-prevention.adr.md
@@ -1,0 +1,55 @@
+# ADR-0052: Supplier Outbound Idempotency and Duplicate-Order Prevention
+
+**Status:** PROPOSED
+**Date:** 2026-08-10
+**Deciders:** Architecture, Backend Lead, Positivity (Integrations) Domain, Order Domain
+**Affected Issues:** durion#375 (CAP-320), durion-positivity-backend#1226
+
+---
+
+## Context
+
+- **Current State**: CAP-320 transmits purchase orders to vendors over EDIWheel order creation. Vendor order APIs are not idempotent by default; a timeout after send is ambiguous (the vendor may or may not have accepted the order).
+- **The Problem**: A naive retry on an ambiguous outcome places a duplicate physical order — trucks deliver tires twice. This is the single largest operational risk of supplier EDI.
+- **Drivers**: At-least-once delivery semantics of the event backbone (ADR-0044 §4); retry behavior of the shared base client; the EDIWheel `DocumentID`/`CustomerReference` mechanism vendors use for deduplication.
+- **Scope**: All outbound supplier exchanges, with the strictest rules on order creation. Applies to `pos-supplier` orchestration; consuming domains inherit the guarantees via events.
+
+---
+
+## Decision
+
+### 1. Deterministic client references
+
+**Decision:** ✅ **Resolved** — Every outbound exchange that creates vendor-side state carries a client reference derived **deterministically from the canonical entity UUID** (e.g. purchase-order UUID → `DocumentID`/`CustomerReference`). Retries of the same intent always present the same reference, making vendor-side deduplication possible. References are never regenerated on retry.
+
+### 2. Transactional outbox for order transmission
+
+**Decision:** ✅ **Resolved** — Consuming `supplier.order.requested.v1` writes the transmission intent and its outbox row in one transaction (exactly-once-intent). A background dispatcher performs the network send; crash/restart re-dispatches from the outbox with the same document ID. Result events (`confirmed`/`rejected`) are applied idempotently against the transmission state.
+
+### 3. Ambiguous outcomes reconcile via status, never blind retry
+
+**Decision:** ✅ **Resolved** — When an order-create call times out or fails after the request may have reached the vendor, the orchestrator MUST NOT re-send the create. It queries the vendor's order-status service by document ID and reconciles:
+
+- Vendor knows the order → apply confirmed/rejected result; no resend.
+- Vendor does not know the order **and** the failure clearly preceded transmission (connection refused before send, breaker open) → safe re-dispatch from outbox with the same document ID.
+- Vendor does not know the order after a confirmed-send window → transmission enters `MANUAL_REVIEW`; resolution actions are human-triggered. **No automatic resend exists for this state**, and no frontend surface offers a blind re-send.
+
+### 4. Retry classification
+
+**Decision:** ✅ **Resolved** — The base client classifies failures: *pre-send* (DNS, connect, breaker-open) → retryable automatically; *post-send ambiguous* (read timeout, 5xx after body sent) → status-first reconciliation per §3; *definitive rejection* (4xx with vendor error payload) → no retry, surface the rejection. Batch reads (PRICAT, stock report, invoice fetch) are idempotent by checkpointed window and may retry freely; consumers deduplicate by natural identity (e.g. one AP voucher per vendor invoice identity).
+
+### 5. Test obligations
+
+**Decision:** ✅ **Resolved** — CAP-320 (and any future capability that creates vendor-side state) MUST ship crash/retry integration tests proving: same document ID across retries; no duplicate transmission after crash between intent and dispatch; status-first reconciliation on simulated ambiguous timeout; `MANUAL_REVIEW` on vendor-unknown-after-send. These tests are acceptance criteria, not optional hardening.
+
+---
+
+## Consequences
+
+**Positive:** duplicate physical orders are structurally prevented rather than operationally hoped against; ambiguity resolves from the vendor's authoritative state; humans only see truly unresolvable cases.
+**Negative / accepted:** order transmission is eventually consistent (queued during vendor outages); `MANUAL_REVIEW` requires an operational owner; status polling adds vendor API traffic.
+
+## References
+
+- `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §9.1
+- ADR-0044 §4 (outbox, idempotent consumers), ADR-0049

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -113,6 +113,10 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0046   | Environment Log Level Policy                           | PROPOSED              | 2026-07-12 |
 | 0047   | Ledger Inalterability and Fiscal Positions Are Accounting Non-Goals | ACCEPTED | 2026-07-17 |
 | 0048   | Inventory-Owned Valuation with Configurable Costing Method | ACCEPTED | 2026-07-23 |
+| 0049   | Supplier Integration Module Boundary and Event Contracts (pos-supplier) | PROPOSED | 2026-08-10 |
+| 0050   | Supplier Vendor Profile Configuration Model            | PROPOSED              | 2026-08-10 |
+| 0051   | Supplier Protocol Adapter and Codec Versioning Policy  | PROPOSED              | 2026-08-10 |
+| 0052   | Supplier Outbound Idempotency and Duplicate-Order Prevention | PROPOSED | 2026-08-10 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 
@@ -168,6 +172,10 @@ Use this matrix during planning, implementation, and review to quickly decide wh
 | 0046 | Log level changes in any `application-{profile}.yml`, adding/removing logger overrides, temporary troubleshooting verbosity in deployed environments (alpha WARN; indus/prod ERROR; prod INFO+ needs Tech Lead signoff) | Planner, Coder, Orchestrator |
 | 0047 | Accounting parity decisions about ledger tamper-evidence non-goals and fiscal-position non-goals, including revisit triggers and accounting-scope guardrails | Planner, Coder, Test, Orchestrator |
 | 0048 | Inventory valuation ownership, cost-bearing inventory facts, costing-method configurability, and the J1/K1 boundary between inventory valuation and accounting posting | Planner, Coder, Test, Orchestrator |
+| 0049 | Supplier connectivity ownership: pos-supplier as the single module holding vendor credentials/wire formats, canonical supplier model, `supplier.*` event contract set, and the single approved synchronous stock-inquiry read surface | Planner, Coder, Test, Orchestrator |
+| 0050 | Vendor profile configuration: capability bindings (absent = disabled), secret-reference-only credentials, canonical billing/delivery account roles with per-location delivery mapping, sandbox overlays, profile audit/permissions | Planner, Coder, Test, Orchestrator |
+| 0051 | Supplier protocol adapters and codecs: adapter-per-wire-format-family, registry keyed (capability, protocolFamily, version), norm-version coexistence, unmapped-field audit, golden-file test obligations | Planner, Coder, Test, Orchestrator |
+| 0052 | Outbound supplier idempotency: deterministic document IDs, transactional outbox for order transmission, status-first reconciliation of ambiguous outcomes (never blind-retry an order create), MANUAL_REVIEW escalation, mandatory crash/retry tests | Planner, Coder, Test, Orchestrator |
 
 ### Agent role shorthand
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,6 +20,10 @@ Use this index to find the current architectural source before consulting older 
 - [Backend Contract Global Standards](./api/BACKEND_CONTRACT_GLOBAL_STANDARDS.md) - Normative rules for backend contract guides and OpenAPI source-of-truth boundaries
 - [GitHub Branching Strategy](./branching-strategy.md) - Branch naming, protection, PR flow, and release branching conventions
 
+### Integration
+
+- [Supplier Integration Architecture — EDIWheel and Beyond](./integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md) - Proposed ports-and-adapters architecture for outbound tire-manufacturer connectivity over the EDIWheel standard (Michelin first), with configuration-driven vendor profiles, multi-norm version support, and reuse for non-EDIWheel parts distributors
+
 ### Deployment And Runtime
 
 - [Deployment Architecture Index](./deployment/README.md) - Entry point for deployment-focused architecture and migration planning

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -347,14 +347,19 @@ The AI services (DOT recognition, TireSnap) follow the same pattern behind `Tire
 
 ## 11. Suggested Phasing
 
-| Phase | Deliverable | Rationale |
-| --- | --- | --- |
-| 1 | `pos-supplier` skeleton: canonical model, profiles/bindings, registry, exchange audit, admin API. Michelin **Price Catalog (B4.0)** + **Stock Inquiry (A2.5)** | Read-only, low-risk capabilities that immediately enrich quoting; proves profile + adapter + version machinery end to end |
-| 2 | **Order Create + Order Status** (C1.0 create, C1.1 status), outbox and idempotency machinery, purchasing events | The commercial core; needs Phase 1 plumbing hardened first |
-| 3 | **Invoice fetch (B3.3)**, **Stock Report (B2.1)**, **Shipment tracking**, accounting/receiving event consumers | Back-office reconciliation |
-| 4 | **S2S workorder authorization** (fleet flows), second protocol family in production | Exercises the non-EDIWheel reuse claim |
-| 5 | MKCAT marketing catalog; DOT / TireSnap scanning behind the `TireIdentificationPort` placeholder | DOT scanning is expected to be required by most service providers — port defined up front, adapter implemented once confirmed |
-| Next vendor | Second EDIWheel manufacturer via configuration (+ codec gaps only) | Validates the reusability goal; target: zero changes outside `adapter/` + profile data |
+The phasing plan is decomposed into capability stories **CAP-317 through CAP-324** (GitHub issues [durion#372](https://github.com/louisburroughs/durion/issues/372)–[durion#379](https://github.com/louisburroughs/durion/issues/379)).
+
+| Phase | Capability | Deliverable | Rationale |
+| --- | --- | --- | --- |
+| 1 | CAP-317 ([#372](https://github.com/louisburroughs/durion/issues/372)) | `pos-supplier` foundation: canonical model, profiles/bindings/accounts, adapter registry, exchange audit, resilience, admin API/UI | The plumbing every later capability plugs into |
+| 1 | CAP-318 ([#373](https://github.com/louisburroughs/durion/issues/373)) | Michelin **Price Catalog (B4.0)** sync with effective-dating (consumer blocked by [#371](https://github.com/louisburroughs/durion/issues/371)) | Read-only, low-risk; proves profile + adapter + version machinery |
+| 1 | CAP-319 ([#374](https://github.com/louisburroughs/durion/issues/374)) | **Stock Inquiry (A2.5)** — live availability in Product Detail and pos-order procurement | Immediately enriches quoting; exercises the approved sync-read exception |
+| 2 | CAP-320 ([#375](https://github.com/louisburroughs/durion/issues/375)) | **Order Create + Order Status** (C1.0 create, C1.1 status), outbox and idempotency machinery, pos-order events | The commercial core; needs Phase 1 plumbing hardened first |
+| 3 | CAP-321 ([#376](https://github.com/louisburroughs/durion/issues/376)) | **Invoice fetch (B3.3)** → AP vouchers in pos-accounting | Back-office reconciliation |
+| 3 | CAP-322 ([#377](https://github.com/louisburroughs/durion/issues/377)) | **Stock Report (B2.1)** + **Shipment tracking** with inventory/receiving consumers | Back-office visibility |
+| 4 | CAP-323 ([#378](https://github.com/louisburroughs/durion/issues/378)) | **S2S workorder authorization** (fleet flows), second protocol family in production | Exercises the non-EDIWheel reuse claim |
+| 5 | CAP-324 ([#379](https://github.com/louisburroughs/durion/issues/379)) | MKCAT marketing catalog (C1.2 JSON); DOT / TireSnap scanning stays a dormant `TireIdentificationPort` placeholder | DOT scanning likely required by most service providers — port defined up front, adapter implemented once confirmed |
+| Next vendor | — | Second EDIWheel manufacturer via configuration (+ codec gaps only) | Validates the reusability goal; target: zero changes outside `adapter/` + profile data |
 
 **Vendor roadmap:** after Michelin, onboard manufacturers in order of market share, favoring vendors that participate in the EDIWheel standard (they reuse existing adapters; non-participants require a new protocol family).
 

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -137,6 +137,7 @@ pos-supplier/
       orchestration/              # retries, outbox, idempotency, sagas
     spi/                          # capability ports adapters implement
       SupplierOrderPort.java
+      SupplierOrderStatusPort.java
       SupplierStockInquiryPort.java
       SupplierStockReportPort.java
       SupplierPriceCatalogPort.java

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -118,7 +118,7 @@ Pre-production policy favors clean, minimal structure. All supplier connectivity
 
 ## 5. Module Layout
 
-New backend module in `durion-positivity-backend`: **`pos-supplier`** (working name; see open question 2). Follows platform layering and ADR-0026 (service package is contract-only interfaces).
+New backend module in `durion-positivity-backend`: **`pos-supplier`** (confirmed; see §12, decision 2). Follows platform layering and ADR-0026 (service package is contract-only interfaces).
 
 ```text
 pos-supplier/

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -1,0 +1,375 @@
+# Supplier Integration Architecture — EDIWheel and Beyond
+
+**Status:** PROPOSED — awaiting review
+**Date:** 2026-08-10
+**Author:** Architecture (drafted from `docs/ediwheel/` source specifications)
+**Scope:** Outbound supplier connectivity for tire manufacturers using the EDIWheel standard (Michelin first), designed for reuse with any parts manufacturer or distributor.
+
+---
+
+## 1. Purpose
+
+Durion needs to talk to the major tire manufacturers — Michelin, Continental, Goodyear, Pirelli, Bridgestone — that expose supplier connectivity through the **EDIWheel** standard (maintained by wdk, `ediwheel.net`). The near-term driver is the Michelin API suite documented in `docs/ediwheel/`.
+
+This document proposes an implementation architecture with three explicit goals:
+
+1. **Reusable modules with swappable endpoint information** — the same order/stock/price/invoice logic must talk to different vendors by changing configuration, not code.
+2. **Reuse beyond EDIWheel** — the same architecture must extend to non-tire parts manufacturers and distributors with proprietary APIs.
+3. **Deployment-level configurability** — every rollout is expected to be custom (different vendors, different capabilities, different credentials, different norm versions), so vendor wiring is data, not code.
+
+A fourth constraint follows from the source specs themselves: **the same business service exists in multiple protocol versions** (EDIWheel norms A2.5, B2.1, B3.3, B4.0, C1.0, C1.1, C1.2), and vendors support different subsets. Multiple versions of the same service must coexist behind one interface.
+
+## 2. Source Documents Reviewed
+
+All files live in [`docs/ediwheel/`](../../ediwheel/).
+
+| Document | Business service | Direction | Norm / version | Wire format | Auth |
+| --- | --- | --- | --- | --- | --- |
+| `EDIWHEEL Order Creation PROD_2 (2).yaml` | Create purchase orders in real time | Durion → vendor | A2.5, C1.0 | XML over HTTPS POST | Basic + API key |
+| `EDIWHEEL Order Status API PROD_1.yaml` | Track order status by date or reference | Durion → vendor | A2.5, C1.0, C1.1 | XML over HTTPS POST | Basic + API key |
+| `Swagger_UPX-Stock Inquiry PROD_1_2.yaml` | Real-time stock availability and quote | Durion → vendor | A2.5, C1.0 | XML over HTTPS POST | Basic + API key |
+| `EDIWHEEL STOCK REPORT PROD_0 (1).yaml` | Snapshot of vendor stock at country level | Durion → vendor | B2.1, C1.0 | JSON / XML GET | Basic + API key |
+| `EDIWheel Price Catalog PROD_0.yaml` | Purchasable products and prices (PRICAT) | Durion → vendor | B4.0 | JSON GET | Basic + API key |
+| `EDIWHEEL Invoice PROD_0.yaml` | Retrieve AR transactions (vendor invoices) | Durion → vendor | B3.3 (B3.4 coming) | XML over HTTPS POST | Basic + API key |
+| `ShipmentTrackingOAS_v1.yaml` | Shipment notice / tracking events (LEX) | Durion → vendor (mock today) | v1 | JSON | Bearer |
+| `MKCAT_API_1.2.0.yaml` | EDIWheel marketing catalog (tread designs, suppliers, images) with change subscription | Durion → ediwheel.net | C1.2 | JSON REST + message-based | per implementation |
+| `ediwheel-workorder-michelin-implementation_1.json` | S2S workorder authorization (fleet contracts, policies, vehicles, approval) | Durion → vendor | Michelin S2S v1/v2 | JSON REST | OAuth2 |
+| `DOT_Spec_R2_Prod_0.yaml` | AI DOT-code recognition from sidewall image | Durion → vendor | v1 | JSON (base64 image) | OAuth2 + API key |
+| `openapi_Prod_v2 (8) (1).yaml` | TireSnap sidewall scanner (tire spec from photo) | Durion → vendor | v1 | multipart JSON | OAuth2 + API key |
+| `EDIWheel-XML_Order_C1.pdf`, `EDIWheel-XML_Order_Response_C1.pdf`, `EDIWHEEL-XML_Order_Status*.pdf` | Message implementation guidelines (element/occurrence definitions) for C1 XML payloads | n/a (spec) | C1, C1.1 | XML | n/a |
+
+Key observations:
+
+- **Everything currently in scope is outbound.** Durion is the API consumer; no spec in the folder requires Durion to host an inbound endpoint. (Open question 7 below covers the possible exception: vendor-initiated fleet workorders.)
+- **Transport is consistent, payloads are not.** All services are HTTPS request/response, but payloads span three generations: A2.x XML (legacy), B-series JSON/XML report-style, C1.x XML (current guideline, defined in the PDFs), and C1.2 JSON (the emerging `ediwheel.net` resource+message API).
+- **Party identification is a first-class config concern.** Every EDIWheel message carries `BuyerParty`/`PartyID`/`AgencyCode` (and often `SellerParty`, `OrderingParty`, `Consignee`) — these are per-deployment, per-vendor account identifiers.
+- **Auth differs per vendor and even per service** within one vendor (Basic + API key for EDIWheel services; OAuth2 client credentials for the S2S workorder and AI services).
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- One canonical, vendor-neutral supplier integration domain inside the Durion backend.
+- Per-capability ports so each vendor can implement any subset (order, stock, price, invoice, shipment, workorder authorization, catalog, tire identification).
+- Multiple protocol versions of the same capability selectable by configuration.
+- Vendor onboarding = new adapter (only if a new wire format) + new configuration profile. Never a change to consuming domains.
+- Full auditability: every outbound exchange persisted with raw payloads, correlation ID, and outcome.
+- Alignment with existing platform policy: ADR-0044 (event-only domain walls), ADR-0026 (service contract boundary), ADR-0013/0027 (UUID identifiers), ADR-0014 (internal service security), ADR-0024 (timestamps), X-Correlation-Id plan.
+
+### Non-Goals
+
+- Building an inbound EDI endpoint (nothing reviewed requires one; revisit if a vendor pushes events to us).
+- Implementing classic EDIFACT/X12 file-based EDI (EDIWheel API flavors are HTTP request/response; batch file EDI would be a new adapter family later).
+- Frontend purchasing UX design (referenced only where the integration surfaces data).
+- Selecting a specific integration middleware product; this is in-platform Spring Boot code.
+
+## 4. Architectural Overview
+
+The design is hexagonal (ports and adapters) with a configuration-driven adapter registry. A single new backend module owns the canonical model and orchestration; protocol adapters translate canonical requests to vendor wire formats; a vendor profile binds each capability to an endpoint, a norm version, and credentials.
+
+```mermaid
+flowchart LR
+    subgraph durion [Durion platform]
+        subgraph consumers [Consuming domains]
+            POSV[pos-positivity<br/>product detail]
+            INV[pos-inventory]
+            CAT[pos-catalog / pos-price]
+            WO[pos-workorder]
+            ACC[pos-accounting / pos-invoice]
+        end
+        subgraph gateway [pos-supplier module]
+            SVC[Supplier services<br/>canonical model + orchestration]
+            REG[Adapter registry<br/>capability x norm x version]
+            PROF[(Vendor profiles<br/>+ endpoint bindings)]
+            AUDIT[(Exchange audit log)]
+            subgraph adapters [Protocol adapters]
+                A25[ediwheel-a25 XML]
+                C1X[ediwheel-c1 XML]
+                BSER[ediwheel-b JSON]
+                MK[ediwheel-json C1.2]
+                S2S[michelin-s2s JSON]
+                CUST[custom-vendor-x]
+            end
+        end
+    end
+    MICH[Michelin APIs]
+    OTH[Other EDIWheel vendors]
+    DIST[Non-EDIWheel distributors]
+    consumers -- events + read API --> SVC
+    SVC --> REG
+    REG --> adapters
+    PROF --> REG
+    SVC --> AUDIT
+    A25 & C1X & BSER --> MICH
+    MK --> OTH
+    S2S --> MICH
+    CUST --> DIST
+```
+
+### 4.1 The three layers
+
+1. **Canonical layer (vendor-neutral).** DTOs and services expressing what Durion means: `SupplierPurchaseOrder`, `SupplierStockInquiry`, `SupplierPriceCatalogEntry`, `SupplierInvoice`, `SupplierShipmentEvent`, `SupplierWorkorderAuthorization`. Consuming domains only ever see this layer. Identifiers follow platform UUID policy; vendor-native references (`SupplierOrderNumber`, `DocumentID`) are carried as attributes, never as primary keys.
+2. **Port (SPI) layer.** One Java interface per capability (§6). Ports are deliberately narrow and asynchronous-friendly. A vendor "supports" a capability if a binding exists for it in its profile — capability discovery is configuration, not reflection.
+3. **Adapter layer.** One adapter per wire-format family, not per vendor. Michelin A2.5 order creation and (hypothetically) Continental A2.5 order creation share the `ediwheel-a25` adapter with different endpoint bindings. A vendor with a proprietary API gets its own adapter implementing the same ports.
+
+### 4.2 Why one module, not one module per vendor
+
+Pre-production policy favors clean, minimal structure. All supplier connectivity lives in a single deployable, `pos-supplier`, with adapters as internal packages structured for later extraction into libraries if adapter count or team ownership demands it. This keeps the blast radius of vendor onboarding inside one module and avoids premature microservice sprawl. The package layout (§5) enforces the seams that would make extraction mechanical.
+
+## 5. Module Layout
+
+New backend module in `durion-positivity-backend`: **`pos-supplier`** (working name; see open question 2). Follows platform layering and ADR-0026 (service package is contract-only interfaces).
+
+```text
+pos-supplier/
+  src/main/java/com/positivity/supplier/
+    service/                      # contract-only interfaces (ADR-0026)
+      SupplierOrderService.java
+      SupplierStockService.java
+      SupplierPriceCatalogService.java
+      SupplierInvoiceService.java
+      SupplierShipmentService.java
+      SupplierWorkorderAuthorizationService.java
+      SupplierCatalogService.java         # MKCAT marketing catalog
+      SupplierProfileAdminService.java
+    domain/                       # canonical model + orchestration
+      model/                      # canonical DTOs and entities
+      orchestration/              # retries, outbox, idempotency, sagas
+    spi/                          # capability ports adapters implement
+      SupplierOrderPort.java
+      SupplierStockInquiryPort.java
+      SupplierStockReportPort.java
+      SupplierPriceCatalogPort.java
+      SupplierInvoicePort.java
+      SupplierShipmentTrackingPort.java
+      SupplierWorkorderAuthorizationPort.java
+      SupplierCatalogPort.java
+      TireIdentificationPort.java         # DOT / sidewall AI (optional)
+    registry/                     # AdapterRegistry, VendorProfileResolver
+    config/                       # profile loading, secret resolution
+    adapter/
+      ediwheel/
+        a25/                      # A2.5 XML codecs + client
+        c1/                       # C1.0 / C1.1 XML codecs + client
+        bseries/                  # B2.1 / B3.3 / B4.0 codecs + client
+        json/                     # C1.2 JSON (ediwheel.net MKCAT style)
+      michelin/
+        s2s/                      # S2S workorder authorization JSON
+        airecognition/            # DOT + TireSnap (optional capability)
+    web/                          # admin/read controllers (profiles, audit)
+    events/                       # published event contracts
+    persistence/                  # profiles, bindings, exchange audit, outbox
+```
+
+Rules:
+
+- `adapter/**` may depend on `spi` and `domain/model`, never the reverse.
+- Consuming modules depend only on `com.positivity.supplier.service..` per ADR-0026, and preferentially on **events** per ADR-0044 (§8).
+- Codecs (XML/JSON binding classes generated or hand-written from the C1 PDFs and OpenAPI schemas) live entirely inside their adapter package; canonical DTOs never expose wire types.
+
+## 6. Capability Ports and Version Strategy
+
+### 6.1 Port catalog
+
+| Port | Canonical operation(s) | EDIWheel service(s) covered | Michelin implementation today |
+| --- | --- | --- | --- |
+| `SupplierOrderPort` | `createOrder`, `parseOrderResponse` | Order (A2.5, C1.0) | `POST /order/A2_5/create`, `POST /order/C1_0/create` |
+| `SupplierOrderStatusPort` | `queryOrderStatus` | Order Status (A2.5, C1.0, C1.1) | `POST /order/{norm}/status` |
+| `SupplierStockInquiryPort` | `inquireAvailability` (real-time, quote) | Stock Inquiry / UPX (A2.5, C1.0) | `POST /stock/{norm}/inquiry` |
+| `SupplierStockReportPort` | `fetchStockSnapshot` | Stock Report (B2.1, C1.0) | `GET /stock/B2_1/report` |
+| `SupplierPriceCatalogPort` | `fetchPriceCatalog` | PRICAT (B4.0) | `GET /catalog/B4_0/pricat` |
+| `SupplierInvoicePort` | `fetchInvoices` | Invoice (B3.3, B3.4 future) | `POST /invoice/B3_3/invoices` |
+| `SupplierShipmentTrackingPort` | `sendShipmentEvents` / `fetchTracking` | Shipment tracking (LEX v1) | `POST /shipment-tracking` |
+| `SupplierWorkorderAuthorizationPort` | `requestAuthorization`, `approveCompletion`, `getVehicle`, `getContracts`, `getPolicies` | Michelin S2S (not an EDIWheel norm) | `POST /api/v1/workOrders`, `PATCH /api/v1/workOrders/{id}/approve`, `GET vehicles/contracts/policies` |
+| `SupplierCatalogPort` | `fetchMarketingCatalog`, `subscribeChanges` | MKCAT (C1.2 JSON) | `ediwheel.net` API |
+| `TireIdentificationPort` | `recognizeDotCode`, `recognizeSidewall` | n/a (vendor value-add AI) | DOT Image Recognition, TireSnap |
+
+Ports accept a `SupplierRef` (the vendor profile key) plus canonical request objects; they return canonical responses plus an `ExchangeMetadata` (correlation ID, norm used, raw-payload audit reference).
+
+### 6.2 Multiple versions of one service
+
+The registry resolves an implementation by `(capability, protocolFamily, version)`:
+
+- Each adapter registers codec implementations, e.g. `EdiwheelOrderCodec` for `A2_5`, `C1_0`; `EdiwheelOrderStatusCodec` for `A2_5`, `C1_0`, `C1_1`.
+- The vendor profile's endpoint binding names the version to use (§7). Switching Michelin order status from C1.0 to C1.1 is a one-line configuration change.
+- New norm version = new codec class in the existing adapter, registered under the new version key. Canonical model changes only when the *business* capability grows, and codec for older norms simply ignores fields they cannot express (recorded in the exchange audit as `unmappedFields` for diagnosis).
+- Version-specific request/response quirks (e.g. C1.1 adds `Geolocation` to `Consignee`, `ErrorHead` structures) stay inside the codec.
+
+This is the mechanism that satisfies "multiple versions of the same services depending on the vendor" — versioning is a registry key, not a class-hierarchy fork of business logic.
+
+## 7. Vendor Profile and Configuration Model
+
+The unit of deployment customization is the **vendor profile**: one per supplier account per environment. Profiles are persisted (DB-backed, admin API + UI later) with an initial bootstrap path from YAML for the first deployments. Secrets are always indirect references resolved from the environment/secret store — never stored in profile rows or YAML (platform secrets rule).
+
+```yaml
+supplier:
+  profiles:
+    - key: michelin-eu            # SupplierRef used by ports
+      displayName: "Michelin Europe"
+      protocolDefaults:
+        family: EDIWHEEL
+        connectTimeoutMs: 5000
+        readTimeoutMs: 30000
+        retry: { maxAttempts: 3, backoff: EXPONENTIAL }
+      party:                       # EDIWheel party identification
+        buyerPartyId: "0000012345"
+        buyerAgencyCode: "31"      # e.g. EAN/GLN agency
+        sellerPartyId: "MICHELIN"
+        sellerAgencyCode: "91"
+      auth:
+        - name: ediwheel-basic
+          type: BASIC_PLUS_APIKEY
+          usernameRef: env:MICHELIN_EDI_USER      # secret indirection
+          passwordRef: env:MICHELIN_EDI_PASSWORD
+          apiKeyHeader: apikey
+          apiKeyRef: env:MICHELIN_EDI_APIKEY
+        - name: s2s-oauth
+          type: OAUTH2_CLIENT_CREDENTIALS
+          tokenUrlRef: env:MICHELIN_S2S_TOKEN_URL
+          clientIdRef: env:MICHELIN_S2S_CLIENT_ID
+          clientSecretRef: env:MICHELIN_S2S_CLIENT_SECRET
+      bindings:                    # capability -> endpoint + version + auth
+        - capability: ORDER_CREATE
+          version: C1_0
+          baseUrl: https://api.michelin.com/order
+          path: /C1_0/create
+          auth: ediwheel-basic
+        - capability: ORDER_STATUS
+          version: C1_1
+          baseUrl: https://api.michelin.com/order
+          path: /C1_1/status
+          auth: ediwheel-basic
+        - capability: STOCK_INQUIRY
+          version: A2_5
+          baseUrl: https://api.michelin.com/stock
+          path: /A2_5/inquiry
+          auth: ediwheel-basic
+        - capability: PRICE_CATALOG
+          version: B4_0
+          baseUrl: https://api.michelin.com
+          path: /catalog/B4_0/pricat
+          auth: ediwheel-basic
+          schedule: "0 0 4 * * *"          # nightly PRICAT sync
+        - capability: INVOICE_FETCH
+          version: B3_3
+          baseUrl: https://api.michelin.com/invoice
+          path: /B3_3/invoices
+          auth: ediwheel-basic
+          schedule: "0 0 5 * * *"
+        - capability: WORKORDER_AUTHORIZATION
+          version: S2S_V1
+          baseUrl: https://<michelin-s2s-host>
+          path: /api/v1
+          auth: s2s-oauth
+      sandbox:                     # environment overlay
+        baseUrlOverride: https://sandbox.api.michelin.com
+```
+
+Design points:
+
+- **Absent binding = capability disabled** for that vendor in that deployment. The canonical services surface this as an explicit `CAPABILITY_NOT_CONFIGURED` status so callers (and the UI) can degrade gracefully, mirroring the positivity component-status pattern (DECISION-POSITIVITY-004/011).
+- **One vendor, many profiles** is legal (e.g. Michelin EU vs Michelin NA accounts, or two buyer accounts for two store groups).
+- **Per-binding schedules** drive the batch capabilities (PRICAT, invoice fetch, stock report) from the orchestration layer's scheduler; real-time capabilities (stock inquiry, order create/status) are request-driven.
+- **Environment overlays** (sandbox vs production URLs, present in every Michelin spec) are part of the profile so promotion between environments is configuration-only, matching the tenant-cell deployment direction.
+- Profile changes are audited (who, when, what) via the standard audit fields policy (ADR-0018/0024).
+
+## 8. Integration with Durion Domains (ADR-0044 Alignment)
+
+`pos-supplier` is a **domain module**, so cross-module interaction is event-first:
+
+| Flow | Mechanism | Notes |
+| --- | --- | --- |
+| PRICAT sync results | `supplier.pricecatalog.updated.v1` event; pos-catalog / pos-price consume and upsert supplier cost/eligibility data | Batch, scheduled per binding |
+| Stock report snapshots | `supplier.stockreport.updated.v1`; pos-inventory consumes for supplier ATP hints | Batch |
+| Order lifecycle | Commands in, results out: consuming domain (purchasing flow) emits `supplier.order.requested.v1`; pos-supplier executes and emits `supplier.order.confirmed.v1` / `supplier.order.rejected.v1` / `supplier.orderstatus.changed.v1` | Command events with result events and pending states, per ADR-0044 |
+| Vendor invoices | `supplier.invoice.received.v1`; accounting consumes for AP reconciliation | Batch |
+| Shipment tracking | `supplier.shipment.event.v1`; consumers: purchasing/receiving flows | |
+| Workorder authorization | Workorder flow emits request command; pos-supplier calls S2S API and emits `supplier.workorderauth.granted.v1` / `.denied.v1`; completion approval triggered by workorder completion events | Keeps `workexec` authority over workorder state |
+| Real-time stock inquiry | **Synchronous read exception**: positivity product-detail composition may call `SupplierStockService` directly for live availability/quote, with the standard degradation semantics (component status, null numerics, `asOf`) | Needs ADR-0044 utility-read exception approval — see open question 5 |
+
+The real-time stock inquiry is the one place where event-only communication fights the use case (a counter user wants live vendor availability while quoting). The proposal is to treat `pos-supplier`'s read side like the existing utility-module reads, wrapped in the positivity degradation contract: timeouts are short, failure degrades to `SUPPLIER_UNAVAILABLE` status, and no numeric field is fabricated.
+
+## 9. Cross-Cutting Concerns
+
+### 9.1 Resilience and idempotency
+
+- Every outbound exchange carries a correlation ID (X-Correlation-Id plan) and a deterministic client reference (`CustomerReference` / `DocumentID` in EDIWheel messages) derived from the canonical entity UUID, so vendor-side deduplication works across retries.
+- Order creation is **exactly-once-intent**: an outbox row is written in the same transaction as the canonical order intent; the dispatcher retries with the same `DocumentID`; a confirmed/rejected result is idempotently applied. Never auto-retry an order create after an ambiguous timeout without first querying order status — duplicate physical orders are the top operational risk in supplier EDI.
+- Circuit breakers per vendor binding; breaker state exposed as a health indicator and in the admin UI.
+- Batch capabilities are checkpointed (last successful window per binding) so a missed night self-heals on the next run.
+
+### 9.2 Audit and observability
+
+- Persist every exchange: profile key, capability, version, endpoint, correlation ID, timing, HTTP outcome, and raw request/response payloads (with credential headers redacted). EDI disputes ("you never sent that order") are settled with raw payloads, not logs.
+- Metrics per (vendor, capability, version): request rate, error rate, latency, breaker state, batch lag. Degradation is metrics/log-tracked, not evented (DECISION-POSITIVITY-015).
+
+### 9.3 Security
+
+- All credentials via secret store / environment indirection (`*Ref` fields); no secrets in code, profiles, or YAML committed to git.
+- Outbound egress to vendor hosts must be allowed by the deployment network policy; document required hosts per profile as part of onboarding.
+- Admin APIs for profiles are permission-gated (deny-by-default, ADR-0040 governance); raw-payload audit access is a distinct, tighter permission because payloads contain commercial terms.
+- Internal service boundary and gateway rules per ADR-0011/0014 apply unchanged; `pos-supplier` exposes no public endpoint.
+
+### 9.4 Contract chain
+
+Admin/read controllers in `pos-supplier` follow the standard controller contract chain: OpenAPI annotations → regenerate `OpenAPI.yaml` → regenerate the Angular SDK.
+
+## 10. Reuse Beyond EDIWheel
+
+The canonical ports are format-agnostic, so a non-EDIWheel distributor (e.g. a national parts distributor with a proprietary JSON API, or a punch-out/cXML supplier) is onboarded by:
+
+1. Writing one adapter package under `adapter/<vendor-or-family>/` implementing whichever ports the vendor supports.
+2. Registering its codecs under a new `protocolFamily` (e.g. `CUSTOM_ACME`, `CXML`).
+3. Adding a vendor profile with bindings pointing at that family.
+
+Nothing in `domain/`, `service/`, `events/`, or any consuming module changes. The Michelin S2S workorder adapter is the proof case already in scope: it is *not* an EDIWheel norm, yet it slots in as just another protocol family behind `SupplierWorkorderAuthorizationPort`.
+
+The AI services (DOT recognition, TireSnap) follow the same pattern behind `TireIdentificationPort` and can be treated as an optional, independently phased capability — they are vendor value-adds, not supply-chain primitives.
+
+## 11. Suggested Phasing
+
+| Phase | Deliverable | Rationale |
+| --- | --- | --- |
+| 1 | `pos-supplier` skeleton: canonical model, profiles/bindings, registry, exchange audit, admin API. Michelin **Price Catalog (B4.0)** + **Stock Inquiry (A2.5)** | Read-only, low-risk capabilities that immediately enrich quoting; proves profile + adapter + version machinery end to end |
+| 2 | **Order Create + Order Status** (C1.0 create, C1.1 status), outbox and idempotency machinery, purchasing events | The commercial core; needs Phase 1 plumbing hardened first |
+| 3 | **Invoice fetch (B3.3)**, **Stock Report (B2.1)**, **Shipment tracking**, accounting/receiving event consumers | Back-office reconciliation |
+| 4 | **S2S workorder authorization** (fleet flows), second protocol family in production | Exercises the non-EDIWheel reuse claim |
+| 5 | MKCAT marketing catalog, DOT / TireSnap AI capabilities | Optional enrichment |
+| Next vendor | Second EDIWheel manufacturer via configuration (+ codec gaps only) | Validates the reusability goal; target: zero changes outside `adapter/` + profile data |
+
+Each phase should land with provider contract tests per adapter codec (golden-file XML/JSON fixtures derived from the specs and C1 PDFs) and a sandbox smoke suite runnable against vendor sandbox URLs.
+
+## 12. Open Questions
+
+Answers to these will be folded into this document and, where binding, promoted into ADRs (§13).
+
+1. **Vendor roadmap.** Michelin is clearly first. Which manufacturer is expected second (Continental, Goodyear, Pirelli, Bridgestone?), and do we hold their spec packs? This determines how soon the C1.2 JSON (`ediwheel.net`) adapter matters versus the Michelin-style A2.5/B/C1 XML family.
+2. **Module name and home.** Is `pos-supplier` acceptable, or is this scoped under an existing module (e.g. extend `pos-order` for purchasing)? Recommendation: new module — supplier connectivity has its own lifecycle, credentials, and audit surface.
+3. **Purchasing ownership.** Which domain owns the purchase-order aggregate that triggers `SupplierOrderPort` — `pos-order`, `pos-inventory` (replenishment), or new purchasing scope inside `pos-supplier`? The proposal assumes the *trigger* lives outside `pos-supplier` and only transmission state lives inside; confirm.
+4. **Real-time stock inquiry UX.** Should live vendor availability appear in the positivity Product Detail composition (as an additional degradable component), in a dedicated procurement screen, or both? Affects the utility-read exception below.
+5. **ADR-0044 exception.** Approve the synchronous read path from positivity composition to `SupplierStockService` (mirroring the existing utility-read set), or must live availability also be event-mediated (pre-fetched/cached)?
+6. **Multi-account topology.** Do deployments need multiple buyer accounts per vendor (per store group / legal entity)? The profile model supports it; confirm whether binding selection needs to be location-aware at call time.
+7. **Inbound flows.** The Michelin S2S workorder spec is modeled here as Durion-initiated. Is there a contract variant where Michelin (fleet manager) *pushes* workorders to the service provider, requiring Durion to host an inbound endpoint? If yes, an inbound receiver component must be added to the design.
+8. **Invoice destination.** Should fetched vendor invoices (B3.3) flow into `pos-accounting` as AP vouchers, or is a lighter reconciliation report sufficient for the first deployments?
+9. **PRICAT merge policy.** When vendor PRICAT data overlaps `pos-catalog`/`pos-price` records, what wins, and is supplier cost data location-scoped? Needs a decision with the Product/Pricing domain owners before Phase 1 lands.
+10. **AI capabilities in scope?** DOT recognition and TireSnap are in the spec folder but are not supply-chain services. Include in the roadmap (Phase 5) or park them?
+
+## 13. ADR Candidates
+
+Once the open questions are settled, the following should be captured as ADRs:
+
+- Supplier integration module boundary, canonical model ownership, and event contract set (extends ADR-0044 matrix).
+- Vendor profile / endpoint binding configuration model and secret-indirection rules.
+- Protocol adapter and codec versioning policy (registry keys, coexistence of norm versions, unmapped-field handling).
+- Outbound idempotency and duplicate-order prevention policy (no blind retry of ambiguous order creates).
+
+---
+
+## References
+
+- Source specifications: [`docs/ediwheel/`](../../ediwheel/)
+- EDIWheel standard body: `https://ediwheel.net`
+- Positivity domain rules: [`domains/positivity/.business-rules/AGENT_GUIDE.md`](../../../domains/positivity/.business-rules/AGENT_GUIDE.md)
+- ADR-0044 Event-Only Domain Walls: [`docs/adr/0044-platform-event-only-domain-walls.adr.md`](../../adr/0044-platform-event-only-domain-walls.adr.md)
+- ADR-0026 Service Contract Boundary: [`docs/adr/0026-service-contract-boundary-policy.adr.md`](../../adr/0026-service-contract-boundary-policy.adr.md)
+- Backend contract standards: [`docs/architecture/api/BACKEND_CONTRACT_GLOBAL_STANDARDS.md`](../api/BACKEND_CONTRACT_GLOBAL_STANDARDS.md)

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Supplier Integration Architecture — EDIWheel and Beyond
 
-**Status:** PROPOSED — awaiting review
+**Status:** ACCEPTED DIRECTION — open questions resolved 2026-08-10 (see §12)
 **Date:** 2026-08-10
 **Author:** Architecture (drafted from `docs/ediwheel/` source specifications)
 **Scope:** Outbound supplier connectivity for tire manufacturers using the EDIWheel standard (Michelin first), designed for reuse with any parts manufacturer or distributor.
@@ -40,7 +40,7 @@ All files live in [`docs/ediwheel/`](../../ediwheel/).
 
 Key observations:
 
-- **Everything currently in scope is outbound.** Durion is the API consumer; no spec in the folder requires Durion to host an inbound endpoint. (Open question 7 below covers the possible exception: vendor-initiated fleet workorders.)
+- **Everything currently in scope is outbound.** Durion is the API consumer; no spec in the folder requires Durion to host an inbound endpoint. Confirmed: workorders are always initiated in the service provider's system. Vendors may push appointment requests, but that is outside current scope (§12, decision 7).
 - **Transport is consistent, payloads are not.** All services are HTTPS request/response, but payloads span three generations: A2.x XML (legacy), B-series JSON/XML report-style, C1.x XML (current guideline, defined in the PDFs), and C1.2 JSON (the emerging `ediwheel.net` resource+message API).
 - **Party identification is a first-class config concern.** Every EDIWheel message carries `BuyerParty`/`PartyID`/`AgencyCode` (and often `SellerParty`, `OrderingParty`, `Consignee`) — these are per-deployment, per-vendor account identifiers.
 - **Auth differs per vendor and even per service** within one vendor (Basic + API key for EDIWheel services; OAuth2 client credentials for the S2S workorder and AI services).
@@ -184,7 +184,9 @@ Rules:
 | `SupplierCatalogPort` | `fetchMarketingCatalog`, `subscribeChanges` | MKCAT (C1.2 JSON) | `ediwheel.net` API |
 | `TireIdentificationPort` | `recognizeDotCode`, `recognizeSidewall` | n/a (vendor value-add AI) | DOT Image Recognition, TireSnap |
 
-Ports accept a `SupplierRef` (the vendor profile key) plus canonical request objects; they return canonical responses plus an `ExchangeMetadata` (correlation ID, norm used, raw-payload audit reference).
+Ports accept a `SupplierRef` (the vendor profile key), a `PartyContext` (billing account plus delivery location, resolved through the profile's account mappings — §7), and canonical request objects; they return canonical responses plus an `ExchangeMetadata` (correlation ID, norm used, raw-payload audit reference).
+
+`TireIdentificationPort` is a **placeholder** in the initial build: DOT scanning is expected to be required by most service providers, so the port and registry slot are defined up front, but no adapter is implemented until the requirement is confirmed (§12, decision 10).
 
 ### 6.2 Multiple versions of one service
 
@@ -211,9 +213,17 @@ supplier:
         connectTimeoutMs: 5000
         readTimeoutMs: 30000
         retry: { maxAttempts: 3, backoff: EXPONENTIAL }
-      party:                       # EDIWheel party identification
-        buyerPartyId: "0000012345"
-        buyerAgencyCode: "31"      # e.g. EAN/GLN agency
+      accounts:                    # commercial account numbers (credentials live in auth)
+        billing:                   # invoicing/settlement account (legal entity
+          accountNumber: "0000012345"      # level, shared across locations)
+          agencyCode: "31"         # e.g. EAN/GLN agency
+        delivery:                  # Durion location -> delivery account number
+          - locationId: 018f6b2e-...-uuid   # pos-location UUID
+            accountNumber: "0000067890"
+            agencyCode: "31"
+          - locationId: 018f6b2e-...-uuid2
+            accountNumber: "0000067891"
+            agencyCode: "31"
         sellerPartyId: "MICHELIN"
         sellerAgencyCode: "91"
       auth:
@@ -269,6 +279,9 @@ Design points:
 
 - **Absent binding = capability disabled** for that vendor in that deployment. The canonical services surface this as an explicit `CAPABILITY_NOT_CONFIGURED` status so callers (and the UI) can degrade gracefully, mirroring the positivity component-status pattern (DECISION-POSITIVITY-004/011).
 - **One vendor, many profiles** is legal (e.g. Michelin EU vs Michelin NA accounts, or two buyer accounts for two store groups).
+- **Credentials and account numbers are separate concerns.** A vendor account has one set of API credentials (userid/password, held in `auth` and shared across the legal entity) and **two account numbers per transaction**: a **billing account number** (invoicing/settlement) and a **delivery account number** (where goods ship). Credentials authenticate the call; the account numbers identify the commercial parties inside the message.
+- **Account roles are canonical; field names are vendor-specific.** The canonical model uses the generic roles *billing* and *delivery*; each adapter maps them onto its vendor's terminology — `billTo`/`shipTo` in the Michelin APIs, `BuyerParty`/`Consignee` in EDIWheel XML norms, whatever a future distributor calls them. Vendor vocabulary never leaks into the canonical layer or the profile schema.
+- **Account resolution is location-aware.** The billing account number is typically fixed per profile (legal entity); the delivery account number varies by location. The profile maps Durion `pos-location` UUIDs to vendor delivery account numbers; callers pass the delivery location in the `PartyContext` and the adapter stamps the correct vendor identities into the wire message. A missing delivery mapping for the requested location is a configuration error surfaced before any network call.
 - **Per-binding schedules** drive the batch capabilities (PRICAT, invoice fetch, stock report) from the orchestration layer's scheduler; real-time capabilities (stock inquiry, order create/status) are request-driven.
 - **Environment overlays** (sandbox vs production URLs, present in every Michelin spec) are part of the profile so promotion between environments is configuration-only, matching the tenant-cell deployment direction.
 - Profile changes are audited (who, when, what) via the standard audit fields policy (ADR-0018/0024).
@@ -279,15 +292,21 @@ Design points:
 
 | Flow | Mechanism | Notes |
 | --- | --- | --- |
-| PRICAT sync results | `supplier.pricecatalog.updated.v1` event; pos-catalog / pos-price consume and upsert supplier cost/eligibility data | Batch, scheduled per binding |
+| PRICAT sync results | `supplier.pricecatalog.updated.v1` event; pos-catalog / pos-price consume and upsert supplier cost/eligibility data | Batch, scheduled per binding; dating and precedence rules in §8.1 |
 | Stock report snapshots | `supplier.stockreport.updated.v1`; pos-inventory consumes for supplier ATP hints | Batch |
-| Order lifecycle | Commands in, results out: consuming domain (purchasing flow) emits `supplier.order.requested.v1`; pos-supplier executes and emits `supplier.order.confirmed.v1` / `supplier.order.rejected.v1` / `supplier.orderstatus.changed.v1` | Command events with result events and pending states, per ADR-0044 |
-| Vendor invoices | `supplier.invoice.received.v1`; accounting consumes for AP reconciliation | Batch |
+| Order lifecycle | Commands in, results out: **pos-order** (purchase-order aggregate owner) emits `supplier.order.requested.v1`; pos-supplier executes and emits `supplier.order.confirmed.v1` / `supplier.order.rejected.v1` / `supplier.orderstatus.changed.v1` | Command events with result events and pending states, per ADR-0044 |
+| Vendor invoices | `supplier.invoice.received.v1`; **pos-accounting** consumes and creates AP vouchers | Batch |
 | Shipment tracking | `supplier.shipment.event.v1`; consumers: purchasing/receiving flows | |
 | Workorder authorization | Workorder flow emits request command; pos-supplier calls S2S API and emits `supplier.workorderauth.granted.v1` / `.denied.v1`; completion approval triggered by workorder completion events | Keeps `workexec` authority over workorder state |
-| Real-time stock inquiry | **Synchronous read exception**: positivity product-detail composition may call `SupplierStockService` directly for live availability/quote, with the standard degradation semantics (component status, null numerics, `asOf`) | Needs ADR-0044 utility-read exception approval — see open question 5 |
+| Real-time stock inquiry | **Synchronous read exception (approved)**: positivity product-detail composition **and pos-order procurement flows** may call `SupplierStockService` directly for live availability/quote, with the standard degradation semantics (component status, null numerics, `asOf`) | Approved 2026-08-10 (§12, decisions 4–5); to be ratified as an ADR-0044 amendment |
 
-The real-time stock inquiry is the one place where event-only communication fights the use case (a counter user wants live vendor availability while quoting). The proposal is to treat `pos-supplier`'s read side like the existing utility-module reads, wrapped in the positivity degradation contract: timeouts are short, failure degrades to `SUPPLIER_UNAVAILABLE` status, and no numeric field is fabricated.
+The real-time stock inquiry is the one place where event-only communication fights the use case (a counter user wants live vendor availability while quoting or raising a purchase order). `pos-supplier`'s read side is treated like the existing utility-module reads, wrapped in the positivity degradation contract: timeouts are short, failure degrades to `SUPPLIER_UNAVAILABLE` status, and no numeric field is fabricated. Live vendor availability surfaces in **both** the Product Detail composition (as an additional degradable component) and the pos-order procurement screens.
+
+### 8.1 PRICAT dating and price precedence
+
+- Every ingested PRICAT entry is stamped with the vendor's effective date and Durion's fetch timestamp; "latest" is always decidable, and superseded entries are retained for audit and cost-history queries.
+- **Vendor prices never override service-provider or location-specific prices.** PRICAT data enters the platform as supplier cost / list-price *input* to the pricing domain; sell-price authority remains with pos-price and its location-scoped rules.
+- The detailed pricing data model and how PRICAT feeds it (cost layers, effective-dating, location scoping) requires further investigation with the Pricing domain owners — tracked in [durion#371](https://github.com/louisburroughs/durion/issues/371) and a precondition for the Phase 1 PRICAT consumer landing in pos-price.
 
 ## 9. Cross-Cutting Concerns
 
@@ -334,34 +353,38 @@ The AI services (DOT recognition, TireSnap) follow the same pattern behind `Tire
 | 2 | **Order Create + Order Status** (C1.0 create, C1.1 status), outbox and idempotency machinery, purchasing events | The commercial core; needs Phase 1 plumbing hardened first |
 | 3 | **Invoice fetch (B3.3)**, **Stock Report (B2.1)**, **Shipment tracking**, accounting/receiving event consumers | Back-office reconciliation |
 | 4 | **S2S workorder authorization** (fleet flows), second protocol family in production | Exercises the non-EDIWheel reuse claim |
-| 5 | MKCAT marketing catalog, DOT / TireSnap AI capabilities | Optional enrichment |
+| 5 | MKCAT marketing catalog; DOT / TireSnap scanning behind the `TireIdentificationPort` placeholder | DOT scanning is expected to be required by most service providers — port defined up front, adapter implemented once confirmed |
 | Next vendor | Second EDIWheel manufacturer via configuration (+ codec gaps only) | Validates the reusability goal; target: zero changes outside `adapter/` + profile data |
+
+**Vendor roadmap:** after Michelin, onboard manufacturers in order of market share, favoring vendors that participate in the EDIWheel standard (they reuse existing adapters; non-participants require a new protocol family).
 
 Each phase should land with provider contract tests per adapter codec (golden-file XML/JSON fixtures derived from the specs and C1 PDFs) and a sandbox smoke suite runnable against vendor sandbox URLs.
 
-## 12. Open Questions
+## 12. Resolved Decisions (2026-08-10)
 
-Answers to these will be folded into this document and, where binding, promoted into ADRs (§13).
+The original open questions were reviewed and resolved as follows. Where binding, they will be promoted into ADRs (§13).
 
-1. **Vendor roadmap.** Michelin is clearly first. Which manufacturer is expected second (Continental, Goodyear, Pirelli, Bridgestone?), and do we hold their spec packs? This determines how soon the C1.2 JSON (`ediwheel.net`) adapter matters versus the Michelin-style A2.5/B/C1 XML family.
-2. **Module name and home.** Is `pos-supplier` acceptable, or is this scoped under an existing module (e.g. extend `pos-order` for purchasing)? Recommendation: new module — supplier connectivity has its own lifecycle, credentials, and audit surface.
-3. **Purchasing ownership.** Which domain owns the purchase-order aggregate that triggers `SupplierOrderPort` — `pos-order`, `pos-inventory` (replenishment), or new purchasing scope inside `pos-supplier`? The proposal assumes the *trigger* lives outside `pos-supplier` and only transmission state lives inside; confirm.
-4. **Real-time stock inquiry UX.** Should live vendor availability appear in the positivity Product Detail composition (as an additional degradable component), in a dedicated procurement screen, or both? Affects the utility-read exception below.
-5. **ADR-0044 exception.** Approve the synchronous read path from positivity composition to `SupplierStockService` (mirroring the existing utility-read set), or must live availability also be event-mediated (pre-fetched/cached)?
-6. **Multi-account topology.** Do deployments need multiple buyer accounts per vendor (per store group / legal entity)? The profile model supports it; confirm whether binding selection needs to be location-aware at call time.
-7. **Inbound flows.** The Michelin S2S workorder spec is modeled here as Durion-initiated. Is there a contract variant where Michelin (fleet manager) *pushes* workorders to the service provider, requiring Durion to host an inbound endpoint? If yes, an inbound receiver component must be added to the design.
-8. **Invoice destination.** Should fetched vendor invoices (B3.3) flow into `pos-accounting` as AP vouchers, or is a lighter reconciliation report sufficient for the first deployments?
-9. **PRICAT merge policy.** When vendor PRICAT data overlaps `pos-catalog`/`pos-price` records, what wins, and is supplier cost data location-scoped? Needs a decision with the Product/Pricing domain owners before Phase 1 lands.
-10. **AI capabilities in scope?** DOT recognition and TireSnap are in the spec folder but are not supply-chain services. Include in the roadmap (Phase 5) or park them?
+1. **Vendor roadmap.** After Michelin, implement manufacturers in order of market share, favoring vendors that participate in the EDIWheel standard.
+2. **Module name.** `pos-supplier` is confirmed as the module name and home.
+3. **Purchasing ownership.** `pos-order` owns the purchase-order aggregate that triggers `SupplierOrderPort`; `pos-supplier` holds only transmission state.
+4. **Real-time stock inquiry UX.** Live vendor stock appears in **both** the positivity Product Detail composition and the pos-order procurement flows.
+5. **ADR-0044 exception.** The synchronous read path to `SupplierStockService` is **approved** (to be ratified as an ADR-0044 amendment).
+6. **Account topology.** Accounts may be shared within a legal entity. Each vendor account has one set of API credentials (userid/password); each order carries **two account numbers, modeled generically as billing and delivery** (Michelin calls them billTo/shipTo). Delivery account numbers are mapped per Durion location in the vendor profile (§7).
+7. **Inbound flows.** None. Workorders are always initiated in the service provider's system. Vendors may push *appointment requests*, but that is explicitly outside current scope.
+8. **Invoice destination.** Fetched vendor invoices (B3.3) become **AP vouchers in pos-accounting**.
+9. **PRICAT policy.** PRICAT data is effective-dated so the latest is always decidable; vendor prices never override service-provider or location-specific prices (§8.1). The deeper investigation of the pricing data model and PRICAT integration is tracked in [durion#371](https://github.com/louisburroughs/durion/issues/371).
+10. **Scanning.** `TireIdentificationPort` stays as a **placeholder** — DOT scanning is likely required for most service providers but is not yet confirmed; no adapter is built until it is.
 
 ## 13. ADR Candidates
 
-Once the open questions are settled, the following should be captured as ADRs:
+With the §12 decisions in place, the following should be captured as ADRs:
 
 - Supplier integration module boundary, canonical model ownership, and event contract set (extends ADR-0044 matrix).
-- Vendor profile / endpoint binding configuration model and secret-indirection rules.
+- **ADR-0044 amendment**: synchronous supplier stock-inquiry read exception for positivity composition and pos-order procurement (§12, decision 5).
+- Vendor profile / endpoint binding configuration model, credential vs account-number separation, and secret-indirection rules.
 - Protocol adapter and codec versioning policy (registry keys, coexistence of norm versions, unmapped-field handling).
 - Outbound idempotency and duplicate-order prevention policy (no blind retry of ambiguous order creates).
+- PRICAT ingestion, effective-dating, and price-precedence policy (after the pricing-data investigation task concludes).
 
 ---
 

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -380,16 +380,17 @@ The original open questions were reviewed and resolved as follows. Where binding
 9. **PRICAT policy.** PRICAT data is effective-dated so the latest is always decidable; vendor prices never override service-provider or location-specific prices (§8.1). The deeper investigation of the pricing data model and PRICAT integration is tracked in [durion#371](https://github.com/louisburroughs/durion/issues/371).
 10. **Scanning.** `TireIdentificationPort` stays as a **placeholder** — DOT scanning is likely required for most service providers but is not yet confirmed; no adapter is built until it is.
 
-## 13. ADR Candidates
+## 13. ADRs
 
-With the §12 decisions in place, the following should be captured as ADRs:
+Drafted 2026-08-10 (PROPOSED status pending review):
 
-- Supplier integration module boundary, canonical model ownership, and event contract set (extends ADR-0044 matrix).
-- **ADR-0044 amendment**: synchronous supplier stock-inquiry read exception for positivity composition and pos-order procurement (§12, decision 5).
-- Vendor profile / endpoint binding configuration model, credential vs account-number separation, and secret-indirection rules.
-- Protocol adapter and codec versioning policy (registry keys, coexistence of norm versions, unmapped-field handling).
-- Outbound idempotency and duplicate-order prevention policy (no blind retry of ambiguous order creates).
-- PRICAT ingestion, effective-dating, and price-precedence policy (after the pricing-data investigation task concludes).
+- [ADR-0049 — Supplier integration module boundary and event contracts](../../adr/0049-supplier-integration-module-boundary.adr.md)
+- **ADR-0044 amendment (2026-08-10)** — synchronous supplier stock-inquiry read exception for positivity composition and pos-order procurement ([ADR-0044 §Amendments](../../adr/0044-platform-event-only-domain-walls.adr.md))
+- [ADR-0050 — Supplier vendor profile configuration model](../../adr/0050-supplier-vendor-profile-configuration.adr.md) (bindings, billing/delivery account roles, secret indirection)
+- [ADR-0051 — Supplier protocol adapter and codec versioning policy](../../adr/0051-supplier-protocol-adapter-versioning.adr.md)
+- [ADR-0052 — Supplier outbound idempotency and duplicate-order prevention](../../adr/0052-supplier-outbound-idempotency-duplicate-order-prevention.adr.md)
+
+Still pending: PRICAT ingestion, effective-dating, and price-precedence policy — drafted after the pricing-data investigation ([durion#371](https://github.com/louisburroughs/durion/issues/371)) concludes.
 
 ---
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `CAP-317` (foundation)
- Parent STORY (durion): louisburroughs/durion#372
- Domain: `domain:supplier`

## Scope

Added comprehensive architecture document for the new `pos-supplier` module, which implements outbound supplier connectivity for tire manufacturers and parts distributors via the EDIWheel standard and proprietary APIs.

**What changed:**
- New file: `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` (403 lines)
  - Defines the canonical supplier integration domain model and orchestration layer
  - Specifies the hexagonal (ports and adapters) architecture with configuration-driven adapter registry
  - Documents the vendor profile and endpoint binding configuration model
  - Establishes capability ports for order, stock, price, invoice, shipment, workorder authorization, and catalog services
  - Details the protocol adapter and codec versioning strategy (supporting multiple EDIWheel norms: A2.5, B2.1, B3.3, B4.0, C1.0–C1.2)
  - Defines module layout (`pos-supplier`) with clear separation of concerns (service contracts, domain, SPI, adapters, persistence)
  - Specifies integration with existing Durion domains via events (ADR-0044 alignment) with one approved synchronous read exception for real-time stock inquiry
  - Documents resilience, idempotency, audit, and security cross-cutting concerns
  - Provides phasing plan (CAP-317 through CAP-324) with rationale for each phase
  - Resolves 10 open design decisions (vendor roadmap, module naming, account topology, inbound scope, scanning placeholder, etc.)
  - Identifies ADR candidates for follow-up formalization

- Updated: `docs/architecture/README.md`
  - Added "Integration" section with link to the new supplier integration architecture document

**Why:**
This architecture document serves as the source of truth for the supplier integration initiative, establishing the design before implementation begins. It:
- Aligns with platform ADRs (ADR-0026 service contracts, ADR-0044 event-only domain walls, ADR-0011/0014 security, ADR-0013/0027 identifiers, ADR-0024 timestamps)
- Enables reuse across multiple vendors and protocol families (EDIWheel norms, Michelin S2S, future proprietary APIs)
- Provides clear phasing and traceability to GitHub issues (durion#372–durion#379)
- Resolves design ambiguities upfront (account topology, credential vs. account-number separation, version coexistence, inbound scope)
- Establishes the configuration-driven vendor profile model to support deployment-level customization without code changes

## Tests
- N/A — this is a documentation-only change (architecture specification). Implementation and tests follow in subsequent capability stories (CAP-317 through CAP-324).

## Risk & Rollback
- Risk level: **Low** — documentation only; no code changes.
- Rollback plan: N/A (revert the commit if needed).

## Checklist
- [x] Branch name matches `cap/<cap-id>` (or documentation branch)
- [x] PR title starts with `[CAP:<cap-id>]` or `docs:` (documentation convention)
- [x] Links to parent + child issues are present (durion#372 and related)
- [x] Architecture aligns with applicable ADRs (ADR-0026, ADR-0044, ADR-0011, ADR-0014, ADR-0013, ADR-0027, ADR-0024, ADR-0018, ADR-0040)
- [x] Document is complete and ready for implementation planning

https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv