### PR TITLE
docs(business-rules): ADR-0054 sell-price split decision entries (DECISION-PRICING-019, DECISION-PRODUCT-011)

### DIFF
--- a/domains/pricing/.business-rules/AGENT_GUIDE.md
+++ b/domains/pricing/.business-rules/AGENT_GUIDE.md
@@ -33,6 +33,7 @@ This document is the normative guide for the Pricing domain. It defines system-o
 | DECISION-PRICING-016 | Deactivation mechanism (status vs effectiveEndAt) |
 | DECISION-PRICING-017 | Product lookup contract for pricing admin screens |
 | DECISION-PRICING-018 | MSRP historical immutability and permissions |
+| DECISION-PRICING-019 | Sell-price system-of-record split (pos-price quoting vs pos-catalog reference) |
 
 ## Domain Boundaries
 
@@ -103,6 +104,7 @@ These are the normative API contract expectations until backend contracts diverg
 | DECISION-PRICING-016 | Prefer `effectiveEndAt` for deactivation; status is derived | [DOMAIN_NOTES.md](DOMAIN_NOTES.md#decision-pricing-016--deactivation-mechanism-status-vs-effectiveendat) |
 | DECISION-PRICING-017 | Admin uses Inventory product search API for product selection | [DOMAIN_NOTES.md](DOMAIN_NOTES.md#decision-pricing-017--product-lookup-contract-for-pricing-admin-screens) |
 | DECISION-PRICING-018 | Past MSRP records are immutable unless special permission present | [DOMAIN_NOTES.md](DOMAIN_NOTES.md#decision-pricing-018--msrp-historical-immutability-and-permissions) |
+| DECISION-PRICING-019 | pos-price owns transactional quoting; pos-catalog owns list/MSRP reference (ADR-0054) | [DOMAIN_NOTES.md](DOMAIN_NOTES.md#decision-pricing-019--sell-price-system-of-record-split-adr-0054) |
 
 ## Open Questions (from source)
 

--- a/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -99,6 +99,20 @@ Headers and auth notes:
 - Successful mutations must produce deterministic persisted outcomes.
 - Failure responses must be explicit and actionable for callers.
 
+### Base Price Effective Windows (ADR-0054 §4)
+
+- Base prices in `pos-price` are history-retaining: each row is one effective window per
+  (productId, currency); price changes append a new row and close the predecessor's window.
+- Window semantics are half-open on `Instant`: a base price row is effective for instants `t`
+  where `effectiveFrom <= t < effectiveTo`; a null `effectiveTo` means the window is open-ended
+  (inclusive start, exclusive end).
+- Quote resolution (`calculatePriceQuote`) selects the base-price window covering the pricing
+  instant. When no window covers it, the API returns `404` with `ApiError` code
+  `PRICE_BASE_UNAVAILABLE` (replaces the former `PRODUCT_NOT_FOUND` on this path).
+- Base-price writes that would overlap or backdate the latest existing window are rejected with
+  `409` and `ApiError` code `PRICE_BASE_WINDOW_CONFLICT`; re-submitting the current open window's
+  price is an idempotent no-op.
+
 ### Frontend Usage Notes
 
 - Use operation IDs above as the stable API integration keys for UI actions.

--- a/domains/pricing/.business-rules/DOMAIN_NOTES.md
+++ b/domains/pricing/.business-rules/DOMAIN_NOTES.md
@@ -340,7 +340,8 @@ This document is the non-normative rationale and decision log for the Pricing do
 ### DECISION-PRICING-019 — Sell-price system-of-record split (ADR-0054)
 
 - Normative source: `AGENT_GUIDE.md` (Decision ID); ADR-0054 (durion#382, decided 2026-08-10)
-- Decision: `pos-price` owns transactional sell-price resolution (quote chain: base price → location override → customer-tier discount) and is the only source read by quotes, workorder/estimate pricing, and checkout; `pos-catalog` owns list/MSRP reference pricing (price books, MSRP history, reference series including PRICAT suggested retail per ADR-0053 §4), which is displayable and reportable but never a transactional price source.
+- Decision: `pos-price` owns transactional sell-price resolution (quote chain: base price → location override → customer-tier discount) and is the only source read by quotes, workorder/estimate pricing, and checkout.
+  `pos-catalog` owns list/MSRP reference pricing (price books, MSRP history, and reference series including PRICAT suggested retail per ADR-0053 §4); it is displayable and reportable but never a transactional price source.
 - Alternatives considered:
  	- Option A (chosen): Narrow both models to documented, non-overlapping roles
  	- Option B: Retire one of the two sell-price models

--- a/domains/pricing/.business-rules/DOMAIN_NOTES.md
+++ b/domains/pricing/.business-rules/DOMAIN_NOTES.md
@@ -337,6 +337,28 @@ This document is the non-normative rationale and decision log for the Pricing do
 - Governance & owner recommendations:
  	- Compliance review for any historical edit policy change.
 
+### DECISION-PRICING-019 — Sell-price system-of-record split (ADR-0054)
+
+- Normative source: `AGENT_GUIDE.md` (Decision ID); ADR-0054 (durion#382, decided 2026-08-10)
+- Decision: `pos-price` owns transactional sell-price resolution (quote chain: base price → location override → customer-tier discount) and is the only source read by quotes, workorder/estimate pricing, and checkout; `pos-catalog` owns list/MSRP reference pricing (price books, MSRP history, reference series including PRICAT suggested retail per ADR-0053 §4), which is displayable and reportable but never a transactional price source.
+- Alternatives considered:
+ 	- Option A (chosen): Narrow both models to documented, non-overlapping roles
+ 	- Option B: Retire one of the two sell-price models
+- Reasoning and evidence:
+ 	- Two coexisting sell-price models had overlapping authority with no documented boundary (surfaced by durion#371, formalized in durion#382).
+ 	- Each model already serves a distinct need: transactional quoting (pos-price) vs reference/list display (pos-catalog).
+- Architectural implications:
+ 	- Routing rule for new stories: computing what a customer pays → `pos-price`; showing a list/MSRP/reference price → `pos-catalog`.
+ 	- Catalog `CUSTOMER_TIER` price books are tier reference/list prices; `pos-price` customer-tier discounts are the applied transactional mechanism — never competing resolvers (ADR-0054 §3).
+ 	- `pos-price` base prices become history-retaining (own row identity, append-on-change windows, ADR-0054 §4); `pos-price` stays a utility module (ADR-0044 §1).
+ 	- Supplier PRICAT cost enters neither resolver (ADR-0053 §4); inventory valuation cost is pos-inventory's (ADR-0048).
+- Auditor-facing explanation:
+ 	- Inspect that transactional documents (quotes, estimates, invoices) reference pos-price outputs only, and that catalog price data appears only as displayed reference values.
+- Migration & backward-compatibility notes:
+ 	- Backend stories: base-price history schema (pos-price), CUSTOMER_TIER candidate-book selection (pos-catalog), and README/business-rules boundary documentation land under ADR-0054; until merged, reviewers enforce the boundary from the ADR.
+- Governance & owner recommendations:
+ 	- Pricing & Fees owns transactional quoting semantics; Product & Catalog owns reference pricing; cross-domain review required for any story that moves a price fact across the boundary.
+
 ## End
 
 End of document.

--- a/domains/product/.business-rules/AGENT_GUIDE.md
+++ b/domains/product/.business-rules/AGENT_GUIDE.md
@@ -35,6 +35,7 @@ The Product domain owns product/service/non-inventory catalog entities, catalog 
 | DECISION-PRODUCT-008 | Substitutes endpoint is read-only and currently not implemented |
 | DECISION-PRODUCT-009 | IDs are opaque UUID values to clients |
 | DECISION-PRODUCT-010 | Standard error envelope required for future hardening |
+| DECISION-PRODUCT-011 | Catalog pricing surface is list/MSRP reference only (ADR-0054) |
 
 ## Domain Boundaries
 
@@ -88,6 +89,7 @@ The Product domain owns product/service/non-inventory catalog entities, catalog 
 | DECISION-PRODUCT-008 | Substitutes endpoint exists but is intentionally 501 | [ADR-0017](../../../docs/adr/0017-api-controller-http-response-codes.adr.md) |
 | DECISION-PRODUCT-009 | Clients must treat IDs as opaque | [ADR-0013](../../../docs/adr/0013-platform-uuid-identifier-strategy.adr.md) |
 | DECISION-PRODUCT-010 | Standardized error envelope is required as contract hardening follow-up | [ADR-0017](../../../docs/adr/0017-api-controller-http-response-codes.adr.md) |
+| DECISION-PRODUCT-011 | `pos-catalog` price books/MSRP are list/reference data, never a transactional price source; transactional quoting is `pos-price`'s. Routing: computing what a customer pays → `pos-price`; showing a list/MSRP/reference price → `pos-catalog`. Catalog `CUSTOMER_TIER` books are tier reference prices; `pos-price` tier discounts are the applied transactional mechanism — never competing resolvers | [ADR-0054](../../../docs/adr/0054-sell-price-system-of-record-split.adr.md) |
 
 ## Open Questions
 

--- a/domains/product/.business-rules/AGENT_GUIDE.md
+++ b/domains/product/.business-rules/AGENT_GUIDE.md
@@ -89,7 +89,7 @@ The Product domain owns product/service/non-inventory catalog entities, catalog 
 | DECISION-PRODUCT-008 | Substitutes endpoint exists but is intentionally 501 | [ADR-0017](../../../docs/adr/0017-api-controller-http-response-codes.adr.md) |
 | DECISION-PRODUCT-009 | Clients must treat IDs as opaque | [ADR-0013](../../../docs/adr/0013-platform-uuid-identifier-strategy.adr.md) |
 | DECISION-PRODUCT-010 | Standardized error envelope is required as contract hardening follow-up | [ADR-0017](../../../docs/adr/0017-api-controller-http-response-codes.adr.md) |
-| DECISION-PRODUCT-011 | `pos-catalog` price books/MSRP are list/reference data, never a transactional price source; transactional quoting is `pos-price`'s. Routing: computing what a customer pays → `pos-price`; showing a list/MSRP/reference price → `pos-catalog`. Catalog `CUSTOMER_TIER` books are tier reference prices; `pos-price` tier discounts are the applied transactional mechanism — never competing resolvers | [ADR-0054](../../../docs/adr/0054-sell-price-system-of-record-split.adr.md) |
+| DECISION-PRODUCT-011 | `pos-catalog` prices are reference-only; transactional quoting is owned by `pos-price` (customer pays → `pos-price`; list/MSRP → `pos-catalog`) | [ADR-0054](../../../docs/adr/0054-sell-price-system-of-record-split.adr.md) |
 
 ## Open Questions
 

--- a/domains/product/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/product/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -200,6 +200,26 @@ Headers and auth notes:
 - Successful mutations must produce deterministic persisted outcomes.
 - Failure responses must be explicit and actionable for callers.
 
+### Reference Price Resolution & Customer-Tier Books (ADR-0054)
+
+- `resolvePrice` (`POST /v1/products/price-books/resolve-price`) resolves **reference/list
+  price data only** — never a transactional sell price. Transactional quoting (what a customer
+  pays) is owned exclusively by `pos-price` (ADR-0054 §1).
+- Candidate price book resolution selects exactly one book in precedence order: explicit
+  `priceBookId` → active `LOCATION` book (`locationId`) → active `CUSTOMER_TIER` book
+  (`customerTierId`) → `COMPANY_DEFAULT` (`isDefault=true`). A supplied context whose book is
+  missing or inactive falls through to the next step (ADR-0054 §3).
+- `customerTierId` (UUID) selects a `CUSTOMER_TIER` book by matching the book's `scopeId`;
+  the separate `customerTier` (string label) matches rule-level `CUSTOMER_TIER` conditions
+  inside the selected book. They are distinct inputs with distinct purposes.
+- Catalog customer-tier books define **reference/list prices for a tier**; `pos-price`
+  customer-tier *discounts* are the applied transactional mechanism. The two are never
+  competing resolvers: pos-price discounting applies on top of, never in competition with,
+  the catalog reference price.
+- Rules inside a selected customer-tier book resolve by the existing SKU → category → global
+  precedence (priority desc, effective-start desc, rule UUID tie-break) — no tier-specific
+  rule semantics.
+
 ### Frontend Usage Notes
 
 - Use operation IDs above as the stable API integration keys for UI actions.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: n/a (documentation-only story; no capability branch)
- Parent STORY (durion): louisburroughs/durion#382 (ADR-0054, decided 2026-08-10)
- Child issue: louisburroughs/durion-positivity-backend#1235
- Domain: `domain:pricing`, `domain:product`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): n/a — no API/event behavior change; this PR updates `domains/pricing/.business-rules/` and `domains/product/.business-rules/` decision guides only
- Durion contract PR (if applicable): n/a

## Scope
- What changed: Records the ADR-0054 sell-price system-of-record split in both domain business-rules guides:
  - `domains/pricing/.business-rules/AGENT_GUIDE.md` — DECISION-PRICING-019 added to the decision index and mapping rows.
  - `domains/pricing/.business-rules/DOMAIN_NOTES.md` — full DECISION-PRICING-019 entry documenting the split (pos-price = transactional sell-price quoting system of record; pos-catalog = list/MSRP reference only).
  - `domains/product/.business-rules/AGENT_GUIDE.md` — DECISION-PRODUCT-011 index and mapping row linking ADR-0054.
  - Both entries carry the routing guidance: "computing what a customer pays → pos-price; showing a list/MSRP/reference price → pos-catalog."
- Why: ADR-0054 §2 split sell-price authority between pos-catalog (list/MSRP reference) and pos-price (transactional quoting). Until the boundary is recorded where domain agents look, it exists only in the ADR. This is the durion-side companion to the README boundary docs tracked by louisburroughs/durion-positivity-backend#1235.

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated (backend)
- [ ] Consumer/UI tests added/updated (frontend)
- How to run: n/a — documentation only, no code changes.

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert this commit; guide entries are additive documentation with no runtime impact.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, docs branch `docs/adr-0054-boundary-guides` per story
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability for this docs story
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — n/a, decision guides updated; no contract semantics changed
- [ ] Required CI checks passing