### PR TITLE
docs: draft ADR-0053 (PRICAT policy) and ADR-0054 (sell-price system-of-record split)

### DIFF
--- a/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
+++ b/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
@@ -56,7 +56,7 @@ Findings from the durion#371 investigation (as-is analysis in the issue comments
   convention; PRICAT effective dates are vendor-local dates), source-document ID and date, import-manifest ID, and fetch timestamp.
 - Rows are **immutable**; a new vendor price appends a new row. Effective windows are half-open `[effectiveFrom, nextEffectiveFrom)` per (vendorProfileId, productId, scope).
 - **Latest** = greatest `effectiveFrom` ≤ today; ties resolve by source-document date, then fetch timestamp. Superseded rows are retained (cost history is a first-class
-  query), satisfying the durion#372 §12 decision 9 dating rule.
+  query), satisfying the dating rule resolved 2026-08-10 in the supplier architecture document (§12, decision 9).
 - The pos-price `ProductBasePrice` overwrite-on-save behavior is noted as a **pre-existing retention defect** but is out of PRICAT scope — supplier data never writes there.
 
 ### 3. Market scope, not location scope
@@ -69,7 +69,7 @@ profile's catalog. Deployments needing different supplier costs per store group 
 
 **Decision:** ✅ **Resolved**
 
-- Neither the pos-price quote chain nor the pos-catalog price-book resolver reads supplier price entries. This makes the durion#372 §12 rule — vendor prices never override
+- Neither the pos-price quote chain nor the pos-catalog price-book resolver reads supplier price entries. This makes the rule resolved in the supplier architecture document (§12, decision 9) — vendor prices never override
   service-provider or location prices — structural rather than procedural.
 - PRICAT **suggested retail** may be surfaced as reference-only display data (alongside MSRP history), labeled with its PRICAT source, and is never auto-applied to any sell
   price.

--- a/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
+++ b/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
@@ -42,7 +42,7 @@ Findings from the durion#371 investigation (as-is analysis in the issue comments
 | Received PRICAT document lines (import staging, unmatched quarantine) | `pos-supplier` | Immutable import records tied to the exchange audit (ADR-0049: exchange state, not a business pricing aggregate) |
 | Supplier catalog/offer cost (the business fact) | `pos-catalog` | Effective-dated supplier price entries (§2), **replacing** mutable `supplier_item_cost` |
 | Inventory valuation cost | `pos-inventory` | Unchanged (ADR-0048); PRICAT never writes valuation |
-| Sell prices | `pos-price` (and the catalog price-book model until §6 reconciliation) | Unchanged; supplier cost participates in **no** sell-price resolver |
+| Sell prices | `pos-price` (transactional quoting; pos-catalog narrows to list/MSRP reference per ADR-0054) | Unchanged; supplier cost participates in **no** sell-price resolver |
 
 `pos-supplier`'s copy is the received-document record (supports audit, latest-selection at import, re-application after late product matches, and the unmatched worklist).
 `pos-catalog`'s entries are the consumable business fact for purchasing, margin context, and reporting.
@@ -88,11 +88,12 @@ profile's catalog. Deployments needing different supplier costs per store group 
 - Unmatched lines stay quarantined in `pos-supplier` (CAP-318's unmatched-lines store) for admin review; when a later catalog fix makes a line matchable, re-application
   happens from the staged import records — no vendor re-fetch required.
 
-### 6. Duplicate sell-price models: flagged, not resolved here
+### 6. Duplicate sell-price models: reconciled by ADR-0054
 
-**Decision:** ✅ **Resolved (scope ruling)** — The overlap between pos-price (base/override/tier) and pos-catalog (price books, MSRP) is a pre-existing conflict that must be
-reconciled by the Pricing & Fees and Product & Catalog domain owners as its own decision (recommended: a dedicated `[CLARIFICATION]` issue and follow-up ADR). This ADR is
-deliberately valid under **either** outcome because supplier cost enters neither resolver (§4).
+**Decision:** ✅ **Resolved** — The overlap between pos-price (base/override/tier) and pos-catalog (price books, MSRP) was raised as clarification durion#382 and decided
+2026-08-10 in **ADR-0054**: pos-catalog owns list/MSRP reference, pos-price owns transactional quoting, each narrowed to a documented non-overlapping role. This ADR was
+drafted to be valid under any outcome (supplier cost enters neither resolver, §4) and is confirmed unaffected; PRICAT suggested retail slots into pos-catalog's reference
+role per ADR-0054 §1.
 
 ### 7. Event contract: manifest-chunked import events
 
@@ -118,11 +119,11 @@ the event model bounds message size while keeping per-aggregate ordering and a c
 **Negative / accepted:** `supplier_item_cost` and its admin/API surface must migrate to the new entries (pre-production, no compatibility shim per platform policy); the
 EAN/UPC uniqueness prerequisite may surface existing dirty catalog data that needs cleanup before CAP-318's consumer lands; two persisted copies (staging in pos-supplier,
 business fact in pos-catalog) are accepted for auditability and re-application.
