### PR TITLE
docs(business-rules): currency-aware quote resolution in pricing contract guide

### DIFF
--- a/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -112,6 +112,12 @@ Headers and auth notes:
 - Base-price writes that would overlap or backdate the latest existing window are rejected with
   `409` and `ApiError` code `PRICE_BASE_WINDOW_CONFLICT`; re-submitting the current open window's
   price is an idempotent no-op.
+- Quote resolution is currency-aware (durion-positivity-backend#1239): `calculatePriceQuote`
+  accepts an optional 3-letter `currency`; when omitted, the company default currency applies
+  (`pos.price.default-currency`, default `USD`). Base-price and location-override selection are
+  filtered to the resolved currency; customer-tier discounts are percentage-based and
+  currency-agnostic. A currency with no applicable base-price window returns `404`
+  `PRICE_BASE_UNAVAILABLE`.
 
 ### Frontend Usage Notes
 

--- a/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -113,7 +113,7 @@ Headers and auth notes:
   `409` and `ApiError` code `PRICE_BASE_WINDOW_CONFLICT`; re-submitting the current open window's
   price is an idempotent no-op.
 - Quote resolution is currency-aware (durion-positivity-backend#1239): `calculatePriceQuote`
-  accepts an optional 3-letter `currency`; when omitted, the company default currency applies
+  accepts an optional ISO 4217 `currency` code; when omitted, the company default currency applies
   (`pos.price.default-currency`, default `USD`). Base-price and location-override selection are
   filtered to the resolved currency; customer-tier discounts are percentage-based and
   currency-agnostic. A currency with no applicable base-price window returns `404`


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:none` — contract-guide documentation for an ADR-0054 follow-up
- Parent STORY (durion): louisburroughs/durion#382 (ADR-0054 decision record)
- Child issue: louisburroughs/durion-positivity-backend#1239
- Domain: `domain:pricing`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): `domains/pricing/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Base Price Effective Windows (currency-aware quote resolution)
- Durion contract PR (if applicable): this PR

## Scope
- What changed: Adds the louisburroughs/durion-positivity-backend#1239 currency decision to the pricing `BACKEND_CONTRACT_GUIDE.md` Base Price Effective Windows section:
  - Optional request `currency` on the price quote request.
  - Company-default fallback when omitted (`pos.price.default-currency`).
  - Currency-filtered base-price and location-override selection.
  - 404 `PRICE_BASE_UNAVAILABLE` for currencies without an applicable window.
- Why: Backend PR https://github.com/louisburroughs/durion-positivity-backend/pull/1240 changes quote-resolution contract semantics; the domain contract guide must record the decision (companion to that PR).

## Tests
- [ ] Unit tests added/updated — N/A: documentation-only change
- [ ] Integration tests added/updated — N/A: documentation-only change
- [ ] Provider behavioral contract tests added/updated (backend) — covered in backend PR louisburroughs/durion-positivity-backend#1240
- [ ] Consumer/UI tests added/updated (frontend) — N/A
- How to run: N/A (docs only)

## Risk & Rollback
- Risk level: Low — documentation-only change.
- Rollback plan: revert the single commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A: no capability; docs branch `docs/1239-currency-guide`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A: no capability
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — this PR is the update
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qf94WzGUfGak57j7xebHT