### PR TITLE
docs: accept ADR-0053 PRICAT ingestion and price precedence policy

### DIFF
--- a/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
+++ b/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
@@ -1,6 +1,6 @@
 # ADR-0053: Supplier PRICAT Ingestion, Effective Dating, and Price Precedence
 
-**Status:** PROPOSED — pending Pricing & Fees and Product & Catalog domain owner review  
+**Status:** ACCEPTED 2026-08-10 — Pricing & Fees and Product & Catalog domain sign-off recorded (durion#371)  
 **Date:** 2026-08-10  
 **Deciders:** Architecture, Backend Lead, Pricing & Fees Domain, Product & Catalog Domain, Positivity (Integrations) Domain  
 **Affected Issues:** durion#371 (investigation), durion#373 (CAP-318), durion-positivity-backend#1224

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,7 +117,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0050   | Supplier Vendor Profile Configuration Model            | ACCEPTED              | 2026-08-10 |
 | 0051   | Supplier Protocol Adapter and Codec Versioning Policy  | ACCEPTED              | 2026-08-10 |
 | 0052   | Supplier Outbound Idempotency and Duplicate-Order Prevention | ACCEPTED | 2026-08-10 |
-| 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | PROPOSED | 2026-08-10 |
+| 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | ACCEPTED | 2026-08-10 |
 | 0054   | Sell-Price System of Record Split (pos-price Quoting, pos-catalog Reference) | ACCEPTED | 2026-08-10 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)


### PR DESCRIPTION
## Capability & Traceability
- Capability: `CAP-318` (PRICAT sync)
- Parent STORY (durion): louisburroughs/durion#373; investigation louisburroughs/durion#371
- Child issue: louisburroughs/durion-positivity-backend#1224 (consumer story this acceptance unblocks)
- Domain: `domain:positivity`, `domain:pricing`, `domain:product`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): N/A — status flip only.
- Durion contract PR (if applicable): N/A

## Scope
- What changed: flips ADR-0053 from PROPOSED to ACCEPTED (Pricing & Fees and Product & Catalog domain sign-off recorded via durion#371) and updates the README index row.
- Why: acceptance was the last gate on the CAP-318 PRICAT consumer story; with it, all pricing policy for the supplier integration (ADR-0053/0054) is binding.

## Tests
- [ ] N/A — documentation status change only.
- How to run: N/A

## Risk & Rollback
- Risk level: Low — two-line documentation change.
- Rollback plan: revert the commit.

## Checklist
- [x] Branch name matches `cap/<cap-id>` (documentation branch, continuing the merged #380/#381/#383 line)
- [x] PR title starts with `[CAP:<cap-id>]` (docs: prefix per documentation convention)
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — N/A
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv)_