-**Follow-ups:** `[CLARIFICATION]` issue for the duplicate sell-price model reconciliation (§6); pos-catalog EAN/UPC uniqueness story under CAP-318; chunk-size validation
-against the Michelin sandbox; pos-price base-price retention defect tracked separately with the Pricing domain.
+**Follow-ups:** pos-catalog EAN/UPC uniqueness story under CAP-318 (durion-positivity-backend#1232); chunk-size validation against the Michelin sandbox. The duplicate
+sell-price reconciliation and the pos-price base-price retention defect are resolved/owned by ADR-0054 (durion#382).
 
 ## References
 
 - Investigation: durion#371 (as-is findings in comments, spot-verified 2026-08-10)
 - `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §8.1
-- ADR-0044 §3–§4, ADR-0048, ADR-0049 §3, ADR-0050 §2/§5; `docs/ediwheel/EDIWheel Price Catalog PROD_0.yaml`
+- ADR-0044 §3–§4, ADR-0048, ADR-0049 §3, ADR-0050 §2/§5, ADR-0054 (sell-price split, durion#382); `docs/ediwheel/EDIWheel Price Catalog PROD_0.yaml`

--- a/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
+++ b/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
@@ -1,0 +1,128 @@
+# ADR-0053: Supplier PRICAT Ingestion, Effective Dating, and Price Precedence
+
+**Status:** PROPOSED — pending Pricing & Fees and Product & Catalog domain owner review  
+**Date:** 2026-08-10  
+**Deciders:** Architecture, Backend Lead, Pricing & Fees Domain, Product & Catalog Domain, Positivity (Integrations) Domain  
+**Affected Issues:** durion#371 (investigation), durion#373 (CAP-318), durion-positivity-backend#1224
+
+---
+
+## Context
+
+Findings from the durion#371 investigation (as-is analysis in the issue comments, spot-verified against the backend source):
+
+- **Current State**:
+  - `pos-price` owns an effective-dated `ProductBasePrice` whose **primary key is `productId`** — saving a price overwrites the row, so base-price history is structurally
+    unretainable despite `effectiveFrom/effectiveTo`. Location overrides and customer-tier rules do retain effective windows. Quote order is base price → location override →
+    customer-tier discount.
+  - `pos-catalog` carries a **second sell-price model** (company-default/location/customer-tier price books, effective-dated rules, MSRP history) plus
+    `supplier_item_cost`: **one mutable row per `(supplierId, itemId)`** with optional quantity tiers but no effective dates, no source-document identity, no market scope,
+    and no history beyond `updatedAt` (verified in `SupplierItemCostEntity`).
+  - ADR-0048 makes `pos-inventory` the sole owner of ledger **valuation** cost — supplier catalog cost and valuation cost are distinct facts.
+  - Date semantics differ across modules: pos-price uses `Instant` with exclusive end; catalog MSRP uses `LocalDate` with inclusive end.
+  - PRICAT B4.0 is scoped by **buyer account (`buyerParty` + `agencyCode`) and market** — there is no delivery-location parameter. It supplies EAN as primary product
+    identity, `supplierCode` (supplier's own code), `xReferenceCode` (UPC/EAN cross-reference), suggested/gross/net values with effective-from dates, tax, and recycling fee.
+  - pos-catalog has **no exact EAN/UPC lookup or uniqueness constraint** today (only SKU and `(manufacturerId, manufacturerPartNumber)` are unique).
+  - No PRICAT event exists; ADR-0044/0049 fix the naming: topic `supplier.events.v1`, unversioned `eventType`, `schemaVersion`.
+- **The Problem**: PRICAT data needs an owner, a retention/effective-dating model, a precedence rule against sell prices, a deterministic matching policy, and an event
+  contract — none of which the current `supplier_item_cost` or either sell-price model provides.
+- **Scope**: Supplier *catalog/offer* price data (PRICAT). Not in scope: reconciling the duplicate pos-price/pos-catalog sell-price models (pre-existing conflict, §6);
+  inventory valuation (ADR-0048); vendor exchange mechanics (ADR-0049..0052).
+
+---
+
+## Decision
+
+### 1. Ownership: four distinct facts, four owners
+
+**Decision:** ✅ **Resolved**
+
+| Fact | Owner | Store |
+| --- | --- | --- |
+| Received PRICAT document lines (import staging, unmatched quarantine) | `pos-supplier` | Immutable import records tied to the exchange audit (ADR-0049: exchange state, not a business pricing aggregate) |
+| Supplier catalog/offer cost (the business fact) | `pos-catalog` | Effective-dated supplier price entries (§2), **replacing** mutable `supplier_item_cost` |
+| Inventory valuation cost | `pos-inventory` | Unchanged (ADR-0048); PRICAT never writes valuation |
+| Sell prices | `pos-price` (and the catalog price-book model until §6 reconciliation) | Unchanged; supplier cost participates in **no** sell-price resolver |
+
+`pos-supplier`'s copy is the received-document record (supports audit, latest-selection at import, re-application after late product matches, and the unmatched worklist).
+`pos-catalog`'s entries are the consumable business fact for purchasing, margin context, and reporting.
+
+### 2. Supplier price entries: append-only, effective-dated, source-identified
+
+**Decision:** ✅ **Resolved** — `supplier_item_cost` is replaced by append-only **supplier price entries** in pos-catalog:
+
+- Row identity: own UUIDv7 id; content: `vendorProfileId`, market scope (`country`, `currency`, buyer-account identity), matched `productId`, `supplierCode` (stored as an
+  alias, never an identifier), suggested/gross/net values, tax and recycling fee, quantity tiers (child rows), `effectiveFrom` (`LocalDate`, inclusive — the pos-catalog
+  convention; PRICAT effective dates are vendor-local dates), source-document ID and date, import-manifest ID, and fetch timestamp.
+- Rows are **immutable**; a new vendor price appends a new row. Effective windows are half-open `[effectiveFrom, nextEffectiveFrom)` per (vendorProfileId, productId, scope).
+- **Latest** = greatest `effectiveFrom` ≤ today; ties resolve by source-document date, then fetch timestamp. Superseded rows are retained (cost history is a first-class
+  query), satisfying the durion#372 §12 decision 9 dating rule.
+- The pos-price `ProductBasePrice` overwrite-on-save behavior is noted as a **pre-existing retention defect** but is out of PRICAT scope — supplier data never writes there.
+
+### 3. Market scope, not location scope
+
+**Decision:** ✅ **Resolved** — PRICAT's factual scope is the buyer account + country/market; entries store exactly that scope and **no per-location supplier cost is
+invented**. Applicability to Durion locations derives from the vendor profile: locations carrying a delivery-account mapping in a profile (ADR-0050 §5) are covered by that
+profile's catalog. Deployments needing different supplier costs per store group model them as separate vendor profiles (ADR-0050 §2), each with its own PRICAT binding.
+
+### 4. Precedence: supplier prices never enter sell-price resolution
+
+**Decision:** ✅ **Resolved**
+
+- Neither the pos-price quote chain nor the pos-catalog price-book resolver reads supplier price entries. This makes the durion#372 §12 rule — vendor prices never override
+  service-provider or location prices — structural rather than procedural.
+- PRICAT **suggested retail** may be surfaced as reference-only display data (alongside MSRP history), labeled with its PRICAT source, and is never auto-applied to any sell
+  price.
+- Quote/margin screens may read the **net cost** of the latest applicable entry as context via a catalog read API; displaying cost context is permitted, feeding it into
+  price calculation is not.
+
+### 5. Product matching: deterministic only, quarantine otherwise
+
+**Decision:** ✅ **Resolved**
+
+- Match order, exact matches only: (1) EAN against catalog product codes of type EAN; (2) UPC via `xReferenceCode` against type UPC; (3) `(manufacturerId,
+  manufacturerPartNumber)` where the vendor profile maps the supplier to a manufacturer. No fuzzy matching; no auto-creation of products; `supplierCode` is never treated as
+  a SKU or used for matching.
+- **Prerequisite (new pos-catalog story under CAP-318):** an indexed, exact-match lookup and per-type uniqueness constraint for EAN/UPC product codes — without it,
+  deterministic matching is impossible.
+- Unmatched lines stay quarantined in `pos-supplier` (CAP-318's unmatched-lines store) for admin review; when a later catalog fix makes a line matchable, re-application
+  happens from the staged import records — no vendor re-fetch required.
+
+### 6. Duplicate sell-price models: flagged, not resolved here
+
+**Decision:** ✅ **Resolved (scope ruling)** — The overlap between pos-price (base/override/tier) and pos-catalog (price books, MSRP) is a pre-existing conflict that must be
+reconciled by the Pricing & Fees and Product & Catalog domain owners as its own decision (recommended: a dedicated `[CLARIFICATION]` issue and follow-up ADR). This ADR is
+deliberately valid under **either** outcome because supplier cost enters neither resolver (§4).
+
+### 7. Event contract: manifest-chunked import events
+
+**Decision:** ✅ **Resolved** — Per ADR-0044/0049 naming: topic `supplier.events.v1`, producer `pos-supplier`, consumer `pos-catalog` (pos-price has no consumer under §4;
+one may be added by ADR-0049 table amendment if margin features need it).
+
+- **Aggregate** = the import manifest (`importManifestId`, UUIDv7) — one per PRICAT fetch; `aggregateVersion` is the chunk sequence.
+- `eventType = supplier.pricecatalog.updated`, `schemaVersion = 1`: **chunk events** carrying manifest metadata (vendorProfileId, source-document ID/date, scope, norm
+  version, chunk sequence/count) plus up to N matched line items (identity, values, effective-from, tiers).
+- `eventType = supplier.pricecatalog.import.completed`, `schemaVersion = 1`: terminal event with totals (lines fetched/matched/unmatched/duplicate, checksum) enabling the
+  consumer's completeness check; missing chunks are recovered via the owner re-emit path on the command topic per ADR-0044 §4 reconciliation — never a synchronous call.
+- Chunk size default **500 lines** (~150 KB at ~300 bytes/line, comfortably under broker message limits for dealer catalogs estimated at 5k–50k lines), configurable per
+  binding; the default MUST be validated against the first Michelin sandbox pull and recorded here.
+- Consumer applies chunks incrementally and idempotently (`processed_events`, ADR-0044 §4); entries become queryable as applied, with the completion event driving the
+  completeness metric.
+
+---
+
+## Consequences
+
+**Positive:** supplier cost gets history, source identity, and market scope; the no-override rule is structural; matching is deterministic with an explicit quarantine path;
+the event model bounds message size while keeping per-aggregate ordering and a completeness check.
+**Negative / accepted:** `supplier_item_cost` and its admin/API surface must migrate to the new entries (pre-production, no compatibility shim per platform policy); the
+EAN/UPC uniqueness prerequisite may surface existing dirty catalog data that needs cleanup before CAP-318's consumer lands; two persisted copies (staging in pos-supplier,
+business fact in pos-catalog) are accepted for auditability and re-application.
+**Follow-ups:** `[CLARIFICATION]` issue for the duplicate sell-price model reconciliation (§6); pos-catalog EAN/UPC uniqueness story under CAP-318; chunk-size validation
+against the Michelin sandbox; pos-price base-price retention defect tracked separately with the Pricing domain.
+
+## References
+
+- Investigation: durion#371 (as-is findings in comments, spot-verified 2026-08-10)
+- `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §8.1
+- ADR-0044 §3–§4, ADR-0048, ADR-0049 §3, ADR-0050 §2/§5; `docs/ediwheel/EDIWheel Price Catalog PROD_0.yaml`

--- a/docs/adr/0054-sell-price-system-of-record-split.adr.md
+++ b/docs/adr/0054-sell-price-system-of-record-split.adr.md
@@ -1,0 +1,69 @@
+# ADR-0054: Sell-Price System of Record Split (pos-price Quoting, pos-catalog List/MSRP Reference)
+
+**Status:** ACCEPTED 2026-08-10 — decisions recorded from durion#382  
+**Date:** 2026-08-10  
+**Deciders:** Pricing & Fees Domain, Product & Catalog Domain, Architecture  
+**Affected Issues:** durion#382 (clarification), durion#371 (investigation that surfaced the conflict)
+
+---
+
+## Context
+
+The durion#371 PRICAT investigation surfaced a pre-existing conflict, formalized as clarification durion#382: two sell-price models coexist with overlapping authority.
+
+- **Current State**:
+  - `pos-price`: effective-dated `ProductBasePrice` (primary key `productId` — overwrites on save, so base-price history is structurally unretainable), location overrides
+    with retained effective windows, customer-tier discounts. Quote order: base price → location override → customer-tier discount.
+  - `pos-catalog`: company-default/location/customer-tier **price books** with effective-dated rules, MSRP history, and location overrides. Rule precedence SKU → category →
+    global; candidate book precedence explicit book → active location book → company default. The `CUSTOMER_TIER` book scope exists but the candidate resolver never selects
+    it.
+  - The overlap is acknowledged in the pos-catalog README but no decision named an authority; features could drift between models depending on which module they called.
+- **The Problem**: Two sources of sell-price truth with no documented boundary.
+- **Constraints honored**: supplier PRICAT cost enters neither resolver (ADR-0053 §4); inventory valuation is pos-inventory's (ADR-0048); `pos-price` remains a **utility**
+  module callable synchronously (ADR-0044 §1) — this split preserves that classification.
+
+---
+
+## Decision
+
+Decisions per durion#382 (2026-08-10):
+
+### 1. System-of-record split
+
+**Decision:** ✅ **Resolved** — **`pos-catalog` owns list/MSRP reference; `pos-price` owns transactional quoting.** Every transactional sell-price resolution (quotes,
+workorder/estimate pricing, checkout) reads pos-price and only pos-price. pos-catalog's pricing surface is reference data: MSRP history, list prices, and reference series
+(including PRICAT suggested retail per ADR-0053 §4) — displayable and reportable, never the source of a transactional price.
+
+### 2. Disposition of the overlap
+
+**Decision:** ✅ **Resolved** — Neither model is retired; each is **narrowed to a documented, non-overlapping role**. The catalog price-book model is scoped to producing
+list/MSRP reference prices; any behavior in it that computes or serves a transactional sell price moves to (or is superseded by) pos-price. Module READMEs and the domain
+business-rules guides must state the boundary so new stories route pricing work to the correct module.
+
+### 3. CUSTOMER_TIER price-book scope
+
+**Decision:** ✅ **Resolved** — The `CUSTOMER_TIER` book scope is a **feature to finish**, not dead code: the candidate resolver must learn to select customer-tier books,
+within pos-catalog's narrowed reference role (customer-tier list/reference pricing). Its relationship to pos-price's customer-tier *discounts* (the transactional mechanism)
+must be documented in the implementation story so the two remain reference vs applied, never competing resolvers.
+
+### 4. pos-price base-price retention fix
+
+**Decision:** ✅ **Resolved** — The `ProductBasePrice` retention defect (`productId` as primary key, overwrite on save) is **fixed as part of this reconciliation**: base
+prices become history-retaining (own row identity, `productId` + effective window, append-on-change), with quote resolution selecting the applicable window. This also gives
+pos-price the same retained-history property the location overrides and ADR-0053 supplier price entries already have.
+
+---
+
+## Consequences
+
+**Positive:** one authoritative answer for "what does the customer pay" (pos-price) and one for "what is the reference/list price" (pos-catalog); pricing stories have a
+routing rule; base-price history becomes auditable; the unreachable `CUSTOMER_TIER` scope gets an explicit destiny.
+**Negative / accepted:** the narrowing and the base-price schema change are backend work that must be storied and scheduled with the Pricing & Fees and Product & Catalog
+domains; until those stories land, the boundary exists on paper and reviewers must enforce it.
+**Follow-ups:** implementation stories for (a) the base-price history-retaining schema in pos-price, (b) `CUSTOMER_TIER` candidate-book selection in pos-catalog, and (c) the
+README/business-rules boundary documentation in both modules.
+
+## References
+
+- durion#382 (decision comment, 2026-08-10), durion#371 (investigation)
+- ADR-0053 (PRICAT — unaffected by this split by design), ADR-0048, ADR-0044 §1

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,6 +117,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0050   | Supplier Vendor Profile Configuration Model            | ACCEPTED              | 2026-08-10 |
 | 0051   | Supplier Protocol Adapter and Codec Versioning Policy  | ACCEPTED              | 2026-08-10 |
 | 0052   | Supplier Outbound Idempotency and Duplicate-Order Prevention | ACCEPTED | 2026-08-10 |
+| 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | PROPOSED | 2026-08-10 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 
@@ -176,6 +177,7 @@ Use this matrix during planning, implementation, and review to quickly decide wh
 | 0050 | Vendor profile configuration: capability bindings (absent = disabled), secret-reference-only credentials, canonical billing/delivery account roles with per-location delivery mapping, sandbox overlays, profile audit/permissions | Planner, Coder, Test, Orchestrator |
 | 0051 | Supplier protocol adapters and codecs: adapter-per-wire-format-family, registry keyed (capability, protocolFamily, version), norm-version coexistence, unmapped-field audit, golden-file test obligations | Planner, Coder, Test, Orchestrator |
 | 0052 | Outbound supplier idempotency: deterministic document IDs, transactional outbox for order transmission, status-first reconciliation of ambiguous outcomes (never blind-retry an order create), MANUAL_REVIEW escalation, mandatory crash/retry tests | Planner, Coder, Test, Orchestrator |
+| 0053 | PRICAT supplier-cost policy: pos-catalog owns append-only effective-dated supplier price entries (replacing supplier_item_cost), market-not-location scope, structural no-override of sell prices, deterministic EAN/UPC/MPN matching with quarantine, manifest-chunked import events | Planner, Coder, Test, Orchestrator |
 
 ### Agent role shorthand
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -118,6 +118,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0051   | Supplier Protocol Adapter and Codec Versioning Policy  | ACCEPTED              | 2026-08-10 |
 | 0052   | Supplier Outbound Idempotency and Duplicate-Order Prevention | ACCEPTED | 2026-08-10 |
 | 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | PROPOSED | 2026-08-10 |
+| 0054   | Sell-Price System of Record Split (pos-price Quoting, pos-catalog Reference) | ACCEPTED | 2026-08-10 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 
@@ -178,6 +179,7 @@ Use this matrix during planning, implementation, and review to quickly decide wh
 | 0051 | Supplier protocol adapters and codecs: adapter-per-wire-format-family, registry keyed (capability, protocolFamily, version), norm-version coexistence, unmapped-field audit, golden-file test obligations | Planner, Coder, Test, Orchestrator |
 | 0052 | Outbound supplier idempotency: deterministic document IDs, transactional outbox for order transmission, status-first reconciliation of ambiguous outcomes (never blind-retry an order create), MANUAL_REVIEW escalation, mandatory crash/retry tests | Planner, Coder, Test, Orchestrator |
 | 0053 | PRICAT supplier-cost policy: pos-catalog owns append-only effective-dated supplier price entries (replacing supplier_item_cost), market-not-location scope, structural no-override of sell prices, deterministic EAN/UPC/MPN matching with quarantine, manifest-chunked import events | Planner, Coder, Test, Orchestrator |
+| 0054 | Sell-price authority routing: pos-price is the transactional quoting SoR, pos-catalog narrows to list/MSRP reference (CUSTOMER_TIER book selection to be finished in the reference role); base-price history retention fix owned here | Planner, Coder, Test, Orchestrator |
 
 ### Agent role shorthand
 

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -318,7 +318,7 @@ The [durion#371](https://github.com/louisburroughs/durion/issues/371) investigat
 - PRICAT scope is buyer account + market (no location parameter); location applicability derives from the vendor profile's delivery mappings — no per-location supplier cost is invented.
 - Product matching is deterministic-only (EAN → UPC cross-reference → manufacturer+MPN), with an EAN/UPC uniqueness prerequisite in pos-catalog and quarantine for the rest; no fuzzy matching, no auto-create.
 - Event contract: manifest-chunked `supplier.pricecatalog.updated` events plus a `supplier.pricecatalog.import.completed` completeness event on `supplier.events.v1` (ADR-0053 §7).
-- Out of scope but flagged: the duplicate pos-price / pos-catalog sell-price models need their own reconciliation decision; the ADR holds under either outcome.
+- The duplicate pos-price / pos-catalog sell-price models were reconciled via [durion#382](https://github.com/louisburroughs/durion/issues/382) → [ADR-0054](../../adr/0054-sell-price-system-of-record-split.adr.md): pos-catalog owns list/MSRP reference, pos-price owns transactional quoting; ADR-0053 is unaffected by design.
 
 ## 9. Cross-Cutting Concerns
 

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -317,7 +317,7 @@ The [durion#371](https://github.com/louisburroughs/durion/issues/371) investigat
 - **Vendor prices never override service-provider or location-specific prices** — structurally: neither sell-price resolver reads supplier price entries. PRICAT suggested retail is reference-only display; net cost may appear as margin context, never as a pricing input.
 - PRICAT scope is buyer account + market (no location parameter); location applicability derives from the vendor profile's delivery mappings — no per-location supplier cost is invented.
 - Product matching is deterministic-only (EAN → UPC cross-reference → manufacturer+MPN), with an EAN/UPC uniqueness prerequisite in pos-catalog and quarantine for the rest; no fuzzy matching, no auto-create.
-- Event contract: manifest-chunked `supplier.pricecatalog.updated` events plus an `import.completed` completeness event on `supplier.events.v1` (ADR-0053 §7).
+- Event contract: manifest-chunked `supplier.pricecatalog.updated` events plus a `supplier.pricecatalog.import.completed` completeness event on `supplier.events.v1` (ADR-0053 §7).
 - Out of scope but flagged: the duplicate pos-price / pos-catalog sell-price models need their own reconciliation decision; the ADR holds under either outcome.
 
 ## 9. Cross-Cutting Concerns

--- a/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
+++ b/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md
@@ -310,9 +310,15 @@ The real-time stock inquiry is the one place where event-only communication figh
 
 ### 8.1 PRICAT dating and price precedence
 
-- Every ingested PRICAT entry is stamped with the vendor's effective date and Durion's fetch timestamp; "latest" is always decidable, and superseded entries are retained for audit and cost-history queries.
-- **Vendor prices never override service-provider or location-specific prices.** PRICAT data enters the platform as supplier cost / list-price *input* to the pricing domain; sell-price authority remains with pos-price and its location-scoped rules.
-- The detailed pricing data model and how PRICAT feeds it (cost layers, effective-dating, location scoping) requires further investigation with the Pricing domain owners — tracked in [durion#371](https://github.com/louisburroughs/durion/issues/371) and a precondition for the Phase 1 PRICAT consumer landing in pos-price.
+The [durion#371](https://github.com/louisburroughs/durion/issues/371) investigation concluded 2026-08-10; the resulting policy is **[ADR-0053](../../adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md)** (PROPOSED, pending Pricing & Fees / Product & Catalog domain sign-off). Summary:
+
+- Four facts, four owners: received PRICAT lines stage in pos-supplier (exchange state); the supplier cost **business fact** lives in **pos-catalog** as append-only, effective-dated, source-identified supplier price entries replacing the mutable `supplier_item_cost`; valuation cost stays in pos-inventory (ADR-0048); sell prices stay with the sell-price models.
+- Every entry carries the vendor's effective date (`LocalDate`, inclusive start, half-open windows) and Durion's fetch timestamp; "latest" is always decidable and superseded entries are retained for cost-history queries.
+- **Vendor prices never override service-provider or location-specific prices** — structurally: neither sell-price resolver reads supplier price entries. PRICAT suggested retail is reference-only display; net cost may appear as margin context, never as a pricing input.
+- PRICAT scope is buyer account + market (no location parameter); location applicability derives from the vendor profile's delivery mappings — no per-location supplier cost is invented.
+- Product matching is deterministic-only (EAN → UPC cross-reference → manufacturer+MPN), with an EAN/UPC uniqueness prerequisite in pos-catalog and quarantine for the rest; no fuzzy matching, no auto-create.
+- Event contract: manifest-chunked `supplier.pricecatalog.updated` events plus an `import.completed` completeness event on `supplier.events.v1` (ADR-0053 §7).
+- Out of scope but flagged: the duplicate pos-price / pos-catalog sell-price models need their own reconciliation decision; the ADR holds under either outcome.
 
 ## 9. Cross-Cutting Concerns
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `CAP-318` (PRICAT sync)
- Parent STORY (durion): louisburroughs/durion#373; investigation louisburroughs/durion#371; clarification louisburroughs/durion#382
- Child issue: louisburroughs/durion-positivity-backend#1224 (governed consumer), louisburroughs/durion-positivity-backend#1232 (new matching prerequisite)
- Domain: `domain:positivity`, `domain:pricing`, `domain:product`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): N/A — documentation-only; the event contract shape (`supplier.pricecatalog.updated` chunks + `supplier.pricecatalog.import.completed`) is specified in ADR-0053 §7 for the implementation stories to follow.
- Durion contract PR (if applicable): N/A

## Scope
- What changed:
  - **New: `docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md`** (PROPOSED — pending Pricing & Fees / Product & Catalog domain owner sign-off). Concludes the durion#371 investigation using the as-is findings recorded on the issue, spot-verified against backend source (`ProductBasePrice` keyed by `productId`; `supplier_item_cost` one mutable row per supplier+item, no effective dates or source identity). Decisions:
    - Four facts, four owners: PRICAT staging + unmatched quarantine in pos-supplier (exchange state per ADR-0049); the supplier-cost **business fact** in pos-catalog as append-only, effective-dated, source-identified supplier price entries **replacing** `supplier_item_cost`; valuation stays pos-inventory (ADR-0048); sell prices untouched.
    - Structural no-override: neither sell-price resolver reads supplier entries; PRICAT suggested retail is reference-only display; net cost is margin context only.
    - Market-not-location scope (PRICAT is buyer-account + country scoped); location applicability derives from vendor-profile delivery mappings.
    - Effective dating: `LocalDate` inclusive-start, half-open windows, immutable append-only rows, latest = max effectiveFrom ≤ today with document-date/fetch-time tie-breaks.
    - Deterministic-only matching (EAN → UPC via `xReferenceCode` → manufacturer+MPN) with an EAN/UPC uniqueness prerequisite in pos-catalog and quarantine for unmatched lines; no fuzzy matching, no auto-create.
    - Event contract per ADR-0044/0049 naming: manifest-chunked `supplier.pricecatalog.updated` events (aggregate = import manifest UUIDv7, default 500 lines/chunk) plus `supplier.pricecatalog.import.completed` for the consumer completeness check.
  - **New: `docs/adr/0054-sell-price-system-of-record-split.adr.md`** (ACCEPTED — decisions recorded verbatim from the durion#382 clarification, 2026-08-10):
    - pos-catalog owns **list/MSRP reference**; pos-price owns **transactional quoting** — the sell-price system-of-record split.
    - Neither model is retired; each narrows to a documented non-overlapping role.
    - The `CUSTOMER_TIER` price-book scope is a feature to finish (candidate-book selection), within the reference role.
    - The pos-price `ProductBasePrice` retention defect (productId as primary key) is fixed as part of this reconciliation (history-retaining base prices).
  - **Updated: ADR-0053** — §1 ownership table and §6 now reference the ADR-0054 resolution; follow-ups and references updated.
  - **Updated: `docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md`** §8.1 — concluded policy summary, ADR-0053 link, and the ADR-0054 reconciliation note; full `supplier.pricecatalog.import.completed` eventType (review fix).
  - **Updated: `docs/adr/README.md`** — ADR-0053 (PROPOSED) and ADR-0054 (ACCEPTED) rows plus decision-matrix entries.
- Why: the pricing investigation (durion#371) was the gate on CAP-318's consumer story; the sell-price overlap it surfaced (durion#382) has now been decided by the domain owner. This PR records both outcomes as reviewable policy, unblocking the consumer story and the matching prerequisite (durion-positivity-backend#1232).

## Tests
- [ ] Unit tests added/updated — N/A (documentation only)
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated (backend) — N/A; ADR-0053 defines the latest-selection and matching test obligations for CAP-318 stories
- [ ] Consumer/UI tests added/updated (frontend) — N/A
- How to run: N/A

## Risk & Rollback
- Risk level: Low — documentation only; no code changes.
- Rollback plan: revert the commits.

## Checklist
- [x] Branch name matches `cap/<cap-id>` (documentation branch `claude/ediwheel-integration-arch-tr3ibn`, continuing the merged #380/#381 line)
- [x] PR title starts with `[CAP:<cap-id>]` (docs: prefix per documentation convention)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — N/A, pre-implementation policy drafts
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv