### PR TITLE
[CAP:317] Positivity contract guide, CAP-317 wave record, and mutation-check tooling

### DIFF
--- a/.claude/hooks/mutation-check-hook.sh
+++ b/.claude/hooks/mutation-check-hook.sh
@@ -154,7 +154,39 @@ if [[ "$test_exit" == "0" ]]; then
   exit 1
 fi
 
-if [[ -n "$expect_message" ]] && ! grep -qF "$expect_message" "$output_file"; then
+# ── Gate 4: a Spring-context test MUST name the assertion it expects to fail ───────────
+# A test that boots a Spring context has two ways to fail, and they look the same from out here: the
+# assertion under test firing, or the context failing to start. The second happens for reasons that have
+# nothing to do with the guarantee -- a mutation that breaks a bean definition, a missing property, a
+# constructor signature the mutation invalidated -- and it is indistinguishable from success at the exit-code
+# level. Recording that as DEFENDED would be the same class of false evidence as the "Tests run: 0" bug.
+#
+# So for those tests, --expect-fail-message is required rather than optional. Detected by the annotations
+# actually present in the test source, not by naming convention.
+#
+# Checked AFTER the run rather than before, deliberately: when the selector is also wrong, the
+# 'no tests actually ran' abort above is the more useful message, and reporting a missing argument
+# would mask it.
+if [[ -z "$expect_message" ]]; then
+  test_class="${test_selector%%#*}"
+  test_class="${test_class%%\$*}"
+  context_test_file="$(find . -path ./target -prune -o -name "${test_class}.java" -print 2>/dev/null | head -1)"
+  if [[ -n "$context_test_file" ]] && grep -qE '@(SpringBootTest|DataJpaTest|WebMvcTest|SpringJUnitConfig|ContextConfiguration)' "$context_test_file"; then
+    echo "MUTATION CHECK ABORTED | '$test_class' loads a Spring context, so --expect-fail-message is required." >&2
+    echo "  A context test can fail because the assertion fired OR because the mutation broke context" >&2
+    echo "  startup, and those are indistinguishable by exit code. Without the expected message, a" >&2
+    echo "  DEFENDED verdict would not mean the guarantee is defended." >&2
+    echo "  Pass the text the failure must contain -- note that AssertJ's .as(...) description is NOT" >&2
+    echo "  included when assertThatThrownBy fails because nothing was thrown, so match on the assertion" >&2
+    echo "  text ('Expecting code to raise a throwable', 'expected: ... but was: ...') in that case." >&2
+    rm -f "$output_file"
+    exit 1
+  fi
+fi
+
+# `grep -qF --` : an expected message may start with a dash; without the terminator grep would read it
+# as a flag and report a spurious mismatch.
+if [[ -n "$expect_message" ]] && ! grep -qF -- "$expect_message" "$output_file"; then
   echo "MUTATION CHECK RESULT: FAILED FOR THE WRONG REASON"
   echo "  The test failed, but its output does not contain: $expect_message"
   echo "  It may be failing on setup or an unrelated assertion rather than the guarantee."

--- a/.claude/hooks/mutation-check-hook.sh
+++ b/.claude/hooks/mutation-check-hook.sh
@@ -129,10 +129,19 @@ JAVA_HOME="$java_home" ./mvnw -o -pl "$module" test \
 test_exit=$?
 set -e
 
-ran=$(grep -cE "Tests run:" "$output_file" || true)
-if [[ "$ran" == "0" ]]; then
-  echo "MUTATION CHECK ABORTED | no tests ran for selector '$test_selector' — check the selector." >&2
-  grep -E "ERROR|BUILD" "$output_file" | head -10 >&2 || true
+# The COUNT must be non-zero, not merely present. Maven prints a "Tests run: 0, Failures: 0" summary
+# even when a selector matched nothing, so grepping for the line's existence accepted a run in which
+# nothing executed — and a run with no tests neither fails nor proves anything, which gate 3 would then
+# report as UNDEFENDED. That is this hook's own failure mode wearing a different hat; it was hit for
+# real on a `Class#method` selector naming a method inside a @Nested class (surefire needs
+# `Class$Nested#method`).
+executed=$(grep -oE "Tests run: [0-9]+" "$output_file" | grep -oE "[0-9]+$" | sort -rn | head -1 || true)
+executed="${executed:-0}"
+if [[ "$executed" == "0" ]]; then
+  echo "MUTATION CHECK ABORTED | no tests actually ran for selector '$test_selector'." >&2
+  echo "  Maven reported 'Tests run: 0'. The selector matched nothing, so NOTHING was proven either" >&2
+  echo "  way. For a method in a @Nested class use 'Outer\$Nested#method'." >&2
+  grep -E "Tests run:|ERROR|BUILD" "$output_file" | head -10 >&2 || true
   rm -f "$output_file"
   exit 1
 fi

--- a/.claude/hooks/mutation-check-hook.sh
+++ b/.claude/hooks/mutation-check-hook.sh
@@ -18,8 +18,11 @@ set -euo pipefail
 # The original file is restored unconditionally, including on error or interrupt, and the restoration is
 # itself verified byte-for-byte.
 #
+# This script is mirrored, byte-identical, at .github/hooks/ and .claude/hooks/. Run whichever copy you
+# are reading; the self-test resolves its hook as a sibling of itself, so each copy tests itself.
+#
 # Usage:
-#   ./.github/hooks/mutation-check-hook.sh \
+#   mutation-check-hook.sh \
 #     --repo /abs/path/to/durion-positivity-backend \
 #     --file pos-supplier/src/main/java/.../Foo.java \
 #     --find 'the exact source text to remove or change' \
@@ -35,6 +38,11 @@ repo_path=""
 target_file=""
 find_text=""
 replace_text=""
+# Tracked separately from replace_text because an EMPTY replacement is legitimate (deleting the matched
+# text is a common mutation), so emptiness cannot distinguish "--replace ''" from "--replace omitted".
+# Without this, forgetting the flag silently deletes the matched text and reports the result as though
+# the intended mutation had been applied.
+replace_given=""
 module=""
 test_selector=""
 expect_message=""
@@ -47,12 +55,14 @@ while [[ $# -gt 0 ]]; do
     --repo) repo_path="$2"; shift 2 ;;
     --file) target_file="$2"; shift 2 ;;
     --find) find_text="$2"; shift 2 ;;
-    --replace) replace_text="$2"; shift 2 ;;
+    --replace) replace_text="$2"; replace_given=1; shift 2 ;;
     --module) module="$2"; shift 2 ;;
     --test) test_selector="$2"; shift 2 ;;
     --expect-fail-message) expect_message="$2"; shift 2 ;;
     --java-home) java_home="$2"; shift 2 ;;
-    -h|--help) sed -n '3,30p' "$0"; exit 0 ;;
+    # Prints the whole leading comment block. Derived from the file rather than a hard-coded line range,
+    # which silently truncated help whenever the block grew.
+    -h|--help) awk 'NR < 3 { next } /^#/ { sub(/^# ?/, ""); print; started = 1; next } started { exit }' "$0"; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -63,6 +73,12 @@ for required in repo_path target_file find_text module test_selector; do
     exit 1
   fi
 done
+
+# Checked apart from the loop above: --replace must be PRESENT, but its value may be empty.
+if [[ -z "$replace_given" ]]; then
+  echo "MUTATION CHECK MISUSE | --replace is required; pass --replace '' to delete the matched text" >&2
+  exit 1
+fi
 
 cd "$repo_path"
 if [[ ! -f "$target_file" ]]; then

--- a/.claude/hooks/mutation-check-hook.sh
+++ b/.claude/hooks/mutation-check-hook.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mutation-check hook: prove a test actually defends the guarantee it claims to.
+#
+# WHY THIS EXISTS
+# A mutation check is only evidence if the mutation was really applied. During CAP-317 a hand-rolled
+# mutation script reported success while its search pattern silently failed to match (the file had been
+# reformatted by spotless). The test then PASSED, which would have been recorded as "the guard is
+# proven" when nothing had been tested at all — the same "passes for the wrong reason" defect class the
+# tests themselves exist to catch.
+#
+# This hook makes the three things that made that possible impossible to skip:
+#   1. The search pattern must match EXACTLY ONCE, or the run aborts before touching anything.
+#   2. The file must actually differ after mutation, or the run aborts.
+#   3. The test must FAIL under mutation. A pass means the guarantee is undefended, and the hook
+#      reports that as the finding it is rather than as success.
+# The original file is restored unconditionally, including on error or interrupt, and the restoration is
+# itself verified byte-for-byte.
+#
+# Usage:
+#   ./.github/hooks/mutation-check-hook.sh \
+#     --repo /abs/path/to/durion-positivity-backend \
+#     --file pos-supplier/src/main/java/.../Foo.java \
+#     --find 'the exact source text to remove or change' \
+#     --replace 'what to put in its place (may be empty)' \
+#     --module pos-supplier \
+#     --test 'FooTest#theGuaranteeUnderTest' \
+#     [--expect-fail-message 'substring the failure output must contain']
+#
+# Exit codes: 0 = mutation applied AND the test failed (the guarantee is defended)
+#             1 = misuse, pattern problem, or the test PASSED under mutation (guarantee undefended)
+
+repo_path=""
+target_file=""
+find_text=""
+replace_text=""
+module=""
+test_selector=""
+expect_message=""
+# The backend enforcer requires Java 25. An inherited JAVA_HOME pointing at an older JDK makes every
+# run fail on the enforcer, which the gates below would report as "no tests ran" rather than a result.
+java_home="${MUTATION_CHECK_JAVA_HOME:-/opt/jdk25}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo_path="$2"; shift 2 ;;
+    --file) target_file="$2"; shift 2 ;;
+    --find) find_text="$2"; shift 2 ;;
+    --replace) replace_text="$2"; shift 2 ;;
+    --module) module="$2"; shift 2 ;;
+    --test) test_selector="$2"; shift 2 ;;
+    --expect-fail-message) expect_message="$2"; shift 2 ;;
+    --java-home) java_home="$2"; shift 2 ;;
+    -h|--help) sed -n '3,30p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+for required in repo_path target_file find_text module test_selector; do
+  if [[ -z "${!required}" ]]; then
+    echo "MUTATION CHECK MISUSE | --${required//_/-} is required" >&2
+    exit 1
+  fi
+done
+
+cd "$repo_path"
+if [[ ! -f "$target_file" ]]; then
+  echo "MUTATION CHECK MISUSE | file not found: $target_file" >&2
+  exit 1
+fi
+
+backup="$(mktemp)"
+cp "$target_file" "$backup"
+
+restore() {
+  cp "$backup" "$target_file"
+  if ! cmp -s "$backup" "$target_file"; then
+    echo "MUTATION CHECK FATAL | could not restore $target_file — restore it from git before continuing" >&2
+    exit 1
+  fi
+  rm -f "$backup"
+}
+# Restore on ANY exit path, including a failed test or an interrupt: a mutation left in the tree is
+# far worse than a missing check.
+trap restore EXIT INT TERM
+
+# ── Gate 1: the pattern must match exactly once ────────────────────────────────────────
+occurrences=$(FIND="$find_text" python3 -c '
+import os, sys
+needle = os.environ["FIND"]
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(handle.read().count(needle))
+' "$target_file")
+
+if [[ "$occurrences" != "1" ]]; then
+  echo "MUTATION CHECK ABORTED | pattern matched ${occurrences} times, expected exactly 1."
+  echo "  This is the failure mode this hook exists for: a non-matching pattern would have left the"
+  echo "  source unchanged, the test would have PASSED, and the guarantee would have been recorded as"
+  echo "  proven without being tested. Re-read the current file text (formatters rewrite it)."
+  exit 1
+fi
+
+# ── Apply ─────────────────────────────────────────────────────────────────────────────
+FIND="$find_text" REPLACE="$replace_text" python3 -c '
+import os, sys
+needle, replacement = os.environ["FIND"], os.environ["REPLACE"]
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text.replace(needle, replacement, 1))
+' "$target_file"
+
+# ── Gate 2: the file must actually have changed ────────────────────────────────────────
+if cmp -s "$backup" "$target_file"; then
+  echo "MUTATION CHECK ABORTED | file is byte-identical after mutation; nothing was changed." >&2
+  exit 1
+fi
+echo "Mutation applied to $target_file:"
+diff <(cat "$backup") "$target_file" | sed 's/^/    /' | head -20 || true
+echo
+
+# ── Gate 3: the test must fail ────────────────────────────────────────────────────────
+output_file="$(mktemp)"
+set +e
+JAVA_HOME="$java_home" ./mvnw -o -pl "$module" test \
+  -Dtest="$test_selector" -DfailIfNoSpecifiedTests=false > "$output_file" 2>&1
+test_exit=$?
+set -e
+
+ran=$(grep -cE "Tests run:" "$output_file" || true)
+if [[ "$ran" == "0" ]]; then
+  echo "MUTATION CHECK ABORTED | no tests ran for selector '$test_selector' — check the selector." >&2
+  grep -E "ERROR|BUILD" "$output_file" | head -10 >&2 || true
+  rm -f "$output_file"
+  exit 1
+fi
+
+if [[ "$test_exit" == "0" ]]; then
+  echo "MUTATION CHECK RESULT: UNDEFENDED"
+  echo "  '$test_selector' PASSED with the guarantee removed, so it does not actually test it."
+  echo "  Treat this as a finding: the test needs strengthening, not the mutation retrying."
+  rm -f "$output_file"
+  exit 1
+fi
+
+if [[ -n "$expect_message" ]] && ! grep -qF "$expect_message" "$output_file"; then
+  echo "MUTATION CHECK RESULT: FAILED FOR THE WRONG REASON"
+  echo "  The test failed, but its output does not contain: $expect_message"
+  echo "  It may be failing on setup or an unrelated assertion rather than the guarantee."
+  grep -E "expected|but was|Tests run:" "$output_file" | head -10 | sed 's/^/    /'
+  rm -f "$output_file"
+  exit 1
+fi
+
+echo "MUTATION CHECK RESULT: DEFENDED"
+grep -E "Tests run:|expected|but was" "$output_file" | head -6 | sed 's/^/    /'
+rm -f "$output_file"
+exit 0

--- a/.claude/hooks/mutation-check-selftest.sh
+++ b/.claude/hooks/mutation-check-selftest.sh
@@ -62,6 +62,10 @@ fixture_replace='@Transactional'
 fixture_class="SupplierExchangeAuditPersistenceTest"
 fixture_nested="PayloadReads"
 fixture_method="keepsTheAccessRecordWhenTheStoredContentCannotBeDecrypted"
+# What the failure output must contain. Deliberately NOT the AssertJ .as(...) description: when
+# assertThatThrownBy fails because nothing was thrown at all, AssertJ raises before the description is
+# attached, so matching on it would report FAILED FOR THE WRONG REASON on a perfectly good check.
+fixture_expected_message="noRollbackFor must keep this record"
 
 failures=0
 case_number=0
@@ -84,7 +88,9 @@ expect() {
     echo "   FAIL | expected exit ${expected_exit}, got ${actual_exit}"
     ok=false
   fi
-  if ! grep -qF "$expected_text" <<<"$output"; then
+  # `grep -qF --` : the expected text can legitimately start with a dash (an option name being
+  # reported), and without the terminator grep would parse it as its own flag and fail confusingly.
+  if ! grep -qF -- "$expected_text" <<<"$output"; then
     echo "   FAIL | output did not contain: ${expected_text}"
     ok=false
   fi
@@ -137,7 +143,8 @@ expect "the same guard with Class\$Nested#method reports DEFENDED" \
   0 "MUTATION CHECK RESULT: DEFENDED" \
   "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
   --find "$fixture_find" --replace "$fixture_replace" \
-  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}" \
+  --expect-fail-message "$fixture_expected_message"
 
 # ── Case 4: gate 1 still guards a stale pattern ───────────────────────────────────────
 # The hook's original reason for existing: a search pattern that no longer matches (formatters rewrite
@@ -146,6 +153,17 @@ expect "a pattern that matches nothing aborts before running any test" \
   1 "pattern matched 0 times" \
   "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
   --find 'this text is deliberately absent from the source' --replace 'x' \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}" \
+  --expect-fail-message "$fixture_expected_message"
+
+# ── Case 5: a Spring-context test without --expect-fail-message must be refused ────────
+# A context test can fail because the assertion fired or because the mutation broke context startup, and
+# those are indistinguishable by exit code. The fixture is a @DataJpaTest, so omitting the expected message
+# must be refused rather than yielding a verdict that cannot mean what it says.
+expect "a Spring-context test without --expect-fail-message is refused" \
+  1 "--expect-fail-message is required" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
   --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
 
 echo

--- a/.claude/hooks/mutation-check-selftest.sh
+++ b/.claude/hooks/mutation-check-selftest.sh
@@ -19,8 +19,12 @@ set -euo pipefail
 # considered sufficient evidence, not in string handling — so these cases drive the real hook end to end
 # against real Maven output.
 #
+# This script is mirrored, byte-identical, at .github/hooks/ and .claude/hooks/. Run whichever copy you
+# are reading: it resolves the hook under test as a sibling of itself, so each copy tests the hook that
+# sits beside it.
+#
 # Usage:
-#   ./.github/hooks/mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
+#   mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
 #
 # Exit codes: 0 = every case behaved as specified
 #             1 = the hook misbehaved (details printed), or the fixture no longer matches the codebase

--- a/.claude/hooks/mutation-check-selftest.sh
+++ b/.claude/hooks/mutation-check-selftest.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for mutation-check-hook.sh.
+#
+# WHY THIS EXISTS
+# The mutation hook's entire value is that it does not lie. It reports whether a guarantee is defended,
+# and every "DEFENDED" recorded in a wave ledger is trusted on its word — so a bug in the hook silently
+# devalues every check that ran through it.
+#
+# It has already had one such bug. Gate 3 checked that a "Tests run:" line EXISTED in the Maven output;
+# Maven prints "Tests run: 0, Failures: 0" when a selector matches nothing, so a run in which nothing
+# executed passed the gate and was then reported as UNDEFENDED — a false finding, which is worse than no
+# finding. The trigger was mundane: surefire's `Class#method` does not match a method inside a @Nested
+# class (it needs `Class$Nested#method`), and this codebase uses @Nested heavily.
+#
+# The nested-selector case is therefore the first thing this script covers. Isolated unit-testing of the
+# count-parsing expression would NOT have caught the original bug, because the bug was in what the gate
+# considered sufficient evidence, not in string handling — so these cases drive the real hook end to end
+# against real Maven output.
+#
+# Usage:
+#   ./.github/hooks/mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
+#
+# Exit codes: 0 = every case behaved as specified
+#             1 = the hook misbehaved (details printed), or the fixture no longer matches the codebase
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="${script_dir}/mutation-check-hook.sh"
+repo_path="${MUTATION_CHECK_SELFTEST_REPO:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo_path="$2"; shift 2 ;;
+    -h|--help) sed -n '3,28p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$repo_path" ]]; then
+  # Sibling layout, matching the rest of the hooks.
+  repo_path="$(cd "${script_dir}/../.." && pwd)/durion-positivity-backend"
+fi
+
+if [[ ! -x "$hook" ]]; then
+  echo "SELFTEST MISUSE | hook not executable at $hook" >&2
+  exit 1
+fi
+if [[ ! -d "$repo_path" ]]; then
+  echo "SELFTEST MISUSE | backend repo not found at $repo_path (pass --repo)" >&2
+  exit 1
+fi
+
+# ── Fixture ───────────────────────────────────────────────────────────────────────────
+# A real guard with a real test, deliberately rather than a synthetic one: the bug being guarded against
+# only appears against genuine surefire output. If this code moves, the self-test fails loudly with
+# "pattern matched 0 times" — which is correct behaviour, not breakage. Repoint the fixture.
+fixture_module="pos-supplier"
+fixture_file="pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierExchangeAuditServiceImpl.java"
+fixture_find='@Transactional(noRollbackFor = PayloadUnreadableException.class)'
+fixture_replace='@Transactional'
+fixture_class="SupplierExchangeAuditPersistenceTest"
+fixture_nested="PayloadReads"
+fixture_method="keepsTheAccessRecordWhenTheStoredContentCannotBeDecrypted"
+
+failures=0
+case_number=0
+
+# Runs the hook and asserts an expected exit code and an expected substring in its output.
+expect() {
+  local description="$1" expected_exit="$2" expected_text="$3"
+  shift 3
+  case_number=$((case_number + 1))
+  echo "── case ${case_number}: ${description}"
+
+  local output actual_exit
+  set +e
+  output="$("$@" 2>&1)"
+  actual_exit=$?
+  set -e
+
+  local ok=true
+  if [[ "$actual_exit" != "$expected_exit" ]]; then
+    echo "   FAIL | expected exit ${expected_exit}, got ${actual_exit}"
+    ok=false
+  fi
+  if ! grep -qF "$expected_text" <<<"$output"; then
+    echo "   FAIL | output did not contain: ${expected_text}"
+    ok=false
+  fi
+
+  # The hook restores on every exit path, including error and interrupt. Verify that here rather than
+  # trusting it: a hook that leaves a mutation in the tree is far worse than one that misreports.
+  if ! git -C "$repo_path" diff --quiet -- "$fixture_file"; then
+    echo "   FAIL | ${fixture_file} was left mutated"
+    git -C "$repo_path" checkout -- "$fixture_file"
+    ok=false
+  fi
+
+  if $ok; then
+    echo "   ok"
+  else
+    echo "   ---- hook output ----"
+    sed 's/^/   | /' <<<"$output" | tail -25
+    failures=$((failures + 1))
+  fi
+}
+
+if ! git -C "$repo_path" diff --quiet -- "$fixture_file"; then
+  echo "SELFTEST MISUSE | ${fixture_file} has uncommitted changes; the restoration check needs a clean" >&2
+  echo "  baseline to compare against. Commit or stash first." >&2
+  exit 1
+fi
+
+echo "Mutation-check self-test | hook=${hook} | repo=${repo_path}"
+echo
+
+# ── Case 1: THE REGRESSION ────────────────────────────────────────────────────────────
+# A method inside a @Nested class addressed with the plain `Class#method` form. Surefire matches nothing
+# and Maven exits 0 having printed "Tests run: 0". The hook must ABORT and say so. Before the fix it
+# reported UNDEFENDED — asserting that a guarantee was untested on the strength of no test having run.
+expect "nested method addressed as Class#method aborts instead of reporting UNDEFENDED" \
+  1 "no tests actually ran" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}#${fixture_method}"
+
+# The abort must also point at the fix, or the next person re-runs it and draws the same false conclusion.
+expect "the abort message names the \$Nested selector form" \
+  1 'Outer$Nested#method' \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}#${fixture_method}"
+
+# ── Case 3: the same check, addressed correctly, must reach a real verdict ─────────────
+expect "the same guard with Class\$Nested#method reports DEFENDED" \
+  0 "MUTATION CHECK RESULT: DEFENDED" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+
+# ── Case 4: gate 1 still guards a stale pattern ───────────────────────────────────────
+# The hook's original reason for existing: a search pattern that no longer matches (formatters rewrite
+# source constantly) must abort before anything runs, never produce a pass.
+expect "a pattern that matches nothing aborts before running any test" \
+  1 "pattern matched 0 times" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find 'this text is deliberately absent from the source' --replace 'x' \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+
+echo
+if [[ "$failures" == "0" ]]; then
+  echo "SELFTEST PASS | ${case_number} cases, the hook behaves as specified"
+  exit 0
+fi
+echo "SELFTEST FAIL | ${failures} of ${case_number} cases misbehaved" >&2
+echo "  The mutation hook is only worth running if it cannot lie. Fix it before trusting any" >&2
+echo "  DEFENDED/UNDEFENDED result produced by it." >&2
+exit 1

--- a/.github/hooks/mutation-check-hook.sh
+++ b/.github/hooks/mutation-check-hook.sh
@@ -154,7 +154,39 @@ if [[ "$test_exit" == "0" ]]; then
   exit 1
 fi
 
-if [[ -n "$expect_message" ]] && ! grep -qF "$expect_message" "$output_file"; then
+# ── Gate 4: a Spring-context test MUST name the assertion it expects to fail ───────────
+# A test that boots a Spring context has two ways to fail, and they look the same from out here: the
+# assertion under test firing, or the context failing to start. The second happens for reasons that have
+# nothing to do with the guarantee -- a mutation that breaks a bean definition, a missing property, a
+# constructor signature the mutation invalidated -- and it is indistinguishable from success at the exit-code
+# level. Recording that as DEFENDED would be the same class of false evidence as the "Tests run: 0" bug.
+#
+# So for those tests, --expect-fail-message is required rather than optional. Detected by the annotations
+# actually present in the test source, not by naming convention.
+#
+# Checked AFTER the run rather than before, deliberately: when the selector is also wrong, the
+# 'no tests actually ran' abort above is the more useful message, and reporting a missing argument
+# would mask it.
+if [[ -z "$expect_message" ]]; then
+  test_class="${test_selector%%#*}"
+  test_class="${test_class%%\$*}"
+  context_test_file="$(find . -path ./target -prune -o -name "${test_class}.java" -print 2>/dev/null | head -1)"
+  if [[ -n "$context_test_file" ]] && grep -qE '@(SpringBootTest|DataJpaTest|WebMvcTest|SpringJUnitConfig|ContextConfiguration)' "$context_test_file"; then
+    echo "MUTATION CHECK ABORTED | '$test_class' loads a Spring context, so --expect-fail-message is required." >&2
+    echo "  A context test can fail because the assertion fired OR because the mutation broke context" >&2
+    echo "  startup, and those are indistinguishable by exit code. Without the expected message, a" >&2
+    echo "  DEFENDED verdict would not mean the guarantee is defended." >&2
+    echo "  Pass the text the failure must contain -- note that AssertJ's .as(...) description is NOT" >&2
+    echo "  included when assertThatThrownBy fails because nothing was thrown, so match on the assertion" >&2
+    echo "  text ('Expecting code to raise a throwable', 'expected: ... but was: ...') in that case." >&2
+    rm -f "$output_file"
+    exit 1
+  fi
+fi
+
+# `grep -qF --` : an expected message may start with a dash; without the terminator grep would read it
+# as a flag and report a spurious mismatch.
+if [[ -n "$expect_message" ]] && ! grep -qF -- "$expect_message" "$output_file"; then
   echo "MUTATION CHECK RESULT: FAILED FOR THE WRONG REASON"
   echo "  The test failed, but its output does not contain: $expect_message"
   echo "  It may be failing on setup or an unrelated assertion rather than the guarantee."

--- a/.github/hooks/mutation-check-hook.sh
+++ b/.github/hooks/mutation-check-hook.sh
@@ -129,10 +129,19 @@ JAVA_HOME="$java_home" ./mvnw -o -pl "$module" test \
 test_exit=$?
 set -e
 
-ran=$(grep -cE "Tests run:" "$output_file" || true)
-if [[ "$ran" == "0" ]]; then
-  echo "MUTATION CHECK ABORTED | no tests ran for selector '$test_selector' — check the selector." >&2
-  grep -E "ERROR|BUILD" "$output_file" | head -10 >&2 || true
+# The COUNT must be non-zero, not merely present. Maven prints a "Tests run: 0, Failures: 0" summary
+# even when a selector matched nothing, so grepping for the line's existence accepted a run in which
+# nothing executed — and a run with no tests neither fails nor proves anything, which gate 3 would then
+# report as UNDEFENDED. That is this hook's own failure mode wearing a different hat; it was hit for
+# real on a `Class#method` selector naming a method inside a @Nested class (surefire needs
+# `Class$Nested#method`).
+executed=$(grep -oE "Tests run: [0-9]+" "$output_file" | grep -oE "[0-9]+$" | sort -rn | head -1 || true)
+executed="${executed:-0}"
+if [[ "$executed" == "0" ]]; then
+  echo "MUTATION CHECK ABORTED | no tests actually ran for selector '$test_selector'." >&2
+  echo "  Maven reported 'Tests run: 0'. The selector matched nothing, so NOTHING was proven either" >&2
+  echo "  way. For a method in a @Nested class use 'Outer\$Nested#method'." >&2
+  grep -E "Tests run:|ERROR|BUILD" "$output_file" | head -10 >&2 || true
   rm -f "$output_file"
   exit 1
 fi

--- a/.github/hooks/mutation-check-hook.sh
+++ b/.github/hooks/mutation-check-hook.sh
@@ -18,8 +18,11 @@ set -euo pipefail
 # The original file is restored unconditionally, including on error or interrupt, and the restoration is
 # itself verified byte-for-byte.
 #
+# This script is mirrored, byte-identical, at .github/hooks/ and .claude/hooks/. Run whichever copy you
+# are reading; the self-test resolves its hook as a sibling of itself, so each copy tests itself.
+#
 # Usage:
-#   ./.github/hooks/mutation-check-hook.sh \
+#   mutation-check-hook.sh \
 #     --repo /abs/path/to/durion-positivity-backend \
 #     --file pos-supplier/src/main/java/.../Foo.java \
 #     --find 'the exact source text to remove or change' \
@@ -35,6 +38,11 @@ repo_path=""
 target_file=""
 find_text=""
 replace_text=""
+# Tracked separately from replace_text because an EMPTY replacement is legitimate (deleting the matched
+# text is a common mutation), so emptiness cannot distinguish "--replace ''" from "--replace omitted".
+# Without this, forgetting the flag silently deletes the matched text and reports the result as though
+# the intended mutation had been applied.
+replace_given=""
 module=""
 test_selector=""
 expect_message=""
@@ -47,12 +55,14 @@ while [[ $# -gt 0 ]]; do
     --repo) repo_path="$2"; shift 2 ;;
     --file) target_file="$2"; shift 2 ;;
     --find) find_text="$2"; shift 2 ;;
-    --replace) replace_text="$2"; shift 2 ;;
+    --replace) replace_text="$2"; replace_given=1; shift 2 ;;
     --module) module="$2"; shift 2 ;;
     --test) test_selector="$2"; shift 2 ;;
     --expect-fail-message) expect_message="$2"; shift 2 ;;
     --java-home) java_home="$2"; shift 2 ;;
-    -h|--help) sed -n '3,30p' "$0"; exit 0 ;;
+    # Prints the whole leading comment block. Derived from the file rather than a hard-coded line range,
+    # which silently truncated help whenever the block grew.
+    -h|--help) awk 'NR < 3 { next } /^#/ { sub(/^# ?/, ""); print; started = 1; next } started { exit }' "$0"; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -63,6 +73,12 @@ for required in repo_path target_file find_text module test_selector; do
     exit 1
   fi
 done
+
+# Checked apart from the loop above: --replace must be PRESENT, but its value may be empty.
+if [[ -z "$replace_given" ]]; then
+  echo "MUTATION CHECK MISUSE | --replace is required; pass --replace '' to delete the matched text" >&2
+  exit 1
+fi
 
 cd "$repo_path"
 if [[ ! -f "$target_file" ]]; then

--- a/.github/hooks/mutation-check-hook.sh
+++ b/.github/hooks/mutation-check-hook.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mutation-check hook: prove a test actually defends the guarantee it claims to.
+#
+# WHY THIS EXISTS
+# A mutation check is only evidence if the mutation was really applied. During CAP-317 a hand-rolled
+# mutation script reported success while its search pattern silently failed to match (the file had been
+# reformatted by spotless). The test then PASSED, which would have been recorded as "the guard is
+# proven" when nothing had been tested at all — the same "passes for the wrong reason" defect class the
+# tests themselves exist to catch.
+#
+# This hook makes the three things that made that possible impossible to skip:
+#   1. The search pattern must match EXACTLY ONCE, or the run aborts before touching anything.
+#   2. The file must actually differ after mutation, or the run aborts.
+#   3. The test must FAIL under mutation. A pass means the guarantee is undefended, and the hook
+#      reports that as the finding it is rather than as success.
+# The original file is restored unconditionally, including on error or interrupt, and the restoration is
+# itself verified byte-for-byte.
+#
+# Usage:
+#   ./.github/hooks/mutation-check-hook.sh \
+#     --repo /abs/path/to/durion-positivity-backend \
+#     --file pos-supplier/src/main/java/.../Foo.java \
+#     --find 'the exact source text to remove or change' \
+#     --replace 'what to put in its place (may be empty)' \
+#     --module pos-supplier \
+#     --test 'FooTest#theGuaranteeUnderTest' \
+#     [--expect-fail-message 'substring the failure output must contain']
+#
+# Exit codes: 0 = mutation applied AND the test failed (the guarantee is defended)
+#             1 = misuse, pattern problem, or the test PASSED under mutation (guarantee undefended)
+
+repo_path=""
+target_file=""
+find_text=""
+replace_text=""
+module=""
+test_selector=""
+expect_message=""
+# The backend enforcer requires Java 25. An inherited JAVA_HOME pointing at an older JDK makes every
+# run fail on the enforcer, which the gates below would report as "no tests ran" rather than a result.
+java_home="${MUTATION_CHECK_JAVA_HOME:-/opt/jdk25}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo_path="$2"; shift 2 ;;
+    --file) target_file="$2"; shift 2 ;;
+    --find) find_text="$2"; shift 2 ;;
+    --replace) replace_text="$2"; shift 2 ;;
+    --module) module="$2"; shift 2 ;;
+    --test) test_selector="$2"; shift 2 ;;
+    --expect-fail-message) expect_message="$2"; shift 2 ;;
+    --java-home) java_home="$2"; shift 2 ;;
+    -h|--help) sed -n '3,30p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+for required in repo_path target_file find_text module test_selector; do
+  if [[ -z "${!required}" ]]; then
+    echo "MUTATION CHECK MISUSE | --${required//_/-} is required" >&2
+    exit 1
+  fi
+done
+
+cd "$repo_path"
+if [[ ! -f "$target_file" ]]; then
+  echo "MUTATION CHECK MISUSE | file not found: $target_file" >&2
+  exit 1
+fi
+
+backup="$(mktemp)"
+cp "$target_file" "$backup"
+
+restore() {
+  cp "$backup" "$target_file"
+  if ! cmp -s "$backup" "$target_file"; then
+    echo "MUTATION CHECK FATAL | could not restore $target_file — restore it from git before continuing" >&2
+    exit 1
+  fi
+  rm -f "$backup"
+}
+# Restore on ANY exit path, including a failed test or an interrupt: a mutation left in the tree is
+# far worse than a missing check.
+trap restore EXIT INT TERM
+
+# ── Gate 1: the pattern must match exactly once ────────────────────────────────────────
+occurrences=$(FIND="$find_text" python3 -c '
+import os, sys
+needle = os.environ["FIND"]
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(handle.read().count(needle))
+' "$target_file")
+
+if [[ "$occurrences" != "1" ]]; then
+  echo "MUTATION CHECK ABORTED | pattern matched ${occurrences} times, expected exactly 1."
+  echo "  This is the failure mode this hook exists for: a non-matching pattern would have left the"
+  echo "  source unchanged, the test would have PASSED, and the guarantee would have been recorded as"
+  echo "  proven without being tested. Re-read the current file text (formatters rewrite it)."
+  exit 1
+fi
+
+# ── Apply ─────────────────────────────────────────────────────────────────────────────
+FIND="$find_text" REPLACE="$replace_text" python3 -c '
+import os, sys
+needle, replacement = os.environ["FIND"], os.environ["REPLACE"]
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text.replace(needle, replacement, 1))
+' "$target_file"
+
+# ── Gate 2: the file must actually have changed ────────────────────────────────────────
+if cmp -s "$backup" "$target_file"; then
+  echo "MUTATION CHECK ABORTED | file is byte-identical after mutation; nothing was changed." >&2
+  exit 1
+fi
+echo "Mutation applied to $target_file:"
+diff <(cat "$backup") "$target_file" | sed 's/^/    /' | head -20 || true
+echo
+
+# ── Gate 3: the test must fail ────────────────────────────────────────────────────────
+output_file="$(mktemp)"
+set +e
+JAVA_HOME="$java_home" ./mvnw -o -pl "$module" test \
+  -Dtest="$test_selector" -DfailIfNoSpecifiedTests=false > "$output_file" 2>&1
+test_exit=$?
+set -e
+
+ran=$(grep -cE "Tests run:" "$output_file" || true)
+if [[ "$ran" == "0" ]]; then
+  echo "MUTATION CHECK ABORTED | no tests ran for selector '$test_selector' — check the selector." >&2
+  grep -E "ERROR|BUILD" "$output_file" | head -10 >&2 || true
+  rm -f "$output_file"
+  exit 1
+fi
+
+if [[ "$test_exit" == "0" ]]; then
+  echo "MUTATION CHECK RESULT: UNDEFENDED"
+  echo "  '$test_selector' PASSED with the guarantee removed, so it does not actually test it."
+  echo "  Treat this as a finding: the test needs strengthening, not the mutation retrying."
+  rm -f "$output_file"
+  exit 1
+fi
+
+if [[ -n "$expect_message" ]] && ! grep -qF "$expect_message" "$output_file"; then
+  echo "MUTATION CHECK RESULT: FAILED FOR THE WRONG REASON"
+  echo "  The test failed, but its output does not contain: $expect_message"
+  echo "  It may be failing on setup or an unrelated assertion rather than the guarantee."
+  grep -E "expected|but was|Tests run:" "$output_file" | head -10 | sed 's/^/    /'
+  rm -f "$output_file"
+  exit 1
+fi
+
+echo "MUTATION CHECK RESULT: DEFENDED"
+grep -E "Tests run:|expected|but was" "$output_file" | head -6 | sed 's/^/    /'
+rm -f "$output_file"
+exit 0

--- a/.github/hooks/mutation-check-selftest.sh
+++ b/.github/hooks/mutation-check-selftest.sh
@@ -62,6 +62,10 @@ fixture_replace='@Transactional'
 fixture_class="SupplierExchangeAuditPersistenceTest"
 fixture_nested="PayloadReads"
 fixture_method="keepsTheAccessRecordWhenTheStoredContentCannotBeDecrypted"
+# What the failure output must contain. Deliberately NOT the AssertJ .as(...) description: when
+# assertThatThrownBy fails because nothing was thrown at all, AssertJ raises before the description is
+# attached, so matching on it would report FAILED FOR THE WRONG REASON on a perfectly good check.
+fixture_expected_message="noRollbackFor must keep this record"
 
 failures=0
 case_number=0
@@ -84,7 +88,9 @@ expect() {
     echo "   FAIL | expected exit ${expected_exit}, got ${actual_exit}"
     ok=false
   fi
-  if ! grep -qF "$expected_text" <<<"$output"; then
+  # `grep -qF --` : the expected text can legitimately start with a dash (an option name being
+  # reported), and without the terminator grep would parse it as its own flag and fail confusingly.
+  if ! grep -qF -- "$expected_text" <<<"$output"; then
     echo "   FAIL | output did not contain: ${expected_text}"
     ok=false
   fi
@@ -137,7 +143,8 @@ expect "the same guard with Class\$Nested#method reports DEFENDED" \
   0 "MUTATION CHECK RESULT: DEFENDED" \
   "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
   --find "$fixture_find" --replace "$fixture_replace" \
-  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}" \
+  --expect-fail-message "$fixture_expected_message"
 
 # ── Case 4: gate 1 still guards a stale pattern ───────────────────────────────────────
 # The hook's original reason for existing: a search pattern that no longer matches (formatters rewrite
@@ -146,6 +153,17 @@ expect "a pattern that matches nothing aborts before running any test" \
   1 "pattern matched 0 times" \
   "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
   --find 'this text is deliberately absent from the source' --replace 'x' \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}" \
+  --expect-fail-message "$fixture_expected_message"
+
+# ── Case 5: a Spring-context test without --expect-fail-message must be refused ────────
+# A context test can fail because the assertion fired or because the mutation broke context startup, and
+# those are indistinguishable by exit code. The fixture is a @DataJpaTest, so omitting the expected message
+# must be refused rather than yielding a verdict that cannot mean what it says.
+expect "a Spring-context test without --expect-fail-message is refused" \
+  1 "--expect-fail-message is required" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
   --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
 
 echo

--- a/.github/hooks/mutation-check-selftest.sh
+++ b/.github/hooks/mutation-check-selftest.sh
@@ -19,8 +19,12 @@ set -euo pipefail
 # considered sufficient evidence, not in string handling — so these cases drive the real hook end to end
 # against real Maven output.
 #
+# This script is mirrored, byte-identical, at .github/hooks/ and .claude/hooks/. Run whichever copy you
+# are reading: it resolves the hook under test as a sibling of itself, so each copy tests the hook that
+# sits beside it.
+#
 # Usage:
-#   ./.github/hooks/mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
+#   mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
 #
 # Exit codes: 0 = every case behaved as specified
 #             1 = the hook misbehaved (details printed), or the fixture no longer matches the codebase

--- a/.github/hooks/mutation-check-selftest.sh
+++ b/.github/hooks/mutation-check-selftest.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for mutation-check-hook.sh.
+#
+# WHY THIS EXISTS
+# The mutation hook's entire value is that it does not lie. It reports whether a guarantee is defended,
+# and every "DEFENDED" recorded in a wave ledger is trusted on its word — so a bug in the hook silently
+# devalues every check that ran through it.
+#
+# It has already had one such bug. Gate 3 checked that a "Tests run:" line EXISTED in the Maven output;
+# Maven prints "Tests run: 0, Failures: 0" when a selector matches nothing, so a run in which nothing
+# executed passed the gate and was then reported as UNDEFENDED — a false finding, which is worse than no
+# finding. The trigger was mundane: surefire's `Class#method` does not match a method inside a @Nested
+# class (it needs `Class$Nested#method`), and this codebase uses @Nested heavily.
+#
+# The nested-selector case is therefore the first thing this script covers. Isolated unit-testing of the
+# count-parsing expression would NOT have caught the original bug, because the bug was in what the gate
+# considered sufficient evidence, not in string handling — so these cases drive the real hook end to end
+# against real Maven output.
+#
+# Usage:
+#   ./.github/hooks/mutation-check-selftest.sh [--repo /abs/path/to/durion-positivity-backend]
+#
+# Exit codes: 0 = every case behaved as specified
+#             1 = the hook misbehaved (details printed), or the fixture no longer matches the codebase
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="${script_dir}/mutation-check-hook.sh"
+repo_path="${MUTATION_CHECK_SELFTEST_REPO:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo_path="$2"; shift 2 ;;
+    -h|--help) sed -n '3,28p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$repo_path" ]]; then
+  # Sibling layout, matching the rest of the hooks.
+  repo_path="$(cd "${script_dir}/../.." && pwd)/durion-positivity-backend"
+fi
+
+if [[ ! -x "$hook" ]]; then
+  echo "SELFTEST MISUSE | hook not executable at $hook" >&2
+  exit 1
+fi
+if [[ ! -d "$repo_path" ]]; then
+  echo "SELFTEST MISUSE | backend repo not found at $repo_path (pass --repo)" >&2
+  exit 1
+fi
+
+# ── Fixture ───────────────────────────────────────────────────────────────────────────
+# A real guard with a real test, deliberately rather than a synthetic one: the bug being guarded against
+# only appears against genuine surefire output. If this code moves, the self-test fails loudly with
+# "pattern matched 0 times" — which is correct behaviour, not breakage. Repoint the fixture.
+fixture_module="pos-supplier"
+fixture_file="pos-supplier/src/main/java/com/positivity/supplier/internal/service/SupplierExchangeAuditServiceImpl.java"
+fixture_find='@Transactional(noRollbackFor = PayloadUnreadableException.class)'
+fixture_replace='@Transactional'
+fixture_class="SupplierExchangeAuditPersistenceTest"
+fixture_nested="PayloadReads"
+fixture_method="keepsTheAccessRecordWhenTheStoredContentCannotBeDecrypted"
+
+failures=0
+case_number=0
+
+# Runs the hook and asserts an expected exit code and an expected substring in its output.
+expect() {
+  local description="$1" expected_exit="$2" expected_text="$3"
+  shift 3
+  case_number=$((case_number + 1))
+  echo "── case ${case_number}: ${description}"
+
+  local output actual_exit
+  set +e
+  output="$("$@" 2>&1)"
+  actual_exit=$?
+  set -e
+
+  local ok=true
+  if [[ "$actual_exit" != "$expected_exit" ]]; then
+    echo "   FAIL | expected exit ${expected_exit}, got ${actual_exit}"
+    ok=false
+  fi
+  if ! grep -qF "$expected_text" <<<"$output"; then
+    echo "   FAIL | output did not contain: ${expected_text}"
+    ok=false
+  fi
+
+  # The hook restores on every exit path, including error and interrupt. Verify that here rather than
+  # trusting it: a hook that leaves a mutation in the tree is far worse than one that misreports.
+  if ! git -C "$repo_path" diff --quiet -- "$fixture_file"; then
+    echo "   FAIL | ${fixture_file} was left mutated"
+    git -C "$repo_path" checkout -- "$fixture_file"
+    ok=false
+  fi
+
+  if $ok; then
+    echo "   ok"
+  else
+    echo "   ---- hook output ----"
+    sed 's/^/   | /' <<<"$output" | tail -25
+    failures=$((failures + 1))
+  fi
+}
+
+if ! git -C "$repo_path" diff --quiet -- "$fixture_file"; then
+  echo "SELFTEST MISUSE | ${fixture_file} has uncommitted changes; the restoration check needs a clean" >&2
+  echo "  baseline to compare against. Commit or stash first." >&2
+  exit 1
+fi
+
+echo "Mutation-check self-test | hook=${hook} | repo=${repo_path}"
+echo
+
+# ── Case 1: THE REGRESSION ────────────────────────────────────────────────────────────
+# A method inside a @Nested class addressed with the plain `Class#method` form. Surefire matches nothing
+# and Maven exits 0 having printed "Tests run: 0". The hook must ABORT and say so. Before the fix it
+# reported UNDEFENDED — asserting that a guarantee was untested on the strength of no test having run.
+expect "nested method addressed as Class#method aborts instead of reporting UNDEFENDED" \
+  1 "no tests actually ran" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}#${fixture_method}"
+
+# The abort must also point at the fix, or the next person re-runs it and draws the same false conclusion.
+expect "the abort message names the \$Nested selector form" \
+  1 'Outer$Nested#method' \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}#${fixture_method}"
+
+# ── Case 3: the same check, addressed correctly, must reach a real verdict ─────────────
+expect "the same guard with Class\$Nested#method reports DEFENDED" \
+  0 "MUTATION CHECK RESULT: DEFENDED" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find "$fixture_find" --replace "$fixture_replace" \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+
+# ── Case 4: gate 1 still guards a stale pattern ───────────────────────────────────────
+# The hook's original reason for existing: a search pattern that no longer matches (formatters rewrite
+# source constantly) must abort before anything runs, never produce a pass.
+expect "a pattern that matches nothing aborts before running any test" \
+  1 "pattern matched 0 times" \
+  "$hook" --repo "$repo_path" --module "$fixture_module" --file "$fixture_file" \
+  --find 'this text is deliberately absent from the source' --replace 'x' \
+  --test "${fixture_class}\$${fixture_nested}#${fixture_method}"
+
+echo
+if [[ "$failures" == "0" ]]; then
+  echo "SELFTEST PASS | ${case_number} cases, the hook behaves as specified"
+  exit 0
+fi
+echo "SELFTEST FAIL | ${failures} of ${case_number} cases misbehaved" >&2
+echo "  The mutation hook is only worth running if it cannot lie. Fix it before trusting any" >&2
+echo "  DEFENDED/UNDEFENDED result produced by it." >&2
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,8 @@ Hook scripts live in `.claude/hooks/` (and the originals in `.github/hooks/`). C
 | `post-test-coverage-commit.sh --repo <path> --story <id> --module <mod> --coverage-before <n> --coverage-after <n>` | Commit coverage improvements                              |
 | `post-code-review-pass-commit.sh`                                                                                   | Commit after code review passes                           |
 | `jacoco-hook.sh`                                                                                                    | Parse JaCoCo coverage report and emit structured evidence |
-| `mutation-check-hook.sh --repo <path> --module <mod> --file <f> --find <text> --replace <text> --test <sel>` | Prove a test defends its guarantee: asserts the mutation applied, requires the test to FAIL, restores the file |
+| `mutation-check-hook.sh --repo <path> --module <mod> --file <f> --find <text> --replace <text> --test <sel>` | Prove a test defends its guarantee: asserts the mutation applied, requires the test to FAIL, restores the file. For a method in a `@Nested` class the selector must be `Class$Nested#method` — `Class#method` matches nothing |
+| `mutation-check-selftest.sh [--repo <path>]`                                                                        | Regression-test the mutation hook itself; run after changing it |
 | `plan-acceptance-hook.sh`                                                                                           | Validate plan acceptance criteria                         |
 | `init-capability-runs-hook.sh`                                                                                      | Initialise capability run tracking                        |
 | `safe-delete-PRP.sh`                                                                                                | Safely delete a processing run artifact                   |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Hook scripts live in `.claude/hooks/` (and the originals in `.github/hooks/`). C
 | `post-test-coverage-commit.sh --repo <path> --story <id> --module <mod> --coverage-before <n> --coverage-after <n>` | Commit coverage improvements                              |
 | `post-code-review-pass-commit.sh`                                                                                   | Commit after code review passes                           |
 | `jacoco-hook.sh`                                                                                                    | Parse JaCoCo coverage report and emit structured evidence |
+| `mutation-check-hook.sh --repo <path> --module <mod> --file <f> --find <text> --replace <text> --test <sel>` | Prove a test defends its guarantee: asserts the mutation applied, requires the test to FAIL, restores the file |
 | `plan-acceptance-hook.sh`                                                                                           | Validate plan acceptance criteria                         |
 | `init-capability-runs-hook.sh`                                                                                      | Initialise capability run tracking                        |
 | `safe-delete-PRP.sh`                                                                                                | Safely delete a processing run artifact                   |

--- a/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
+++ b/docs/adr/0053-supplier-pricat-ingestion-and-price-precedence.adr.md
@@ -1,6 +1,6 @@
 # ADR-0053: Supplier PRICAT Ingestion, Effective Dating, and Price Precedence
 
-**Status:** PROPOSED — pending Pricing & Fees and Product & Catalog domain owner review  
+**Status:** ACCEPTED 2026-08-10 — Pricing & Fees and Product & Catalog domain sign-off recorded (durion#371)  
 **Date:** 2026-08-10  
 **Deciders:** Architecture, Backend Lead, Pricing & Fees Domain, Product & Catalog Domain, Positivity (Integrations) Domain  
 **Affected Issues:** durion#371 (investigation), durion#373 (CAP-318), durion-positivity-backend#1224

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,7 +117,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0050   | Supplier Vendor Profile Configuration Model            | ACCEPTED              | 2026-08-10 |
 | 0051   | Supplier Protocol Adapter and Codec Versioning Policy  | ACCEPTED              | 2026-08-10 |
 | 0052   | Supplier Outbound Idempotency and Duplicate-Order Prevention | ACCEPTED | 2026-08-10 |
-| 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | PROPOSED | 2026-08-10 |
+| 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence | ACCEPTED | 2026-08-10 |
 | 0054   | Sell-Price System of Record Split (pos-price Quoting, pos-catalog Reference) | ACCEPTED | 2026-08-10 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -207,3 +207,80 @@ Carry-forwards still in force for slice 3: `supplier:audit:read` (bit 445) **mus
 > never committed** (hence `.github/hooks/safe-delete-DP.sh`). `WAVE_PAUSE_STATE.md` is the tracked,
 > durable resume brief. Anything that must survive a session — decisions, gate evidence, follow-ups —
 > belongs **here**, not only in the ledger.
+
+---
+
+## UPDATE — independent review FAIL cleared + slice-3 client foundation started (2026-08-11)
+
+Backend `cap/317-supplier-foundation` @ `cb61886`, pushed. Two commits on top of `9e61d81`.
+
+### Independent Code Review of `5449315..9e61d81`: **FAIL** → now remediated in `cb61886`
+
+The review confirmed all four blocking items plus #5 and #8 as genuinely closed, verified `770666e`
+as truly format-only, confirmed the 500 branch leaks nothing, and independently corroborated the #8
+premise correction (adding that `generate-permissions.py`'s sync functions are strictly append-only,
+so the normalization is durable). It failed on four defects in the annotations added by `a5228d1`.
+
+| # | Defect | Resolution |
+| --- | --- | --- |
+| 1 | All 17 `401`s declared an `ApiError` body no code path sends (`GatewaySecurityConfig:138` is `HttpStatusEntryPoint`, bodiless) | Fixed — **but not by the prescribed method**, see below |
+| 2 | Binding `enabled` `@Schema` copied from `VendorProfileRequest`, describing a supplier-wide kill switch | Fixed in both binding records using their own correct javadoc |
+| 3 | `EndpointBindingRequest` class `@Schema` named `SUPPLIER_CAPABILITY_NOT_CONFIGURED`, not a contract value | Fixed to `CAPABILITY_NOT_CONFIGURED` + a clause naming both and which is which |
+| 4 | `version` example `"2.5"` resolves to nothing (legal keys are `A2_5`…`S2S_V1`); write path does no validation | Fixed to `A2_5`; description now states it is unvalidated on write and lists the shipped keys |
+| 5 | `updateAuthConfig` allowlist guard undefended by any test | Test added; mutation-checked |
+| 7 | `AuthReferenceRules` interpolated the rejected scheme into its message | Now names the field and allowlist only |
+| 6 | Shape note on `SupplierConfigurationCodeMappingTest` | Javadoc pointer added; no restructuring |
+
+### IMPORTANT — the prescribed fix for defect 1 was wrong, and regeneration is what caught it
+
+Dropping `content =` from the 401 annotations does **not** produce a bodiless response. springdoc then
+falls back to the method return type — *the very mechanism that caused the original 4xx defect* — and
+the regenerated spec showed **13 of 17 401s newly typed as the SUCCESS schema**, which is strictly
+worse than the defect being fixed. The working fix is an explicitly empty content:
+`content = @Content(schema = @Schema(hidden = true))`. Verified in the regenerated artifact: 17
+documented 401s, zero declaring a body.
+
+**Generalizable lesson: for this module, "remove the annotation" is never equivalent to "declare no
+body" — absence means inference. Any future response-shape change must be verified in the
+regenerated spec, never reasoned about from the annotation diff alone.**
+
+`403` deliberately **keeps** its `ApiError` body: `@PreAuthorize` denials flow through
+`SupplierExceptionHandler.handleAccessDenied`, which does return an envelope. Verified, not assumed.
+
+### Slice-3 client foundation (`55f8f49`) — first increment, no OpenAPI surface
+
+`internal.client`: `ExchangeOutcome` (ADR-0052 §5 classification — only `PRE_SEND_FAILURE` is
+retryable; idempotent batch reads stay a per-call property rather than widening the constants),
+`ExchangeContext` + `ExchangeObserver` + `ExchangeObserverConfig` no-op default (invoked once per
+attempt **including failures and each retry**, per ADR-0050 §7; carries no credential material),
+`SupplierCorrelationContext` (thread-scoped mirroring `AuditActorContext` — *not* request-scoped,
+because the per-binding scheduler has no servlet scope), and the three auth strategies +
+`SupplierAuthStrategies` dispatcher (fails startup on a missing or duplicated type).
+
+OAuth2 specifics: cache keyed per `authConfigId` (never per token URL, or two profiles sharing an
+endpoint would share a token), expiry-skew refresh so a token cannot expire mid-flight and return an
+indistinguishable 401, and single-flight behind a per-key lock with an in-lock re-check.
+Mutation-checked: removing the re-check fails the concurrency test with "No further requests
+expected". Basic+ApiKey encodes UTF-8 explicitly.
+
+### Gate results at `cb61886`
+
+pos-supplier `-am verify` **BUILD SUCCESS**, **313 tests** 0 failures (287 → 311 → 313);
+pos-openapi-validation **43**; touched-file lint **0 findings**; `spotless:check` **clean**;
+`generate-permissions.sh --sync --check` **exit 0**, CATALOG_VERSION unchanged at v42;
+`openapi-aggregate.yaml` rebuilt with the full 26-module list and **diff-verified byte-identical**.
+`pos-archunit -am test` was re-running at the time of writing (the `-am` form runs every dependency
+module's tests, so it takes >10 min); it was green at `9e61d81` and this pass added no new package.
+
+### Slice-3 constraint carried forward (from the reviewer)
+
+The 409 mapping for `CAPABILITY_NOT_CONFIGURED` is a **safety net, not the contract**. ADR-0050 §3
+requires the capability endpoints to surface that condition as a **typed 200 status**, so slice 3
+must still convert at the service layer. The 409 makes an escaped exception look plausible rather
+than loud — treat any 409 with that code as a defect signal.
+
+### Two more fleet-wide gaps logged as notes (out of scope, same shape as the description gap)
+
+- **No module supplies swagger `@RequestBody` description/required/examples** (ADR-0042 §3).
+- **pos-supplier is now strictly ahead of the fleet** on 401/403 documentation and `ApiError` response
+  typing — pos-warranty documents neither. Scope all three ADR-0042 gaps into one fleet pass.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -1,0 +1,34 @@
+## PAUSE STATE — 2026-08-11 (session credit pause; resume from here)
+
+### Where the wave stands
+
+| Slice | Story | Status |
+| --- | --- | --- |
+| 1 | #1221 skeleton/model/SPI/registry | **COMPLETE** — implemented, test gate green, Code Review **PASS** (2 minor deferrals folded into slice 2; carry-forwards honored) |
+| 2 | #1222 profiles/admin API | Implementation + test gate **COMPLETE** (214 module tests green, catalog v42 check green); **Code Review pending** (agent was mid-run at pause) |
+| 3 | #1223 client/audit/scheduler | **NOT STARTED** (a Client Coder run was lost to a model switch before writing anything) |
+| Close-out | gates + PR | Pending slice 3 |
+
+All slice 1+2 work is committed and pushed: `durion-positivity-backend` branch `cap/317-supplier-foundation`, commit `472de48` (147 files). Base branch is `main`.
+
+### Binding arbitration decisions already made (anvil — do NOT re-decide)
+1. **Audit payload encryption**: AES-256-GCM via JPA `AttributeConverter` (`EncryptedPayloadConverter`, bytea columns, envelope = 0x01 version + key-id + 12-byte nonce + ciphertext); key from `pos.supplier.audit.encryption.key` (env-ref, 32-byte base64) + `key-id` (default k1); fail-closed startup in prod/indus/alpha, ephemeral key + WARN in dev/test; decrypt failure → typed `PayloadUnreadableException`. **OPS ESCALATION OPEN**: `SUPPLIER_AUDIT_ENC_KEY` must be provisioned in non-dev secret stores before first deploy.
+2. **Test stubs**: MockRestServiceServer for protocol-level; JDK `com.sun.net.httpserver` via a `FaultInjectingHttpServer` fixture for socket-level (connect/read timeout, refused, breaker) — fixture never grows request-verification features.
+3. **Packages**: repo convention wins (`internal.entity/repository/controller/dto/service/client` + ADR-0051's `internal.domain/spi/registry/adapter.<family>`); ADR-0051 §1 errata is a separate doc-only durion PR (not this wave).
+4. **Scheduler lease**: `supplier_schedule_lease` table; atomic compare-and-claim UPDATE using DB `now()` (never JVM time); lease `max(2×run, 10min)` via `pos.supplier.schedule.lease-duration`; heartbeat every lease/3 extends owner-guarded; stolen lease → abort before next page, checkpoint commits in the same tx as the batch page, owner-guarded; release = set lease_until=now.
+
+### Slice 3 relaunch briefs (sequence: Client Coder → Domain Data Coder → API Surface Coder → Testing → Review)
+- **Client Coder**: `internal.client` — `SupplierBaseClient` (per-binding RestClient, correlation reuse/generate + X-Correlation-Id, ADR-0052 §5 classification: pre-send retryable / post-send-ambiguous never-retried / definitive-4xx), 3 auth strategies (Basic+ApiKey w/ apiKeyHeader default `apikey`; OAuth2 client-credentials with per-authConfigId cache + single-flight; bearer) resolving refs call-time, resolved values never logged; resilience4j (GAVs from pos-document-helper/pos-tax) retry pre-send-only + breaker per (vendorProfileId, capability) + health indicator; Micrometer per (vendorProfileId, capability); `ExchangeObserver.onExchange(ExchangeContext)` SPI invoked on EVERY attempt incl. failures, no-op default bean.
+- **Domain Data Coder**: `ExchangeAudit` entity + Flyway V3 (incl. `supplier_schedule_lease`), `EncryptedPayloadConverter` per decision 1, capture levels FULL|REDACTED|METADATA_ONLY per binding (column exists on binding entity: `captureLevel`), credential-header redaction, failures recorded, 400-day purge job (`pos.supplier.audit.retention`, delete payloads keep metadata), scheduler per decision 4 wiring binding `scheduleCron`, `AuditActorContext.withActor` for system writes (flush inside scope).
+- **API Surface Coder**: audit read API behind `supplier:audit:read` — permission bit **445 already in catalog v42, permissions.yaml already declares it — do NOT bump the catalog again**; add constant to `SupplierPermissions`, warranty `@PreAuthorize` idiom; paging/filtering per warranty read-controller pattern; OpenAPI + regenerate module openapi.yaml.
+- Carry-forwards in force: `vendorProfileId` (never `supplierRef`) in audit/event identity; AuthConfigView never gains ref fields; deps with first use; vendor-wire-type escape ArchUnit rule lands with first codec (CAP-318, not this wave).
+
+### Environment recreate (fresh container)
+- Clone backend (base `main`), branch `cap/317-supplier-foundation`; durion at the session repo root.
+- Java 25: `apt-get update && apt-get install -y openjdk-25-jdk-headless`; `ln -sfn /usr/lib/jvm/java-25-openjdk-amd64 /opt/jdk25`; build `JAVA_HOME=/opt/jdk25 ./mvnw ...` (first build downloads ~15 min; then prefer `-o`).
+- pos-archunit must run in-reactor (`-pl pos-archunit -am`), see repo issue #909.
+- semgrep registry is proxy-blocked: lint hook with `--config` pointing at a clone of github.com/semgrep/semgrep-rules `java/`.
+- `gh` unavailable: PR via GitHub MCP `create_pull_request` (hook documented as primary, MCP as fallback).
+
+### Remaining close-out gates (unchanged from plan)
+Full-reactor `JAVA_HOME=/opt/jdk25 ./mvnw -DskipTests=false verify`; pos-archunit in-reactor; `scripts/generate-permissions.sh --sync --check`; `scripts/check-flyway-hygiene.sh`; lint hook pos-supplier + pos-api-gateway; Documentation Agent ledger/status updates; PR base `main`, head `cap/317-supplier-foundation`, title `[CAP:317] pos-supplier foundation: module skeleton, vendor profiles, base client & exchange audit`, body MUST include: CATALOG_VERSION 41→42 fleet-coordinated deploy, SUPPLIER_AUDIT_ENC_KEY ops prerequisite, Angular SDK regeneration follow-up (pos-supplier/openapi.yaml is the input), closes #1221 #1222 #1223.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -388,3 +388,76 @@ guessed.
 **If a future wave adds health groups**, the alternative shape is to keep this indicator out of the
 default group and expose it at `/actuator/health/suppliers`; the always-UP contract makes that
 optional rather than necessary.
+
+---
+
+## SLICE 3 PROGRESS — client transport layer COMPLETE (2026-08-11)
+
+Backend `cap/317-supplier-foundation` @ `69ef390`, pushed. `55f8f49`, `4a38426`, `69ef390`.
+
+### Done — `internal.client` (13 production classes, 342 module tests)
+
+| Piece | Notes |
+| --- | --- |
+| `ExchangeOutcome` | ADR-0052 §5 classification; only `PRE_SEND_FAILURE` retryable |
+| `ExchangeContext` / `ExchangeObserver` / `ExchangeObserverConfig` | Per attempt incl. failures; no-op default; no credential material |
+| `SupplierCorrelationContext` | Thread-scoped (scheduler has no servlet scope); reuse-or-generate |
+| 3 auth strategies + `SupplierAuthStrategies` | Call-time resolution, never logged; startup validation |
+| `SupplierBreakerRegistry` | Breaker per `(vendorProfileId, capability)`; `minimumNumberOfCalls` guard |
+| `SupplierClientHealthIndicator` | **Always UP**; see the decision section above |
+| `SupplierClientMetrics` | `supplier.client.breaker.state` gauge + `supplier.client.exchanges` timer |
+| `SupplierHttpRequest` / `SupplierHttpResponse` | Transport-level; codecs map to `SupplierExchange` in CAP-318 |
+| `SupplierBaseClient` | The transport itself |
+| `FaultInjectingHttpServer` (test) | Socket-level faults per binding decision 2 |
+
+### Two real defects found by testing, not inspection
+
+1. **`toEntity(String.class)` failed on unexpected content types.** Now reads `byte[]` and decodes
+   UTF-8 — the correct design for a transport that will carry XML, JSON and EDIFACT under assorted
+   (sometimes absent) content types.
+2. **Any `RestClientException` other than the two caught escaped UNCLASSIFIED** to the caller as a raw
+   Spring type — the error leak ADR-0050 §3 forbids. Added a catch-all classified ambiguous, since a
+   conversion failure means a response *was* received and therefore the request *was* sent.
+
+Also, the socket fixture's refused-port helper originally used `HttpServer.create` + `stop`, which
+leaves the port bound with no accept loop: the client connected into the backlog and **read**-timed
+out, silently inverting what the pre-send test proved. Now a plain `ServerSocket`, closed, for a
+genuine `ECONNREFUSED`. Worth remembering — a fixture bug that makes a test pass for the wrong reason
+is worse than a failing test.
+
+### Deliberate conservative choice, recorded
+
+`SocketTimeoutException` covers **both** connect and read timeouts, and the JDK distinguishes them
+only by message text. Any socket timeout is therefore classified `POST_SEND_AMBIGUOUS`. The risk is
+asymmetric: calling a connect timeout ambiguous costs one retry we could safely have made; calling a
+read timeout pre-send costs **a duplicate purchase order at a vendor**. Connection refused, unknown
+host and no route are definitively pre-send and keep their retryable classification. This slightly
+under-retries by design.
+
+### Gate results at `69ef390`
+
+pos-supplier `-am verify` **BUILD SUCCESS**, **342 tests** 0 failures (322 → 342);
+`spotless:check` clean; touched-file lint **0 findings**. Retry tests assert on requests that actually
+reached the wire (`receivedRequests()`), not only on the returned outcome, because an outcome can look
+correct while the client silently re-sent the document.
+
+**Mutation checks now at six**, each confirmed to fail when the guarantee is removed: OAuth2
+single-flight, `updateAuthConfig` allowlist guard, configuration code→status completeness, the
+never-DOWN health guarantee, and the never-retry-ambiguous rule (dropping the idempotent gate fails
+exactly the read-timeout and 5xx tests).
+
+### REMAINING in slice 3 — not started
+
+1. `ExchangeAudit` entity + **Flyway V3** (no FK, snapshot `vendorProfileId` + `supplierRef`,
+   plus `supplier_schedule_lease` per decision 4)
+2. `EncryptedPayloadConverter` per binding decision 1 (AES-256-GCM, bytea, 0x01 version + key-id +
+   12-byte nonce + ciphertext, fail-closed in prod/indus/alpha, ephemeral + WARN in dev/test)
+3. Capture levels `FULL|REDACTED|METADATA_ONLY` + credential-header redaction
+4. 400-day retention purge (delete payloads, keep metadata rows)
+5. Per-binding scheduler per decision 4 (compare-and-claim lease on DB `now()`, heartbeat, owner-guarded
+   checkpoint in the batch transaction)
+6. Audit read API behind bit **445** — must actually enforce `supplier:audit:read` or the permission is
+   removed (ADR-0025 §4 parity debt), and payload reads must themselves be audited (ADR-0050 §7)
+
+The audit writer will be an `ExchangeObserver`, which is why that SPI exists: `SupplierBaseClient`
+never depends on a repository.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -13,6 +13,10 @@ All slice 1+2 work is committed and pushed: `durion-positivity-backend` branch `
 
 ### Binding arbitration decisions already made (anvil — do NOT re-decide)
 1. **Audit payload encryption**: AES-256-GCM via JPA `AttributeConverter` (`EncryptedPayloadConverter`, bytea columns, envelope = 0x01 version + key-id + 12-byte nonce + ciphertext); key from `pos.supplier.audit.encryption.key` (env-ref, 32-byte base64) + `key-id` (default k1); fail-closed startup in prod/indus/alpha, ephemeral key + WARN in dev/test; decrypt failure → typed `PayloadUnreadableException`. **OPS ESCALATION OPEN**: `SUPPLIER_AUDIT_ENC_KEY` must be provisioned in non-dev secret stores before first deploy.
+
+   **AMENDMENT (2026-08-11, implemented in `a5caf79`, coordinator-endorsed): key rotation is part of this decision, not extra scope.** Decrypt-only keys are supplied as `pos.supplier.audit.encryption.previous-keys` in `keyId:base64` form; the active key seals new payloads while prior keys stay readable. This *completes* the decision's intent rather than exceeding it: the envelope already carries a key id, which is meaningless without a rotation path, and the 400-day retention window of ADR-0050 §7 outlives any sane key lifetime — so without it, rotating a key would silently orphan every stored payload for the rest of the window. An unconfigured key id is reported as `SUPPLIER_AUDIT_PAYLOAD_UNKNOWN_KEY`, distinct from an authentication failure, and its message names `previous-keys` as the remedy.
+
+   **Suppression precedent:** the two GCM sites carry line-scoped `// nosemgrep` for semgrep's audit-category `gcm-detection`. pos-supplier is the first module in the repo doing crypto, so this is the precedent later modules will copy — each suppression states the evidence (the per-call `SecureRandom` nonce, the absence of any derived-nonce path, and `AuditPayloadCipherTest.NonceDiscipline.neverReusesANonceForTheSameKeyAndPayload` by name) and is deliberately never file- or class-wide.
 2. **Test stubs**: MockRestServiceServer for protocol-level; JDK `com.sun.net.httpserver` via a `FaultInjectingHttpServer` fixture for socket-level (connect/read timeout, refused, breaker) — fixture never grows request-verification features.
 3. **Packages**: repo convention wins (`internal.entity/repository/controller/dto/service/client` + ADR-0051's `internal.domain/spi/registry/adapter.<family>`); ADR-0051 §1 errata is a separate doc-only durion PR (not this wave).
 4. **Scheduler lease**: `supplier_schedule_lease` table; atomic compare-and-claim UPDATE using DB `now()` (never JVM time); lease `max(2×run, 10min)` via `pos.supplier.schedule.lease-duration`; heartbeat every lease/3 extends owner-guarded; stolen lease → abort before next page, checkpoint commits in the same tx as the batch page, owner-guarded; release = set lease_until=now.
@@ -555,3 +559,35 @@ ordering trap, the AAD binding, and the 401 invalidation.
 obligation, per the corrected contract); 400-day purge keeping metadata; scheduler per decision 4;
 audit read API behind bit **445**, which must genuinely enforce it (ADR-0025 §4 parity debt) and whose
 payload reads must themselves be audited (ADR-0050 §7).
+
+---
+
+## PATTERN TO WATCH — twice this wave, tests asserted the defect
+
+Recording this because it recurred and the failure mode is subtle: **a test that pins wrong behaviour
+is worse than no test**, because it converts a defect into a defended invariant and the next person to
+fix the code sees a red build and assumes they broke something.
+
+1. **Finding 7 (scheme echo).** `AuthReferenceRulesTest` and `SupplierYamlBootstrapTest` asserted
+   `hasMessageContaining("user:")` — i.e. they required the message to echo the rejected scheme, which
+   for a plaintext credential containing a colon *is* credential text. The tests were half the defect.
+2. **Finding 1 (token-leg transport).** The token-endpoint-500 test asserted
+   `AUTH_CONFIG_MISSING`, pinning exactly the misclassification the review flagged.
+
+Both were corrected to the right contract rather than worked around. When a fix makes an existing test
+fail, check whether the test was asserting the defect before assuming the fix is wrong.
+
+## PATTERN TO WATCH — framework behaviour beats reasoning in this module
+
+Two prescriptions in this wave did not survive contact with actual framework behaviour, and in both
+cases only a regenerated artifact or a real test caught it:
+
+1. **"Drop `content =` to make 401 bodiless"** — springdoc treats an absent `content` as an instruction
+   to *infer from the method return type*, so 13 of 17 401s became typed as the SUCCESS schema, worse
+   than the defect. Fixed with `@Content(schema = @Schema(hidden = true))`.
+2. **"Classify 3xx in the `RestClientResponseException` handler"** — Spring's `retrieve()` raises only
+   for 4xx/5xx, so a redirect arrives on the **success** path. The branch was dead code until a test
+   failed with `expected: CONFIGURATION_ERROR but was: OK`.
+
+**Rule for this module: verify contract- and transport-shape changes against the regenerated spec or a
+real socket, never against the annotation/handler diff alone.**

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -461,3 +461,97 @@ exactly the read-timeout and 5xx tests).
 
 The audit writer will be an `ExchangeObserver`, which is why that SPI exists: `SupplierBaseClient`
 never depends on a repository.
+
+---
+
+## UPDATE — client-layer review FAIL cleared; encryption landed (2026-08-11)
+
+Backend `cap/317-supplier-foundation` @ `1f6fc1a`, pushed. Commits since `69ef390`:
+`67dc356` factory switch, `a5caf79` encryption, `585c49c` review queue, `1f6fc1a` token invalidation.
+
+### Independent review of `9e61d81..69ef390`: **FAIL** → cleared
+
+All findings reproduced in the code before fixing. Three HIGH were behavioural, not annotation-deep.
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| 1 | OAuth2 **token-endpoint transport** failure reported as `AUTH_CONFIG_MISSING` → 409, never retried | Split three ways (below) |
+| 2 | `contentType` mandatory on the record, **never sent** — every document went out `text/plain` | Applied and asserted on the wire |
+| 3 | Query params/`pathSuffix` unencoded; `absoluteUri` **outside every try**, so a malformed URI escaped raw with **no observation** | Encoded; URI resolved once inside the observed region |
+| 4 | `ExchangeContext` javadoc claimed bodies "already redacted" — they are not | Corrected on both `ExchangeContext` and `ExchangeObserver` |
+| 6 | Breaker counted **every** exception, laundering permanent rejections into retryables | `recordException(countsAsTransportFailure)` |
+| 5 | never-DOWN guarantee not total (no try/catch, no Boot wrapping) | Wrapped; UP + `detailsUnavailable` |
+| 7/8 | `invalidate` had no caller — a revoked token re-sent for up to an hour | Wired on 401 |
+| 10-13 | Token in record `toString`; two `@NonNull` gaps; fixture leaked its executor | All fixed |
+
+### Finding 1 in detail — the worst defect in the range
+
+`catch (RestClientException)` is the **parent** of both `ResourceAccessException` and
+`RestClientResponseException`, so a refusal, timeout, 503 or 429 on the **token** leg all became
+`AUTH_CONFIG_MISSING` → `CONFIGURATION_ERROR` → 409, blaming the operator for a correct env var.
+Now split:
+
+- **transport failure of the token leg** → new `SupplierAuthTransportException` → classified
+  `PRE_SEND_FAILURE` and **returned**, so a caller can consult `isSafeToRedispatch()`. Nothing reached
+  the vendor's *business* endpoint, so ADR-0052 §5 makes it unambiguously pre-send.
+- **401/403** → new code `SUPPLIER_AUTH_CREDENTIALS_REJECTED` (409). The references resolved; the
+  vendor refused them. Retrying would only hammer the vendor.
+- **2xx with no `access_token`** → new code `SUPPLIER_AUTH_TOKEN_RESPONSE_INVALID` (500-generic). A
+  vendor contract violation, not operator error.
+
+Adding two codes forced two explicit HTTP decisions, because
+`SupplierConfigurationCodeMappingTest` fails on any unmapped code — the guard doing its job. The table
+outgrew `Map.of`'s 10-pair limit and moved to `Map.ofEntries`.
+
+### Rulings applied
+
+- **Finding 6:** fixed *what opens the breaker*, not `isSafeToRedispatch()`. ADR-0052 §3's premise is
+  true for a genuine transport-driven breaker; only the miscount made it misleading.
+- **3xx:** classified `CONFIGURATION_ERROR` naming the redirect target — "fix this profile's baseUrl",
+  not "the vendor permanently refused this order". **Note:** it arrives on the **success** path, since
+  Spring's `retrieve()` raises only for 4xx/5xx. My first attempt put it in the exception handler,
+  where it was dead code until a test caught it.
+
+### Two pre-existing tests asserted the DEFECT and were corrected, not worked around
+
+The token-endpoint-500 test pinned `AUTH_CONFIG_MISSING` — it *was* finding 1. Second time this wave
+that tests were part of the defect (the first was finding 7's scheme-echo tests).
+
+### Encryption (`a5caf79`) — binding decision 1
+
+AES-256-GCM, envelope `0x01 | keyIdLen | keyId | 12-byte nonce | ciphertext+tag`, header as **AAD** so
+version and key id are tag-covered. Key mandatory in prod/indus/alpha (fail closed), ephemeral + WARN
+in dev/test. **Rotation via decrypt-only `previous-keys`** — this is what the key id is *for*: a
+400-day retention window outlives any key lifetime, so without it rotation would orphan every payload.
+`PayloadUnreadableException` keeps malformed / unknown-key / authentication-failed distinct, because a
+failed GCM tag is potential tampering evidence and must not read as routine misconfiguration.
+Converter maps `null`↔`null`: `METADATA_ONLY` bindings and purged rows legitimately have no payload.
+
+Two justified `nosemgrep` suppressions on the GCM sites — `gcm-detection` is an **audit** rule asking a
+human to confirm nonce uniqueness, which the `SecureRandom` per-message nonce and the 500-iteration
+test establish. **pos-supplier is the first module in the repo doing crypto**, so the first to meet
+these rules. Bare form because the local hook derives rule ids from the rules-clone path.
+
+### Gate evidence at `1f6fc1a` — also covers `67dc356`, whose recorded evidence predated it
+
+pos-supplier `-am verify` **BUILD SUCCESS**, **387 tests** 0 failures (342 → 387);
+`spotless:check` clean; touched-file lint **0 findings**; `generate-permissions --sync --check` exit 0,
+CATALOG_VERSION unchanged. **Mutation checks now at ten**, each confirmed failing when its guarantee is
+removed — added this round: breaker `recordException`, the Content-Type header, the connect/read
+ordering trap, the AAD binding, and the 401 invalidation.
+
+### Still open from findings 7/8 — recorded, not silently skipped
+
+- The OAuth2 **token leg runs on the platform-internal `RestClient.Builder`**, whose own javadoc says
+  vendor-facing transport does not run through it, so **per-profile timeouts do not apply to the token
+  call**.
+- **`updateAuthConfig` does not invalidate a cached token** when an operator rotates a secret, so a
+  rotated credential is not picked up until natural expiry.
+
+### REMAINING in slice 3
+
+`ExchangeAudit` entity + **Flyway V3** (no FK, snapshot `vendorProfileId` + `supplierRef`, plus
+`supplier_schedule_lease`); capture levels + credential-header redaction **in the observer** (its
+obligation, per the corrected contract); 400-day purge keeping metadata; scheduler per decision 4;
+audit read API behind bit **445**, which must genuinely enforce it (ADR-0025 §4 parity debt) and whose
+payload reads must themselves be audited (ADR-0050 §7).

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -32,3 +32,33 @@ All slice 1+2 work is committed and pushed: `durion-positivity-backend` branch `
 
 ### Remaining close-out gates (unchanged from plan)
 Full-reactor `JAVA_HOME=/opt/jdk25 ./mvnw -DskipTests=false verify`; pos-archunit in-reactor; `scripts/generate-permissions.sh --sync --check`; `scripts/check-flyway-hygiene.sh`; lint hook pos-supplier + pos-api-gateway; Documentation Agent ledger/status updates; PR base `main`, head `cap/317-supplier-foundation`, title `[CAP:317] pos-supplier foundation: module skeleton, vendor profiles, base client & exchange audit`, body MUST include: CATALOG_VERSION 41→42 fleet-coordinated deploy, SUPPLIER_AUDIT_ENC_KEY ops prerequisite, Angular SDK regeneration follow-up (pos-supplier/openapi.yaml is the input), closes #1221 #1222 #1223.
+
+---
+
+## Slice 2 Code Review verdict (received 2026-08-11, post-pause): **FAIL**
+
+Substance is strong (ADR-0050 model, YAML-authoritative reconciliation, secret hygiene, permission bookkeeping, 214 tests all validated as genuine). It fails on contract-shape items that are expensive to reverse once the Angular SDK is generated. **Slice 2 is NOT accepted; do not open the PR until the blocking queue is cleared.**
+
+### Blocking (must fix before PR)
+1. **Route base is unversioned and prefix-doubling** — all four admin controllers map `/supplier/admin/...`; every other module in the repo maps `/v1/{domain}/...`. With gateway `Path=/supplier/**` + `StripPrefix=1` this resolves externally as `/supplier/supplier/admin/profiles`. **Recommended resolution: remap to `/v1/supplier/admin/...`** (CLAUDE.md "follow existing patterns"; pre-production policy = fix, no shim). Mechanical: 4 `@RequestMapping` values + regenerate spec/aggregate/SDK. No further arbitration needed unless a deliberate new fleet convention is intended, which would require an ADR-0011 amendment.
+2. **OpenAPI plumbing**: register `pos-supplier: mode: STRICT` in `pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml` (currently the module's spec is validated by nothing) and regenerate `pos-api-gateway/docs/openapi-aggregate.yaml` (stale; no supplier paths indexed).
+3. **ADR-0042 response typing**: every 4xx `@ApiResponse` must declare `ApiError` content (spec currently types 404/409 bodies as the success schema), document 401/403, add `@Schema` to `service.model` records and `schema`/`example` to `@Parameter`; then regenerate spec + SDK.
+4. **Secret-reference scheme allowlist**: `AuthReferenceRules.isWellFormed` validates `scheme:value` shape but not the scheme, so `MYDOMAIN:hunter2` (a plaintext credential) persists — violates ADR-0050 §4/§6. Enforce an allowlist (`env`, + future store) at admin write time AND in `SupplierYamlBootstrap.validate`; add `"user:hunter2"` cases to `AuthReferenceRulesTest` and `SupplierYamlBootstrapTest`.
+
+### Non-blocking queue (address in-wave)
+5. Add `sandboxBaseUrlOverride` + `retryBackoff` to `VendorProfileRequest`/`View` and map them, or document YAML-only ownership in ADR-0050 (today an ADMIN profile can set `sandbox=true` with no way to supply the URL → slice-3 adapters read null).
+6. Move the 456-line reconciler out of `internal.config` into `internal.service` (`SupplierYamlReconciler`, thin `ApplicationRunner` remains) and extract shared entity mappers — admin and YAML paths currently duplicate field mapping (the `apiKeyHeader` change already had to be applied twice).
+7. Map `SupplierConfigurationException` in `SupplierExceptionHandler` with a code→status table + test (otherwise slice 3 turns `CAPABILITY_NOT_CONFIGURED` into a 500, the leak ADR-0050 §3 forbids); rename `CAPABILITY_NOT_CONFIGURED` → `SUPPLIER_CAPABILITY_NOT_CONFIGURED` for code-prefix consistency.
+8. Normalise `DownstreamPermissionCatalog.java:545-547` comment spacing to the generator's `", // 445"` form.
+9. Add `pos-supplier/README.md` (admin routes, permissions, full `supplier.profiles` YAML example with `env:` refs, disable-not-delete semantics) and create `durion/domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` with the CAP-317 entry (story #1222 asks for it; file does not exist).
+
+### Open questions for the user/architecture at resume
+- Route convention (finding 1) — confirm remap vs deliberate deviation. **Decides whether the PR can proceed.**
+- Is a `vault:`/AWS secret-store resolver in slice-3 scope, and should the scheme allowlist be deployment-configurable?
+- Will the exchange-audit table FK to `supplier_profile`? That decides whether ADMIN `deleteProfile` (currently a hard delete of profile + children) must become a disable now — ADR-0050 §6/§7 preserve history, so a slice-3 FK would either break or orphan commercial records.
+- Expose `version` on profile views + require If-Match on PUT, or accept last-write-wins on the admin surface (record the decision either way)?
+
+### Additional slice-3 carry-forwards from this review
+- `supplier:audit:read` (bit 445) is allocated but enforced nowhere — slice 3 MUST attach it to the audit read endpoints or the permission must be removed (ADR-0025 §4 parity is owed). Payload reads must themselves be audited.
+- Any NEW slice-3 permission needs a **second** manual catalog batch (bits 448+, CATALOG_VERSION → 43) across all four artifacts plus `PermissionCodeTest.EXPECTED_PERMISSION_COUNT` and the `SecurityGatewayConfigTest` out-of-range guard — `--sync --check` cannot detect this because the module uses constant-based `@PreAuthorize` (verified: the generator only diffs string-literal scans and is additive-only).
+- `sellerPartyId`/`sellerAgencyCode` are bound by `SupplierProfileProperties.Accounts` but never persisted — slice 3 must persist them or drop them from the YAML contract.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -269,8 +269,10 @@ pos-supplier `-am verify` **BUILD SUCCESS**, **313 tests** 0 failures (287 → 3
 pos-openapi-validation **43**; touched-file lint **0 findings**; `spotless:check` **clean**;
 `generate-permissions.sh --sync --check` **exit 0**, CATALOG_VERSION unchanged at v42;
 `openapi-aggregate.yaml` rebuilt with the full 26-module list and **diff-verified byte-identical**.
-`pos-archunit -am test` was re-running at the time of writing (the `-am` form runs every dependency
-module's tests, so it takes >10 min); it was green at `9e61d81` and this pass added no new package.
+`pos-archunit -am test` **BUILD SUCCESS** — confirmed fresh, not inherited: 30 modules, 15:23 min,
+all four rule classes re-run (`ArchitectureTests` 12, `ClasspathVisibilityGuardTest` 2,
+`DomainWallsTest` 1, `EntityStandardsArchitectureTest` 5), 0 failures. Note for future waves: the
+`-am` form runs every dependency module's full test suite, so budget ~15 min and run it detached.
 
 ### Slice-3 constraint carried forward (from the reviewer)
 

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -910,3 +910,167 @@ rule cannot see it.
 2. `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md`.
 3. Follow-ups: inbound `X-Correlation-Id` filter; cross-instance credential invalidation; fleet ADR-0013
    assigned-id exemption (now cosmetic); CAP-318 per-binding redaction (F6).
+
+---
+
+## UPDATE — final review queue cleared (2026-08-11)
+
+### Accounting correction first
+
+The previous update's F12 row covered **two different items under one heading**, and that is how the
+`endpoint_uri` question disappeared: it read as closed because the row said "Fixed". One row per finding from
+here on. The two items are now separated, and both are resolved below.
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| F12a | Oversized `correlation_id` costing audit rows | **Fixed** — truncated in the writer. |
+| F12b | `endpoint_uri` retained in plaintext, unpurged, at every capture level | **Was never decided.** Now decided: redact. See below. |
+
+### HIGH — `protocol_version` was the one bounded audit column written untruncated
+
+All three legs confirmed: the writer applied no bound, V3 declared `varchar(32)`, and the **source** column on
+`SupplierEndpointBindingEntity` is `varchar(64)` with no `@Size` on the DTO and no registry gate. So an
+operator could PUT a 33–64 character version through the documented admin API and every subsequent audit
+insert for that binding would fail `22001`, be swallowed by the observer, and leave the exchange succeeding.
+Every row for that binding permanently missing from the §7 trail, with an ERROR log as the only trace, and
+`ddl-auto: validate` does not compare widths.
+
+**Fixed by widening, not truncating.** V5 takes the audit column to 64 to match its source, and
+`EndpointBindingRequest.version` gains `@Size(max = 64)`. Truncating would have been wrong in a way the other
+three bounds are not: this value **selects a codec**, so a shortened one would make the row misreport which
+vendor norm built the document. Present-and-wrong is worse than absent-and-logged.
+
+**And the class is closed, not just the instance.** `ExchangeAuditColumnWidthParityTest` parses every
+`truncate(x, N)` bound out of the writer and every column width out of V3 + V5 and requires them to agree, and
+separately requires each bounded, externally-influenced column to be either truncated or a *recorded* exception
+with its reason. That is what stops a third occurrence — this was the second.
+
+Two things worth noting about that test. It caught a real drift immediately: adding URI redaction put a comma
+inside `truncate(...)`, the bound stopped being visible, and the test reported `endpoint_uri` as unprotected
+rather than passing quietly. The writer now assigns the redacted URI to a local so the bound stays greppable.
+And the parse itself is guarded — an empty match set fails, because a parity test that silently stops parsing is
+the exact failure mode it exists to prevent.
+
+### F12b — `endpoint_uri`: redact, don't accept (ADR-0050 §4/§7)
+
+**The decision.** `PayloadRedactor.redactUri` applies the existing form-field patterns to the query string, and
+`METADATA_ONLY` strips the query string **entirely**.
+
+**Why redaction rather than accepting the status quo.** This is the only audit column stored in plaintext at
+every capture level *and* exempt from the 400-day purge, so anything in it is kept permanently and is readable
+by any holder of `supplier:audit:read`. A binding configured to retain nothing retained the full URI forever.
+The entity javadoc asserted that credentials never travel in the URI — true of the three shipped strategies and
+**enforced by nothing**; a fourth strategy or a binding path carrying `?apikey=...` would put a live credential
+into permanent unpurged storage. That javadoc is now a statement of current fact naming the redaction as the
+control, not an assertion about caller behaviour.
+
+**Why `METADATA_ONLY` drops the whole query string** rather than only sensitive names: that level's meaning is
+that no content is retained, and query parameters *are* content — order numbers, part numbers, account
+references, date ranges. Redacting only the sensitive list would leave commercial data in the one column that
+is never purged. The path is always kept; which endpoint was called is metadata and is the point of the trail.
+
+**Not rejected:** query strings in a binding `path`. Vendors legitimately need query parameters and the client
+already supports them.
+
+### The remaining four
+
+| # | Finding | Resolution |
+| --- | --- | --- |
+| 2 [med] | F1's inversion incomplete — `prod,dev` still minted an ephemeral key | **Fixed.** Now **every** active profile must be optional, not merely one of them. A deployment profile always wins. `KeyPolicy` covers `prod,dev`, `dev,prod`, `alpha,test` and `dev,docker`. |
+| 4 [med] | `SupplierHttpClients` javadoc false in its second half | **Doc corrected, code unchanged.** |
+| 5 [med] | The `@EventListener` half of the invalidation seam unproven | **Fixed.** `SupplierCredentialInvalidationWiringTest` publishes through a real `ApplicationEventPublisher` and asserts eviction. Mutation-proven: deleting the annotation fails it. |
+| 6, 7, 8 | Stale/contradictory javadoc | **Fixed** at all three sites. |
+| 9, 10, 11 | Optional hardening | **9 done** (compose and `.env.example` pinned by test). **10** recorded for the owed README. **11** below. |
+
+**On finding 2**, the reversal is deliberate and documented: a developer running `dev,local` must now drop the
+extra profile or supply a key. That is the right side to err on for the only control standing between a real
+deployment and permanently unreadable commercial history — every relaxation of it should be one somebody typed
+on purpose. The old presence-based test was replaced rather than deleted, so the reversal is visible.
+
+**On finding 4**, the reviewer is right and this is the wave's own recurring pattern: the doc claimed the
+factory swap mattered on the token leg because a read timeout may have minted a token server-side and must not
+be retried. The code maps every `RestClientException` to `PRE_SEND_FAILURE` — retryable — and that behaviour is
+correct, because a token-leg failure means nothing reached the vendor's *business* endpoint. A wasted token is
+not a duplicate submission. The doc now says what the swap actually buys: a type-safe timeout distinction and
+refused redirects, the latter mattering more on this leg than the main one, since a followed redirect would
+replay client credentials to whatever host the `Location` header named.
+
+The missing coverage is also closed: `SupplierHttpClientsTest` asserts the factory type, the redirect policy,
+the applied connect timeout, per-pair caching, and — the gap that mattered — that all three
+`pos.supplier.oauth2.*` `@Value` keys are declared in `application.yml`. A typo in one would have silently
+fallen back to the annotation default with the suite green. The properties are now declared explicitly rather
+than left implicit. The constructor check is asserted on parameter **types**, after a first version that
+grepped the source and failed on the comment explaining the fix — a test that breaks when you document
+something is testing prose.
+
+### Finding 11 — the batching decision, recorded explicitly
+
+Spec regeneration is **batched once per wave, after all contract work**, not per commit. Each run boots the
+application (~10 minutes here) and the aggregate must then be rebuilt with the full 26-module list. Running it
+per commit would multiply that cost for intermediate states nobody ships, and the risk it guards against —
+drift between annotations and the generated artifact — is only real at the point the wave is handed over. The
+countervailing risk is that a contract change lands and is not regenerated; that is covered by regenerating
+before every close-out and diffing, which is where this wave found that its module spec had not changed at all.
+
+### Gates at the final commit
+
+| Gate | Result |
+| --- | --- |
+| Full-reactor `./mvnw -DskipTests=false test` | **BUILD SUCCESS — 41 modules**, pos-supplier and pos-archunit green in the same run |
+| Full-reactor `verify` (with ITs) | **RED, and not CAP-317's** — see the section below for the three causes and how each was proven |
+| `./mvnw -pl pos-supplier -am -DskipTests=false verify` | **BUILD SUCCESS** — pos-supplier **538** tests (519 to 538) |
+| `./mvnw -pl pos-archunit -am -DskipTests=false test` | **BUILD SUCCESS** |
+| `./mvnw -pl pos-supplier spotless:check` | **clean** |
+| lint hook, touched files | **PASS**, 113 rules, **0 findings** |
+| `scripts/generate-permissions.sh --sync --check` | **exit 0**, **CATALOG_VERSION 42 unchanged** |
+| `scripts/check-flyway-hygiene.sh` | **passed** |
+| spec + 26-module aggregate | regenerated, diff recorded |
+
+### The full-reactor gate — run, and here is exactly what it says
+
+This was the gate deferred all wave. It was worth running: **two of my assumptions about it were wrong**, and
+only running it showed that.
+
+**`./mvnw -DskipTests=false test` across the whole reactor: BUILD SUCCESS, 41 modules, every unit test in
+every module, with `pos-supplier` and `pos-archunit` both green in the same invocation.** That is the gate
+green and recorded.
+
+**`./mvnw -DskipTests=false verify` across the whole reactor cannot pass in this container**, for three
+reasons, none of them CAP-317's and each established by running something rather than reasoning:
+
+1. **`pos-accounting` `ReportExportRenderingContractBehaviorIT.trialBalanceCsvMatchesJson`** fails with
+   `Table "LATERAL" not found` — the query is `CROSS JOIN LATERAL generate_series(...)`, PostgreSQL-only,
+   executed against H2.
+
+   I first assumed this was pre-existing because pos-accounting is untouched by the branch and has no
+   dependency on pos-supplier. **That reasoning was insufficient and the test caught me**: the branch also
+   touches the root `pom.xml`. So I built a worktree at the branch base `da21c33` and ran it there. The single
+   IT **passes** in isolation at base — which briefly looked like a regression — and the **full pos-accounting
+   module fails identically at base**, same test, same SQL. It only fails when the whole IT suite runs, so
+   there is cross-IT data coupling that makes this test reach a PostgreSQL-only query. Pre-existing, proven,
+   and pos-accounting's to fix.
+
+2. **`FlywayMigrationIT` requires Docker**, which this container does not provide
+   (`DockerDesktopClientProviderStrategy ... no valid configuration was found`). It exists in four modules:
+   `pos-customer`, `pos-people`, `pos-people-contact`, `pos-workorder`. Environmental, not a defect.
+
+3. **`pos-archunit` fails under `verify` but passes under `test`** — and this is expected, documented
+   behaviour, not a regression. `verify` runs `spring-boot:repackage`, so upstream modules become fat jars and
+   ArchUnit cannot see application classes inside `BOOT-INF/classes`. Its own `ClasspathVisibilityGuardTest`
+   detects exactly this and prints the remedy (issue #909): run `-pl pos-archunit -am`. Which is why that has
+   always been its own gate, and why the `test`-phase reactor run has it green.
+
+**What this means for close-out:** the full-reactor `verify` gate needs a CI environment with a Docker daemon,
+and it will still be red until pos-accounting's `generate_series` query is fixed or its ITs are decoupled. That
+is a separate blocker to raise against pos-accounting, not something to fix or work around inside CAP-317.
+Recorded rather than softened.
+
+<!-- Superseded gate rows: the table above listed the full-reactor row as "see below". This section is that row. -->
+
+### Still owed at close-out
+
+1. `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md` — and the README must note that this module's tests
+   require the `test` Spring profile, activated by a surefire `systemPropertyVariables` entry, because
+   `AuditPayloadCipher` fails closed without a key (finding 10).
+2. Follow-ups: inbound `X-Correlation-Id` filter; cross-instance credential invalidation; fleet ADR-0013
+   assigned-id exemption (cosmetic); CAP-318 per-binding redaction and positional-format field maps.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -591,3 +591,187 @@ cases only a regenerated artifact or a real test caught it:
 
 **Rule for this module: verify contract- and transport-shape changes against the regenerated spec or a
 real socket, never against the annotation/handler diff alone.**
+
+---
+
+## UPDATE — audit read API delivered (2026-08-11)
+
+Backend `cap/317-supplier-foundation` @ `a61b369`, **not pushed, no PR** (per standing instruction).
+durion `claude/ediwheel-integration-arch-tr3ibn` @ `400422a`.
+
+### The ADR-0025 §4 parity debt is closed
+
+Bit 445 is now genuinely enforced. Five endpoints under `/v1/supplier/admin/audit`, every one
+`@PreAuthorize`-gated on `supplier:audit:read`, and `SupplierExchangeAuditControllerWebMvcTest`
+exercises each three ways — granted, **denied while holding both `supplier:profile:read` and
+`supplier:profile:write`**, and unauthenticated. Mutation-proven: weakening the payload endpoint to
+`PROFILE_READ` fails the separation tests with `403 expected but was 200`.
+
+Endpoints: `GET /exchanges` (windowed, paginated, optional capability filter),
+`GET /exchanges/by-correlation/{id}` (oldest-first — a retry sequence only reads as a sequence in the
+order it happened), `GET /exchanges/{id}`, `GET /exchanges/{id}/payload` (the audited read),
+`GET /exchanges/{id}/accesses`.
+
+**Not nested under `/profiles/{vendorProfileId}`**, and that follows from binding decision 1: audit rows
+carry no FK and `deleteProfile` is a hard delete, so the audit trail of a *deleted* supplier is exactly
+what an investigation asks for. A path implying "child of an existing profile" would promise something
+the data model deliberately refuses. The profile is a query filter.
+
+### Two structural properties, both mutation-proven
+
+**1. Metadata reads never decrypt.** Every listing selects into `ExchangeAuditMetadata` via an explicit
+JPQL constructor expression that does not name the payload columns. Not an interface projection: "no
+plaintext is produced here" is a security property and must not depend on a projection optimisation.
+Three consequences, all wanted — no crypto work on listings, no plaintext in the JVM for a request that
+asked for none, and **a row whose payload cannot be decrypted still lists**. That last one is the point:
+the row an investigation is looking for must not be the row that breaks the listing.
+
+**2. The access record is a precondition of access, not a side effect.** `AuditAccessRecorder` is
+`MANDATORY`, does not catch, and `saveAndFlush`es inside the read's own transaction. If it cannot be
+written, the caller gets nothing.
+
+The counterpart took a second decision: `readPayload` declares
+`noRollbackFor = PayloadUnreadableException.class`. An unreadable payload is a read that **happened** and
+produced nothing usable — the case §7 most wants recorded, because it may be tampering or a mishandled
+rotation. Letting it roll back would delete the evidence of the one event worth investigating.
+
+This forced a design change worth knowing about: **payload content cannot be read through
+`ExchangeAuditEntity`.** Its converter decrypts during Hibernate *hydration*, so a decrypt failure would
+be raised from inside the persistence context with the identity needed to write the access row trapped in
+the load that just failed. Content is therefore read through `ExchangeAuditRawPayloadEntity` — a second,
+`@Immutable` mapping of the same table with **no converter** — and decrypted explicitly in the service.
+Mutation-proven: adding `@Convert` to that entity (the exact mistake its javadoc forbids) fails the
+UNREADABLE test.
+
+### Decisions taken
+
+1. **`payload_outcome`, not `decrypt_outcome`, with three values.** `NOT_CAPTURED` joins
+   `DECRYPTED`/`UNREADABLE` for the legitimately empty cases (METADATA_ONLY, no body, purged). An
+   evidentiary row must not claim a disclosure that never happened. `SupplierContractKeyParityTest` now
+   pins the enums to the V4 CHECK constraint text — that pair has a *third* copy in SQL, and a constant
+   added to the enum alone would surface as a constraint violation on an audit write, i.e. exactly where
+   §7 makes the write a precondition of serving a payload.
+2. **`PayloadUnreadableException` → 500 with its typed code and a generic message.** Handled explicitly,
+   not left to the catch-all, for three reasons: the catch-all would collapse "unconfigured key"
+   (operator error) and "failed GCM tag" (possible tampering) into `INTERNAL_ERROR`; it would log a
+   security-relevant integrity failure as "Unhandled exception"; and with rotation shipped this path is
+   **reachable in normal operation**. The exception's own message names the envelope's key id and the
+   `previous-keys` property — useful in a log, and never returned. `AUTHENTICATION_FAILED` gets its own
+   log line saying what it may mean. Test asserts the response contains neither the key id nor the
+   property name.
+3. **A 403 is not a payload read** — denials stay out of `supplier_audit_access` (schema-pinned by
+   `chk_saccess_kind`), and reading the access trail is not itself recorded, or every audit review would
+   generate the noise the next review has to sift through.
+4. **Access-row retention is permanent**, stated in the migration as a decision. The 400-day payload purge
+   deliberately does not apply: this table holds no payloads, it holds the record of who saw them.
+5. **NO `correlation_id` on the access row.** The only correlation scope this module has is
+   `SupplierCorrelationContext`, established around an **outbound** exchange — it is not in flight during
+   an inbound audit read, so the column could only ever have been null, and a permanently null column reads as
+   "this read had no correlation" rather than "we never captured one". See the follow-up below.
+6. **Half-open query windows** (`from` inclusive, `to` exclusive), replacing `Between`. Adjacent windows
+   tile without listing a boundary attempt twice; `from == to` is a typed 400 rather than a silently empty
+   page. An unknown capability filter is also a typed 400 — a filter that silently matches nothing turns a
+   typo into "this integration was never used".
+7. **`PagedResponse<T>` in `service.model`**, following pos-customer/pos-marketing rather than returning
+   Spring Data's `Page`, whose unstable nested shape would leak into the SDK. Kept free of Spring types;
+   mapping lives on the impl side of the ADR-0026 boundary.
+
+### ArchUnit caught a real defect, not a layering nit
+
+The module cycle check failed on `internal.service → internal.client`, because the recorder read
+`SupplierCorrelationContext`. Investigating rather than relocating the class revealed that scope is
+**never active during an inbound audit read** — the field would have been null in production forever. The
+cycle was removed by deleting an incorrect dependency, not by moving a class to accommodate it.
+
+**FOLLOW-UP (recorded, deliberately not actioned):** `SupplierCorrelationContext`'s javadoc states an
+inbound `X-Correlation-Id` "must be reused so a vendor exchange can be traced back to the operator action
+that caused it". **Nothing in production does this** — only a test calls `withCorrelationId`. Implementing
+it properly means a `OncePerRequestFilter` establishing the scope for every inbound request, which would
+also give outbound vendor calls the operator's correlation id and would let the access row carry an honest
+one. That is a module-wide request-handling change and was not smuggled into this slice.
+
+### Pre-existing breakage found and fixed: pos-archunit was RED
+
+`pos-archunit` had **not** been run after the scheduler-lease commit (`32d8080`) — my verification gap.
+`SupplierScheduleLeaseEntity` was violating four fleet entity rules.
+
+- **ADR-0024** (`@CreatedDate`/`@LastModifiedDate`/`@EntityListeners`): added. Behaviour-neutral for the
+  lease's DB-time guarantee — every *transition* still sets `updated_at = now()` in the atomic UPDATE;
+  the listener applies only at JPA insert, the one moment there is no transition to attribute it to.
+  Nothing about lease safety reads `updated_at`.
+- **ADR-0013** (`@UUIDv7Id` on a UUID `@Id`): added to both `SupplierScheduleLeaseEntity.bindingId` and
+  the new `ExchangeAuditRawPayloadEntity`. **Both are assigned natural-key ids that are never generated.**
+  This is safe only because `UUIDv7HibernateGenerator` returns `currentValue != null ? currentValue :
+  generate()` and reports `allowAssignedIdentifiers() == true` — verified in source, not assumed.
+
+  **Trade-off named rather than hidden:** before the annotation, saving a lease with a null `bindingId`
+  failed loudly on NOT NULL; now it would silently insert a lease keyed to a nonexistent binding, which no
+  constraint catches (valid UUID, no FK). `SupplierScheduleLeaseRepositoryTest`
+  `.assignedBindingIdSurvivesTheIdentifierGenerator` pins assigned-id-wins so a regression fails the
+  build. **DECISION GAP for the fleet:** ADR-0013 governs id *generation*; an assigned natural-key id is
+  outside its scope, and the rule has no exemption for `@Id` fields that are never generated. The correct
+  fix is to amend `EntityStandardsArchitectureTest` to exempt them — a 9-module fleet decision, so the gate
+  was satisfied rather than weakened unilaterally.
+
+### Hook integrity fix (durion `400422a`) — the mutation checker had this wave's own bug
+
+`mutation-check-hook.sh` gate 3 checked that a `Tests run:` line *existed*. Maven prints
+`Tests run: 0, Failures: 0` when a selector matches nothing, so the gate passed on a run where nothing
+executed — and a run with no tests neither fails nor proves anything, which gate 3 then reported as
+**UNDEFENDED**. Hit for real: `Class#method` does not match a method inside a `@Nested` class (surefire
+needs `Class$Nested#method`), so the first check of the `noRollbackFor` guard was reported UNDEFENDED on
+the strength of zero tests. The gate now requires a non-zero count and its abort message names the
+`@Nested` selector form. With the fix the same check reports DEFENDED.
+
+**This is the second time the same failure class has appeared in this wave.** The first produced the hook;
+the second was inside the hook.
+
+### Mutation checks recorded (11, all DEFENDED)
+
+| Mutation | Test that failed |
+| --- | --- |
+| `noRollbackFor` removed from `readPayload` | access record lost on unreadable payload |
+| `MANDATORY` → `REQUIRED` | recorder callable outside a transaction |
+| `@Convert` added to `ExchangeAuditRawPayloadEntity` | access record lost on unreadable payload |
+| access-write failure swallowed | payload served despite unrecordable read |
+| `classify` always returns `DECRYPTED` | `NOT_CAPTURED` outcome |
+| `!to.isAfter(from)` → `to.isBefore(from)` | empty-window rejection |
+| metadata read routed through `findById` (entity hydration) | undecryptable row readable by id |
+| payload endpoint `@PreAuthorize` weakened to `PROFILE_READ` | both permission-separation tests |
+| `NOT_CAPTURED` dropped from the V4 CHECK constraint | enum↔constraint parity |
+| `@CreatedDate` removed from the lease | NOT NULL insert |
+| (plus the pre-fix run that exposed the hook's own gate bug) | — |
+
+### Gate results at `a61b369`
+
+| Gate | Result |
+| --- | --- |
+| `./mvnw -pl pos-supplier -DskipTests=false test` | **499 tests, 0 failures** (313 → 499) |
+| `./mvnw -pl pos-supplier -DskipTests=false verify` | **BUILD SUCCESS** |
+| `./mvnw -pl pos-archunit -am -DskipTests=false test` | **BUILD SUCCESS** (was RED before this slice) |
+| lint hook `--module pos-supplier` | **PASS** — 113 rules / 28 touched files, **0 findings** |
+| `scripts/check-flyway-hygiene.sh` | **passed**, 25 modules |
+| `scripts/check-authz-doc-drift.sh` | **passed**, catalog v42 unchanged |
+| `pos-supplier/openapi.yaml` | regenerated via the `openapi` profile — **+5 paths, +5 schemas, 0 changed, 0 removed** |
+| `pos-api-gateway/docs/openapi-aggregate.yaml` | rebuilt with the full **26**-module list — +10 lines, 773 → 778 paths, **additive-only**, no module dropped |
+| Contract-rule audit of the 5 new operations | 401 bodiless ×5, 403 `ApiError` ×5, every 4xx/5xx `ApiError`, every parameter has schema + description |
+| Full-reactor `verify` | **NOT RUN** — close-out gate |
+
+`check-authz-doc-drift.sh` requires durion as a **sibling** of the backend (`../durion`); in this
+container durion lives elsewhere, so a symlink was needed. Worth knowing before reporting it as broken.
+
+### Still owed before close-out
+
+1. **`updateAuthConfig` / delete / rename → OAuth2 cache invalidation.** NOT IMPLEMENTED. Seam decided:
+   `internal.service` publishes a plain-record application event and `OAuth2ClientCredentialsAuthStrategy`
+   `@EventListener`s it, so no `service → client` compile dependency appears. Put the event in
+   `internal.spi` (framework-clean, already the neutral package for exactly this) — `service → spi` and
+   `client → spi`, no cycle. `SupplierAuthStrategies.invalidateCachedCredential` already exists and is
+   wired for 401s; only the admin-write trigger is missing. Today an operator who rotates a client secret
+   keeps failing until the cached token expires naturally — up to an hour.
+2. **Token-leg timeouts.** NOT IMPLEMENTED. Must come off the existing per-binding client cache; the
+   now-false `RestClientConfig` javadoc needs correcting and the caught cause needs chaining.
+3. **Independent Code Review of the persistence + audit-read range** (`1f6fc1a..HEAD`). Still owed; this
+   session had no subagent-invocation tool, so there is again no independent verdict.
+4. `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md` (close-out item 9).
+5. The inbound-correlation filter (above), and the fleet ADR-0013 assigned-id exemption decision.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -92,3 +92,27 @@ Substance is sound (ADR-0050 model, YAML-authoritative reconciliation, secret hy
 - `supplier:audit:read` (bit 445) **must** be enforced by the audit read endpoints or removed (ADR-0025 §4 parity is owed); payload reads must themselves be audited (ADR-0050 §7).
 - Any *new* slice-3 permission needs a **second** manual catalog batch (bits 448+), `CATALOG_VERSION` → 43, and updates to `PermissionCodeTest.EXPECTED_PERMISSION_COUNT` + `SecurityGatewayConfigTest` out-of-range guard — `--sync --check` will not catch it.
 - `sellerPartyId`/`sellerAgencyCode` are bound by `SupplierProfileProperties.Accounts` but never persisted — slice 3 must persist them or drop them from the YAML contract.
+
+---
+
+## UPDATE — blocking fix #1 cleared (2026-08-11): routes remapped to `/v1/supplier`
+
+Backend `cap/317-supplier-foundation` @ `5449315`.
+
+**Done**
+- All four admin controllers now map `/v1/supplier/admin/...` (`SupplierProfileAdminController`, `SupplierAccountAdminController`, `SupplierAuthConfigAdminController`, `SupplierEndpointBindingAdminController`) — repo convention `/v1/{domain}/...` restored, prefix-doubling gone. External path is now `/supplier/v1/supplier/admin/profiles`, matching the shape of every other module (e.g. `/customer/v1/customers`).
+- `pos-supplier/openapi.yaml` regenerated from the running app via the `openapi` Maven profile (springdoc + `scripts/sanitize-openapi.py`). Diff is exactly the eight path keys; no schema churn.
+- `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated with the full 26-module list (`scripts/generate-openapi.sh`'s aggregation step). Diff is additive only: the eight supplier paths, the `pos-supplier` tag, and the `x-aggregated-modules` entry — no drift in the other 25 modules. This also clears the aggregate half of blocking fix #2.
+- `SupplierAdminControllersWebMvcTest.BASE` updated; `mvn -pl pos-supplier test` → **214 tests, 0 failures** (same count as before the remap).
+
+**Decided**
+- The route-convention open decision is resolved in favour of the `/v1/supplier/...` remap. No ADR-0011 amendment needed.
+
+**Deliberately not touched (still open)**
+- Gateway `application.yml` needs no change: the `/supplier` prefix it strips with `StripPrefix=1` is the service prefix, not the API version.
+- Blocking #2 remainder: `pos-supplier: mode: STRICT` is still unregistered in `pos-openapi-validation/.../module-inventory.yaml`.
+- Blocking #3 (ADR-0042 response typing) and #4 (secret-scheme allowlist) are untouched — both will require another spec regeneration afterwards.
+- No Angular SDK generated yet, so nothing downstream to re-sync from this remap.
+
+**Noticed, pre-existing**
+- `mvn -pl pos-supplier spotless:check` fails on two files that predate this change and were not part of it: `ArchitectureTest.java` (line-wrap in `resideInAnyPackage`) and `ServiceModelInvariantsTest.java` (lambda wrap in `rejectsBlankAccountNumber`). `mvn -pl pos-supplier spotless:apply` fixes both. Add to the non-blocking queue.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -116,3 +116,71 @@ Backend `cap/317-supplier-foundation` @ `5449315`.
 
 **Noticed, pre-existing**
 - `mvn -pl pos-supplier spotless:check` fails on two files that predate this change and were not part of it: `ArchitectureTest.java` (line-wrap in `resideInAnyPackage`) and `ServiceModelInvariantsTest.java` (lambda wrap in `rejectsBlankAccountNumber`). `mvn -pl pos-supplier spotless:apply` fixes both. Add to the non-blocking queue.
+
+---
+
+## UPDATE — slice-2 fix wave complete (2026-08-11): all four blocking items cleared
+
+Backend `cap/317-supplier-foundation` @ `9e61d81` (pushed). Five commits on top of `5449315`.
+
+### Blocking queue — CLEARED
+
+| # | Item | Commit | Evidence |
+| --- | --- | --- | --- |
+| 1 | Route remap to `/v1/supplier` | `5449315` (previous session) | 214 tests green |
+| 2 | `pos-supplier: mode: STRICT` in `module-inventory.yaml` | `a5228d1` | 43 validation tests green; mutation-probed |
+| 3 | ADR-0042 annotation depth | `a5228d1` | 17/17 ops: zero 4xx untyped, zero missing 401/403 |
+| 4 | Secret-reference scheme allowlist | `26ed6a6` | AuthReferenceRulesTest 40 → 86 |
+
+### Non-blocking queue
+
+| # | Item | Status |
+| --- | --- | --- |
+| 5 | `sandboxBaseUrlOverride` + `retryBackoff` on profile DTOs | **DONE** (`a5228d1`) — implemented, not deferred to an ADR note |
+| 6 | Move the 456-line reconciler to `internal.service` | **DEFERRED to slice 3, bound** (see decision below) |
+| 7 | Map `SupplierConfigurationException`; rename the code | **DONE** (`d1cfb1d`) |
+| 8 | `DownstreamPermissionCatalog` comment spacing | **DONE** (`9e61d81`) — review's premise corrected, see below |
+| 9 | `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md` | Out of scope for this wave; close-out |
+| 10 | Optimistic locking / `version` on views | **CLOSED as decided** — last-write-wins accepted |
+
+### What landed, in detail
+
+- **`26ed6a6` secret-scheme allowlist.** `SecretReferenceResolver` now declares `scheme()`; new `SecretSchemeRegistry` collects the resolver beans, dispatches by scheme, and *is* the allowlist. Today `env:` alone. Not deployment-configurable by design. The registry is a distinct type from `SecretReferenceResolver`, so a second resolver never makes by-type injection ambiguous; duplicate/blank scheme claims fail startup. Enforced at admin write time **and** in `SupplierYamlBootstrap.validate`. Rejection messages name the scheme and allowlist but never echo the value.
+- **`d1cfb1d` configuration-exception mapping.** Code → status table: `SUPPLIER_UNKNOWN` 404; `PROFILE_DISABLED` / `CAPABILITY_NOT_CONFIGURED` / `MISSING_BILLING_ACCOUNT` / `MISSING_DELIVERY_MAPPING` / `AUTH_CONFIG_MISSING` 409 (ADR-0017 §2 prefers 409 to 422 for state collisions); the four secret/bootstrap codes 500 with a **generic** message, detail logged server-side only, because those messages name deployment env-var names. `CAPABILITY_NOT_CONFIGURED` value → `SUPPLIER_CAPABILITY_NOT_CONFIGURED`. The identically named `service.model` outcome-enum constants were **not** renamed — different namespace (successful-response status, not `ApiError.code`); renaming them would break the published contract.
+- **`a5228d1` contract pass** (single spec regeneration for #2/#3/#5). All 4xx now `@Content(schema = ApiError)`; 401/403 on every operation; class- and component-level `@Schema` on all 8 admin records; `schema`/`example` on every `@Parameter`. Success responses keep springdoc inference (already correct). `service.model.RetryBackoff` mirror added; `SupplierContractKeyParityTest` now pins **all five** contract/internal enum mirrors — they convert via `valueOf(name())`, so a one-sided constant was previously only a runtime failure.
+
+### Decisions recorded this wave
+
+1. **[#6 reconciler refactor] DEFERRED to slice 3, as a bound precondition — not optional.** Evidence: all **33 of 33** entity setters are used by *both* `SupplierYamlBootstrap` and `SupplierProfileAdminServiceImpl` — the mapping surface is 100 % duplicated, none unique to either path. The tax has now been paid twice in consecutive changes (`apiKeyHeader` in slice 2, `sandboxBaseUrlOverride`/`retryBackoff` in this wave). *Why not now:* the refactor is **not** mechanical — the two paths map to the same fields from *different source types* (YAML `ProfileSpec`/`AuthSpec`/`BindingSpec` vs contract `VendorProfileRequest`/`AuthConfigRequest`/…), so no shared mapper is directly extractable. The real design is to convert YAML specs into the contract request records and route both paths through one request→entity mapper — extending the pattern the bootstrap **already** uses when it builds an `AuthConfigRequest` to reuse `AuthReferenceRules`. That deserves design attention, and it carries semantic subtleties (YAML `enabled` null→true, sandbox nesting, `sourceOfTruth`, disable-not-delete). *Binding mandate:* do it as the **first step** of slice 3's `sellerPartyId`/`sellerAgencyCode` persistence work, which must touch account mapping anyway and would otherwise pay the duplication tax a third time. **The `internal.config` → `internal.service` package move + rename is separately REJECTED** as presentation-only churn: it forces import rewrites across tests and delivers no behavioural or duplication benefit. No ArchUnit rule requires it (pos-archunit and the module's `ArchitectureTest` are green with the reconciler where it is).
+2. **[#8] The review's stated premise was wrong and is corrected.** The target `", // 445"` form is **not** what the generator emits: `generate-permissions.py` pads to `max(1, 45 - len(perm))` — 26 spaces for `supplier:audit:read`. One space is what **palantir-java-format/spotless** produces; spotless collapses trailing-comment padding. That is why the generator-shaped crm batch (bits 438–442) is already one-space in the file. Verified by running `spotless:check` before/after: the supplier lines moved from rewritten to unchanged context.
+3. **Pre-existing defect discovered, deliberately NOT fixed:** bits 443–444 (`pos-people-contact`) carry the same wide padding and are still rewritten by spotless. That dirt is present at base `da21c33`, so `pos-security-common` `spotless:check` was **already failing before CAP-317 touched the file**. Out of this wave's scope, matching the ledger's existing decision not to repair pos-marketing's archunit gaps here. Note spotless is bound to **no** lifecycle phase and **no** CI workflow runs it — it is hygiene, not a gate.
+4. **Pre-existing gap discovered:** `module-inventory.yaml` is missing `pos-marketing`, `pos-people-contact` and `pos-tax` as well (22 entries vs 26 spec-producing modules). Only `pos-supplier` was added, per scope.
+
+### Gate results (all at `9e61d81`)
+
+| Gate | Result |
+| --- | --- |
+| `./mvnw -pl pos-supplier -am -DskipTests=false verify` | **BUILD SUCCESS** — pos-supplier 287 tests, 0 failures (214 → 287) |
+| `./mvnw -pl pos-archunit -am test` | **BUILD SUCCESS** — 20 tests / 4 classes, incl. `EntityStandardsArchitectureTest`, `ClasspathVisibilityGuardTest`, `DomainWallsTest` |
+| `./mvnw -pl pos-openapi-validation test` | **BUILD SUCCESS** — 43 tests, 0 failures |
+| `./mvnw -pl pos-security-common test` | **BUILD SUCCESS** — 28 tests, 0 failures |
+| `scripts/generate-permissions.sh --sync --check` | **exit 0**, all modules up-to-date, **CATALOG_VERSION unchanged (v42)** |
+| `scripts/check-flyway-hygiene.sh` | **passed**, 25 modules |
+| lint hook `--module pos-supplier` | **PASS** — 113 rules / 59 files, 0 findings |
+| lint hook `--module pos-security-common` | **PASS** — 113 rules / 1 file, 0 findings |
+| `./mvnw -pl pos-supplier spotless:check` | **clean** (was failing at `5449315`; `770666e` fixed 38 files, format-only, 214 tests green before and after) |
+| Full-reactor `verify` | **NOT RUN** — close-out gate, and no cross-module consumer exists: only `pos-archunit` references `pos-supplier` (verified by grep + pom scan), and that gate is green |
+
+Spec regeneration was batched once after the contract work: `pos-supplier/openapi.yaml` via the `openapi` Maven profile, then `openapi-aggregate.yaml` rebuilt with the full **26**-module list (the script's own aggregation code, invoked with the complete list — never `generate-openapi.sh pos-supplier`). The aggregate came out **byte-identical**: 773 paths, 26 modules, 8 supplier paths, zero additions/removals — correct, because this pass changed operation *contents*, not path keys, and the aggregate indexes path keys only.
+
+### Process caveat — READ THIS
+
+The executing session had **no subagent-invocation tool**: `API Planner`, `anvil`, `API Surface Coder`, `Domain Data Coder`, `Backend Testing Agent`, `Code Review Agent` and `Documentation Agent` could not be invoked, and `mcp__tokensave-backend__*` was unavailable. All work — planning, implementation, testing and this documentation — was done by the orchestrator directly. **There is therefore NO independent Code Review Agent verdict for this fix wave.** An independent review of `5449315..9e61d81` is still owed before the PR.
+
+### Slice 3 — now unblocked, three binding decisions received
+
+1. **Exchange-audit FK: NO FK.** `ExchangeAudit` stores `vendorProfileId` as a plain UUID column with no FK to `supplier_profile`, plus a denormalised `supplierRef` snapshot for readability. Admin `deleteProfile` **keeps its current hard-delete semantics** — slice 2's behaviour and tests are unchanged, do NOT convert it to a soft disable. Audit rows survive profile deletion, satisfying ADR-0050 §7. `vendorProfileId` remains the identity in audit/event payloads; the `supplierRef` snapshot is descriptive only, never a join/filter key. Design Flyway V3 accordingly.
+2. **Secret-store resolver: `env:` only; allowlist NOT deployment-configurable.** No `vault:`/AWS resolver in slice 3. Already implemented this wave (`26ed6a6`). Explicitly rejected: letting deployments widen the allowlist by property, because a deployment could then allowlist a scheme nothing resolves and push the failure back to call time — the exact defect fix #4 closes.
+3. **Optimistic locking: last-write-wins accepted.** No `@Version` addition, no `version` field on profile views, no `If-Match` on PUT. The admin surface is low-concurrency (a handful of operators) and this avoids a third contract change and spec regeneration in the wave. Item #10 is **closed as decided, not deferred**. (Note: `SupplierProfileEntity` already carries a `@Version` column and the handler already maps `ObjectOptimisticLockingFailureException` → 409; the decision is only that the *version is not exposed on the contract* and `If-Match` is not required.)
+
+Carry-forwards still in force for slice 3: `supplier:audit:read` (bit 445) **must** be enforced by the audit read endpoints or removed; payload reads must themselves be audited; `sellerPartyId`/`sellerAgencyCode` must be persisted or dropped from the YAML contract (and see decision 1 above — do the mapper unification first); **do not bump `CATALOG_VERSION`**; do not touch the route bases; do not run `generate-openapi.sh` with a module filter.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -184,3 +184,26 @@ The executing session had **no subagent-invocation tool**: `API Planner`, `anvil
 3. **Optimistic locking: last-write-wins accepted.** No `@Version` addition, no `version` field on profile views, no `If-Match` on PUT. The admin surface is low-concurrency (a handful of operators) and this avoids a third contract change and spec regeneration in the wave. Item #10 is **closed as decided, not deferred**. (Note: `SupplierProfileEntity` already carries a `@Version` column and the handler already maps `ObjectOptimisticLockingFailureException` → 409; the decision is only that the *version is not exposed on the contract* and `If-Match` is not required.)
 
 Carry-forwards still in force for slice 3: `supplier:audit:read` (bit 445) **must** be enforced by the audit read endpoints or removed; payload reads must themselves be audited; `sellerPartyId`/`sellerAgencyCode` must be persisted or dropped from the YAML contract (and see decision 1 above — do the mapper unification first); **do not bump `CATALOG_VERSION`**; do not touch the route bases; do not run `generate-openapi.sh` with a module filter.
+
+### Follow-ups recorded, deliberately NOT actioned (coordinator-confirmed)
+
+- **Fleet-wide ADR-0042 §1 description-depth gap — NOT pos-supplier's to close alone.** ADR-0042 §1
+  asks for a 7-part, 4–8-sentence tool-invocation description per operation. **No module in the repo
+  follows it.** Median operation description length: pos-warranty 54 chars, pos-accounting 70,
+  pos-people-contact 64, pos-supplier 58. `OpenApiModuleValidator` asserts description *presence*
+  only, so `mode: STRICT` does not enforce depth either. Rewriting pos-supplier's 17 descriptions
+  alone would make it the sole compliant module of 26 — a unilateral divergence in voice. Belongs in
+  its own fleet-wide effort. The four items actually constituting slice-2 review finding #3
+  (4xx → `ApiError`, 401/403 documented, `@Schema` on the admin records, `@Parameter`
+  schema/example) are complete.
+- **`module-inventory.yaml` also misses `pos-marketing`, `pos-people-contact`, `pos-tax`**
+  (22 entries vs 26 spec-producing modules) — their specs are validated by nothing. Only
+  `pos-supplier` was registered, per scope.
+- **`pos-security-common` `spotless:check` already failed at base `da21c33`** on the
+  `pos-people-contact` bits 443–444 comment padding. Pre-existing; not CAP-317's to repair.
+
+> **Note on this file vs `Durion-Processing.md`:** `.gitignore:9` lists `Durion-Processing.md` under
+> "#temp processing document", so the execution ledger is a **transient local run artifact and is
+> never committed** (hence `.github/hooks/safe-delete-DP.sh`). `WAVE_PAUSE_STATE.md` is the tracked,
+> durable resume brief. Anything that must survive a session — decisions, gate evidence, follow-ups —
+> belongs **here**, not only in the ledger.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -286,3 +286,105 @@ than loud — treat any 409 with that code as a defect signal.
 - **No module supplies swagger `@RequestBody` description/required/examples** (ADR-0042 §3).
 - **pos-supplier is now strictly ahead of the fleet** on 401/403 documentation and `ApiError` response
   typing — pos-warranty documents neither. Scope all three ADR-0042 gaps into one fleet pass.
+
+---
+
+## FOLLOW-UP (own PR, NOT this wave) — resilience4j family is half-pinned and resolves split
+
+**Proven, not inferred.** `./mvnw -pl pos-document-helper dependency:tree -Dincludes='io.github.resilience4j:*'`
+and the same for `pos-supplier` both resolve **identically**:
+
+```
+resilience4j-spring-boot4      2.4.0   <- root pom pin
+  resilience4j-spring6         2.3.0
+    resilience4j-annotations   2.3.0
+    resilience4j-consumer      2.3.0
+    resilience4j-framework-common 2.3.0
+  resilience4j-micrometer      2.3.0
+    resilience4j-bulkhead / -ratelimiter / -timelimiter  2.3.0
+resilience4j-retry             2.4.0   <- root pom pin
+  resilience4j-core            2.3.0
+resilience4j-circuitbreaker    2.3.0
+```
+
+So **2.4.0 autoconfiguration and retry sit on a 2.3.0 core / circuitbreaker / spring6 / micrometer
+stack**. `resilience4j-retry:2.4.0` depends on `resilience4j-core:2.3.0`.
+
+### Exact mechanism (traced to the line)
+
+1. Root `pom.xml` imports `spring-cloud-dependencies:${spring-cloud.version}` (2025.1.2).
+2. That transitively imports `spring-cloud-circuitbreaker-dependencies:5.0.2`, which at
+   **line 88** sets `<resilience4j.version>2.3.0</resilience4j.version>` and at **lines 92–98**
+   imports `io.github.resilience4j:resilience4j-bom` at that version — managing the whole family.
+3. Root `pom.xml` `dependencyManagement` then overrides **exactly two** artifacts
+   (`resilience4j-retry`, `resilience4j-spring-boot4`) to `${resilience4j.version}` = **2.4.0**.
+4. **Spring Boot's own BOM (4.1.0) does not manage resilience4j at all** — verified by grepping
+   `spring-boot-dependencies-4.1.0.pom`. The 2.3.0 baseline is Spring Cloud's, not Boot's.
+
+**The defect is the half-pin**, not any single artifact: two members of a family that an imported
+BOM manages as a coherent set are overridden individually.
+
+### Two options
+
+- **A (leaning, and the coordinator's): delete both partial pins** and let the imported
+  `resilience4j-bom` govern the whole family at 2.3.0. Coherent, the combination Spring Cloud
+  ships and tested, zero new downloads. Also removes the `resilience4j.version` property's
+  misleading appearance of controlling the family.
+- **B: import `resilience4j-bom:2.4.0` explicitly** in root `dependencyManagement` *before* the
+  spring-cloud import, moving the whole family up together. Coherent at a newer version, but
+  pulls new artifacts and diverges from what Spring Cloud 2025.1.2 was tested against.
+
+### Why not in this wave
+
+Either change alters what **`pos-document-helper` and `pos-tax`** resolve, so it needs their test
+suites as evidence and belongs in its own PR — not inside a capability wave. `pos-supplier` mirrors
+`pos-document-helper`'s GAVs exactly and inherits the split rather than introducing it (proven: both
+trees are identical).
+
+### Consequence already honoured in pos-supplier
+
+**Do not rely on any resilience4j auto-configured behaviour that differs across 2.3/2.4.** The module
+configures `Retry`/`CircuitBreaker` **programmatically** (matching `DocumentClient`), ships **no**
+resilience4j yaml, and leaves **`registerHealthIndicator` off** — verified: the string appears only in
+explanatory comments, never as a setting.
+
+---
+
+## DECISION — supplier health indicator always reports UP (new repo pattern, justified)
+
+`SupplierClientHealthIndicator` reports breaker state in `details` only and **never DOWN**.
+
+**The hazard it closes.** `docker-compose.yml:1291-1297` gives pos-supplier
+`healthcheck: wget -qO- http://localhost:8080/actuator/health` (`retries: 12`,
+`start_period: 300s`), and `application.yml:20-29` exposes `health` with **no health groups defined**
+and `show-details: when-authorized`. Every contributor therefore lands in the aggregate status the
+container healthcheck reads. Sibling services in the same file gate startup on
+`condition: service_healthy`. So a DOWN on breaker-open would mark the container unhealthy on one
+vendor's outage, Docker would restart it, and dependents would refuse to start — **handing any vendor
+a restart lever over our own service.** A supplier being unreachable is the expected steady state a
+circuit breaker exists to absorb; pos-supplier with every vendor down still serves its admin API and
+audit reads perfectly well.
+
+*Verified nuance:* **nothing currently gates on pos-supplier** (`depends_on` scan found no
+dependents — it is a new module), so today's hazard is the **container restarting itself**; the
+dependent-startup hazard is latent and arrives with the first consumer.
+
+**Constraints honoured**
+- Always `Health.up()`; never `status(open > 0 ? DOWN : UP)`. **Mutation-checked**: applying
+  resilience4j's OPEN→DOWN default fails 3 tests, each naming the restart hazard.
+- `registerHealthIndicator` **not** set on any resilience4j config (its default is this hazard).
+- Keys are `(vendorProfileId, capability)`; breaker name `supplier.<vendorProfileId>.<CAPABILITY>`.
+- Details carry no credential material — a test asserts the rendered details contain no `http://`,
+  `https://`, `Bearer `, `Basic `, `env:` or `apikey`, which matters because
+  `show-details: when-authorized` makes them HTTP-reachable.
+- **Micrometer is the alerting channel** for breaker state; health answers "is this pod serviceable",
+  and it is. A per-key gauge follows with `SupplierClientMetrics`.
+
+New repo pattern (no `HealthIndicator` exists anywhere else in the repo), justified because the
+alternative default would let a vendor outage restart our container. Boot 4 package is
+`org.springframework.boot.health.contributor` — verified against `spring-boot-health-4.1.0.jar`, not
+guessed.
+
+**If a future wave adds health groups**, the alternative shape is to keep this indicator out of the
+default group and expose it at `/actuator/health/suppliers`; the always-UP contract makes that
+optional rather than necessary.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -62,3 +62,33 @@ Substance is strong (ADR-0050 model, YAML-authoritative reconciliation, secret h
 - `supplier:audit:read` (bit 445) is allocated but enforced nowhere — slice 3 MUST attach it to the audit read endpoints or the permission must be removed (ADR-0025 §4 parity is owed). Payload reads must themselves be audited.
 - Any NEW slice-3 permission needs a **second** manual catalog batch (bits 448+, CATALOG_VERSION → 43) across all four artifacts plus `PermissionCodeTest.EXPECTED_PERMISSION_COUNT` and the `SecurityGatewayConfigTest` out-of-range guard — `--sync --check` cannot detect this because the module uses constant-based `@PreAuthorize` (verified: the generator only diffs string-literal scans and is additive-only).
 - `sellerPartyId`/`sellerAgencyCode` are bound by `SupplierProfileProperties.Accounts` but never persisted — slice 3 must persist them or drop them from the YAML contract.
+
+---
+
+## UPDATE — slice 2 Code Review verdict: **FAIL** (landed after pause was recorded)
+
+Substance is sound (ADR-0050 model, YAML-authoritative reconciliation, secret hygiene, catalog bookkeeping, 214 tests all verified good; the manual bits 445-447 were confirmed mutually consistent across all four artifacts, and the reviewer confirmed `--sync --check` structurally *cannot* detect drift for constant-based `@PreAuthorize` — so the manual entries are the only guarantee and they hold). It fails on contract-shape items that are expensive to reverse after SDK generation.
+
+### Blocking fix queue (must clear before PR)
+1. **[high] Route base unversioned + prefix-doubling.** All four admin controllers map `/supplier/admin/...`; every other module maps `/v1/{domain}/...`. With `Path=/supplier/**` + `StripPrefix=1` the external path becomes `/supplier/supplier/admin/profiles`. Remap to `/v1/supplier/admin/...`, regenerate `pos-supplier/openapi.yaml` **and** `pos-api-gateway/docs/openapi-aggregate.yaml`. **Do this before any SDK generation.**
+2. **[med] OpenAPI CI + discovery gaps.** Register `pos-supplier: mode: STRICT` in `pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml` (currently the module's spec is validated by nothing); regenerate the gateway aggregate.
+3. **[med] ADR-0042 annotation depth.** 4xx `@ApiResponse`s are typed as the success schema (e.g. 404 → `VendorProfileView`); add `@Content(schema = @Schema(implementation = ApiError.class))`, document 401/403, add `@Schema` to `service.model` records, `@Parameter` schema/example — then regenerate spec + SDK.
+4. **[med] Secret-reference scheme allowlist.** `AuthReferenceRules.isWellFormed` validates `scheme:value` shape but not the scheme, so `MYDOMAIN:hunter2` (a plaintext credential) persists and only fails at call time — violates ADR-0050 §4/§6. Validate against supported resolver schemes at write time and in `SupplierYamlBootstrap.validate`; add `"user:hunter2"` tests. Consider a scheme-dispatching composite resolver now (a second `SecretReferenceResolver` bean would make by-type injection ambiguous).
+
+### Non-blocking (fold in during slice 3 or a cleanup pass)
+5. Add `sandboxBaseUrlOverride` + `retryBackoff` to `VendorProfileRequest`/`View` (ADMIN profiles currently cannot express the ADR-0050 §2 sandbox overlay — slice-3 adapters would read null), or document YAML-only ownership in ADR-0050.
+6. Move the 456-line reconciler out of `internal.config` into `internal.service` (`SupplierYamlReconciler`) and extract shared entity mappers — admin and YAML paths currently duplicate field mapping (the `apiKeyHeader` change already had to be applied twice).
+7. Map `SupplierConfigurationException` in `SupplierExceptionHandler` with a code→status table + test (**required before slice 3 exposes the resolver over HTTP**, else `CAPABILITY_NOT_CONFIGURED` becomes a 500); rename `CAPABILITY_NOT_CONFIGURED` → `SUPPLIER_CAPABILITY_NOT_CONFIGURED` for prefix consistency.
+8. Normalise `DownstreamPermissionCatalog.java:545-547` comment spacing to the generator's `", // 445"` form.
+9. Add `pos-supplier/README.md` (admin routes, permissions, full `supplier.profiles` YAML example with `env:` refs, disable-not-delete semantics) and create `durion/domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` (does not exist).
+10. Consider exposing `version` on profile views + If-Match on PUT (today two operators editing one profile is last-write-wins), or record the decision.
+
+### Open decisions needed (were the reviewer's questions)
+- **Route convention**: confirm the `/v1/supplier/...` remap (recommended — repo-wide convention) vs. an ADR-0011 amendment justifying a new convention. **Decides fix #1.**
+- **Secret-store resolver** (`vault:`/AWS) in slice 3 scope? Should the write-time scheme allowlist be per-deployment configurable?
+- **Exchange-audit FK to `supplier_profile`?** If yes, admin `deleteProfile` (currently a hard delete of profile + children) must become a disable, or the audit must snapshot `supplierRef` — ADR-0050 §6/§7 tension. **Decide before slice 3's Flyway V3.**
+
+### Additional slice-3 carry-forwards from this review
+- `supplier:audit:read` (bit 445) **must** be enforced by the audit read endpoints or removed (ADR-0025 §4 parity is owed); payload reads must themselves be audited (ADR-0050 §7).
+- Any *new* slice-3 permission needs a **second** manual catalog batch (bits 448+), `CATALOG_VERSION` → 43, and updates to `PermissionCodeTest.EXPECTED_PERMISSION_COUNT` + `SecurityGatewayConfigTest` out-of-range guard — `--sync --check` will not catch it.
+- `sellerPartyId`/`sellerAgencyCode` are bound by `SupplierProfileProperties.Accounts` but never persisted — slice 3 must persist them or drop them from the YAML contract.

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -1074,3 +1074,99 @@ Recorded rather than softened.
    `AuditPayloadCipher` fails closed without a key (finding 10).
 2. Follow-ups: inbound `X-Correlation-Id` filter; cross-instance credential invalidation; fleet ADR-0013
    assigned-id exemption (cosmetic); CAP-318 per-binding redaction and positional-format field maps.
+
+---
+
+## UPDATE — verification queue on `36643e3..82245f7` cleared (2026-08-11)
+
+### The blocker: the published contract still carried the claim F3 was raised about
+
+The *entity* javadoc was corrected from an assertion into a statement about a control. The same unfoundable
+guarantee was still in four other places, one of which is the generated spec — the artifact that is expensive
+to reverse after SDK generation:
+
+| Site | Was | Now |
+| --- | --- | --- |
+| `pos-supplier/openapi.yaml` (generated) | "Credentials travel in headers and never appear here." | describes redaction, and that `METADATA_ONLY` returns the path only |
+| `ExchangeAuditSummary` javadoc + `@Schema` | same claim | same correction |
+| `ExchangeAuditMetadata` | "credentials travel in headers, never here" | "credential-redacted at capture time" |
+| `ExchangeContext` | "never carries credentials" | "this is the RAW value and it may well carry credentials — redaction is the audit writer's job" |
+
+The `ExchangeContext` wording matters most for the next implementer: it is the *input* side, so the honest
+statement is the opposite of a guarantee. Observers must not persist it verbatim.
+
+**And the contract now documents the behaviour change it was silent about:** at `METADATA_ONLY` the returned
+URI has no query string. The meaning of a contract field had changed with no spec change, which is the second
+time this wave failed review on that class. Verified in the regenerated artifact rather than the annotations:
+zero occurrences of the three old claims, `METADATA_ONLY` present on `endpointUri`, redaction present on
+`failureDetail`, and the diff is `ExchangeAuditSummary` descriptions only — no paths or schemas added or
+removed, aggregate byte-identical.
+
+### The three answered questions
+
+**1. `failure_detail` — redacted now, not deferred.** It quotes vendor responses, and a redirect `Location`
+routinely carries a signed URL whose token is a live bearer credential. `PayloadRedactor.redactEmbeddedUris`
+finds URLs in free text and redacts their query credentials and userinfo, at every capture level — an
+operator-facing message has no legitimate need for the token inside a signed URL, so unlike the payload columns
+there is no level at which keeping it is the point. The diagnostic itself survives, which a test asserts.
+
+**2. `baseUrl` userinfo — rejected at write time AND stripped at storage.** ADR-0050 §4 is that plaintext
+credentials never persist, and userinfo in a URL is a plaintext credential.
+`https://apiuser:hunter2@edi.example/a25` previously persisted a password into *configuration* — precisely where
+it would live indefinitely — and from there into the retained `endpoint_uri` of every audit row for that
+binding. `SUPPLIER_URL_CONTAINS_CREDENTIALS` is a 400 at the boundary; the message names the field and does not
+echo the value, because the value is the credential. Storage-side stripping stays as defence in depth, and is
+not redundant: YAML-managed profiles bypass admin validation entirely.
+
+**3. Module `verify` re-run at HEAD** rather than carried forward — recorded against this commit below.
+
+### V5 has not executed against real PostgreSQL — recorded, not fixed
+
+Only H2 in PostgreSQL mode, because this container has no Docker daemon for the Testcontainers-based
+`FlywayMigrationIT`. `ALTER COLUMN … TYPE character varying` widening has direct repo precedent
+(`pos-security-service/V19`), and widening a varchar is a metadata-only operation in PostgreSQL that takes no
+table rewrite, so the risk is low. But low is not proven, and it should be stated as unproven: the first
+execution against real PostgreSQL will be in a deployed environment.
+
+### The rest of the queue
+
+| # | Item | Resolution |
+| --- | --- | --- |
+| med | URI redaction missed `key`, `token`, `api-key`, `sig`, `signature`, `subscription-key` | **Fixed with a URI-ONLY name set**, applied to query strings only. |
+| med | The URI-redaction seam was unproven | **Fixed.** Asserted on persisted rows; both call sites mutation-proven. |
+| med | `isKeyRequired`'s method javadoc stated the reverse of its code | **Fixed.** |
+| med | The parity test was narrower than its javadoc claimed | **Fixed.** Column list derived from the DDL, width parse scoped to the audited table, migrations globbed in version order. |
+| low | "the one audit column in plaintext / exempt from the purge" | **Dropped in all three places.** |
+| low | Two doc nits | **Fixed.** |
+| low | `@Size` boundary test; yaml key coverage | **Both done** — see below. |
+
+**On the URI-only name set:** the reviewer's shaping was right and the reason is asymmetric blast radius.
+`key` and `token` are unambiguous as URL parameters and dangerously ambiguous in a document body — widening the
+shared set would newly redact `<Key>` and `"key"` inside vendor payloads at `REDACTED`, silently destroying
+legitimate commercial content (part keys, sort keys, price keys) in a store that keeps it for 400 days. A test
+pins both halves: the names are redacted in a query string and are *not* redacted in a body.
+
+**On the parity test:** it was load-bearing for a defect class while being narrower than it claimed —
+`unmapped_fields varchar(4000)` was invisible, a V6 narrowing a width would have been invisible, and the width
+map mixed both tables in V3 via `putIfAbsent`. All three closed. It also earned itself twice more during this
+queue: adding URI redaction and then failure-detail redaction each put a comma inside `truncate(...)`, and both
+times it reported the column as unprotected rather than passing quietly. The writer now assigns those values to
+locals so the bounds stay parseable.
+
+**On yaml coverage:** the comment asserted a principle — "a typo in a `@Value` key falls back to the annotation
+default with the suite green" — while covering 3 of 16 keys. Rather than drop the principle, all 16
+`pos.supplier.*` keys are now declared, and a test scans the source for `@Value` keys and requires each to
+appear in `application.yml`, so a new one is caught rather than remembered.
+
+### Gates at this commit
+
+| Gate | Result |
+| --- | --- |
+| `./mvnw -pl pos-supplier -am -DskipTests=false verify` at **this** commit | **BUILD SUCCESS**, 562 tests, and the failsafe `verify` phase actually reached (pos-supplier declares no ITs) |
+| `./mvnw -pl pos-supplier -DskipTests=false test` | **546 tests** (538 to 546); 562 across the `-am` reactor |
+| spec regenerated and **verified as an artifact** | no old claims, `METADATA_ONLY` documented, `ExchangeAuditSummary` descriptions only |
+| aggregate | **byte-identical**, no path keys moved |
+| spotless | **clean** |
+| lint hook, 16 touched files | **PASS**, 113 rules, **0 findings** |
+| `scripts/check-flyway-hygiene.sh` | **passed**, 25 modules |
+| `scripts/generate-permissions.sh --sync --check` | **exit 0**, **CATALOG_VERSION 42 unchanged** |

--- a/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
+++ b/docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md
@@ -775,3 +775,138 @@ container durion lives elsewhere, so a symlink was needed. Worth knowing before 
    session had no subagent-invocation tool, so there is again no independent verdict.
 4. `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md` (close-out item 9).
 5. The inbound-correlation filter (above), and the fleet ADR-0013 assigned-id exemption decision.
+
+---
+
+## UPDATE — slice 3 complete: persistence review queue cleared, both owed items landed (2026-08-11)
+
+### Review fix queue
+
+| # | Item | Resolution |
+| --- | --- | --- |
+| F1 | Key-required predicate failed open | **Fixed.** Polarity inverted: an allowlist of where a key is OPTIONAL (`dev`, `test`) instead of a list of where it is required. An empty profile set — the shape compose actually ships — now fails startup. |
+| F2 | `pos.supplier.audit.encryption.*` bound by nothing | **Fixed.** Wired in `application.yml`, `docker-compose.yml` and `.env.example` from `SUPPLIER_AUDIT_ENC_KEY`, the variable the failure message names. |
+| F3 | `REQUIRES_NEW` on the audit write was inert | **Fixed.** Extracted `ExchangeAuditWriter`; the observer delegates through the injected bean. |
+| F4 | Lease mutations joined the page transaction | **Fixed** on the coordinator, plus a recorded `now()` decision. |
+| F5 | V3 CHECK constraints unpinned; `correlation_id` untruncated | **Fixed.** Both constraints pinned to their enums; the client-influenced field is truncated. |
+| F6 | Per-binding configured redaction not implemented | **Recorded, not implemented** — deferred to CAP-318. §7 no longer reads as complete. ADR untouched. |
+| F7 | `JpaRepository` on the converter-bypassing entity | **Fixed.** Narrowed to `Repository` with one declared `findById`. |
+| F8 | `@ConditionalOnMissingBean` racing scan order | **Fixed.** `@Primary` on the audit observer; precedence declared, not raced for. |
+| F9/F10 | "no FK" comment; `@PrePersist` guard | **Settled differently — see below.** |
+| F11 | Purge has no lease | **Documented and tested as safe**, with the lease rejected for a stated reason. |
+| F12 | Oversized values costing audit rows | **Fixed** with F5. |
+| F13 | Raw NUL byte made a test file binary | **Fixed.** Unicode escape instead; git and ripgrep can read it again. |
+
+### F9/F10 — I did not commit the guard you asked for, because it does not work
+
+Two corrections, both found by writing the test rather than by reading the code:
+
+1. **The hazard I reported does not exist.** V3 declares `fk_slease_binding` on `binding_id` with
+   `ON DELETE CASCADE`. A minted lease id references no binding and fails the insert, loudly. My earlier
+   report of "a silent orphan lease no constraint catches" was wrong, and my javadoc said so too. Corrected.
+2. **`@PrePersist` fires AFTER identifier generation.** The guard could never observe a null id — it was dead
+   code that read as protection. Removed.
+
+What is committed instead is the test, repointed at the constraint that actually protects this, and
+mutation-proven: dropping `fk_slease_binding` from V3 makes it fail. The residual concern is now purely that
+an FK violation is a less readable message than a domain one, so the fleet ADR-0013 exemption follow-up is
+cosmetic rather than safety-relevant — as you predicted, for a different reason than either of us had.
+
+### F4 — the `now()` decision, and why it is a correctness issue
+
+**PostgreSQL's `now()` is `transaction_timestamp()`: it does not advance for the transaction's lifetime.**
+`heartbeat`, `stillOwns` and `release` are all called from inside a long-running page, so joining that
+transaction broke each differently: a heartbeat five minutes into a ten-minute page would compute its new
+expiry from the moment the page *started*, so the operation whose entire purpose is keeping a long run's lease
+alive would compute an expiry already in the past and the lease would be stolen mid-run; `stillOwns` would
+compare against the same frozen reading and call an expired lease live; `release` would roll back with a
+failed page.
+
+**Decision: keep `now()`, reject `clock_timestamp()`, move the boundary.** `clock_timestamp()` is
+PostgreSQL-only, so every contention test that establishes this lease's correctness would stop running, and it
+would not fix the release-rollback half at all. `REQUIRES_NEW` fixes both, portably.
+
+**Placed on `SupplierScheduleCoordinator`, not the repository.** On the repository it would additionally stop
+every `@DataJpaTest` of those queries from seeing its own uncommitted fixtures — the tests would have to be
+rewritten around a constraint unrelated to what they prove. `advanceCheckpoint` deliberately stays `REQUIRED`
+(binding decision 4).
+
+**H2 cannot reproduce this** — its `now()` is statement-scoped — so no behavioural test can demonstrate it and
+the boundary is pinned structurally. `SupplierScheduleCoordinatorTest` did have to move to real commit
+boundaries, which is the right shape for a lease test anyway.
+
+### The two owed items
+
+**OAuth2 invalidation.** `internal.service` publishes `SupplierAuthConfigChanged`; `internal.client` listens.
+Event, not a call, because the reverse edge is a package cycle; the record lives in `internal.spi`. Published
+unconditionally on update **including a pure rename**, because rotating a secret changes the value behind an
+unchanged `env:` reference and is invisible from here — over-signalling costs one token request,
+under-signalling costs an hour of failures. A plain `@EventListener`, not `AFTER_COMMIT`, for the same
+asymmetry. `deleteProfile` reads its auth config ids before the bulk delete.
+
+**Known limitation, stated rather than assumed:** an application event does not leave the JVM, so this clears
+the cache only on the instance that served the admin request. Complete for a single instance; a cross-instance
+signal needs the platform event bus. Recorded as a follow-up.
+
+**Token-leg timeouts.** Extracted `SupplierHttpClients` so the token leg shares the vendor transport. It had
+been using the *platform* builder — 2s connect / 5s read budgets meant for in-cluster services, applied to a
+third-party token endpoint, on `SimpleClientHttpRequestFactory`, which cannot distinguish a connect timeout
+from a read timeout. **The token leg still had the exact defect `67dc356` fixed for the main leg.** Its
+timeouts are now its own (`pos.supplier.oauth2.connect-timeout-millis` / `read-timeout-millis`, 5s/15s):
+`apply()` receives only the auth config, and a token endpoint is a different endpoint from the vendor API and
+reasonably budgeted separately. The `RestClientConfig` javadoc claiming vendor transport "does not run through
+this builder" was false by the time OAuth2 shipped, and is corrected. The caught cause was already chained.
+
+### A self-inflicted trap worth reading: test-resources config SHADOWS main config
+
+Activating the `test` profile via `src/test/resources/application.yml` was the first attempt at F1, and it was
+worse than the problem. **A test-classpath `application.yml` replaces the main one entirely**, so the module's
+real configuration stopped being loaded by any test — and a duplicate `pos:` key I introduced in
+`application.yml` survived a fully green **519-test** run, surfacing only when the app was actually started to
+generate the OpenAPI spec. The profile is now activated by a surefire `systemPropertyVariables` entry, so the
+main file loads in tests and `PosSupplierApplicationSmokeTest` is once again a real guard on it.
+
+### The mutation hook, again
+
+Two more findings in the tool itself, both of the same family as the first:
+
+1. **Gate 4 added: `--expect-fail-message` is now mandatory for Spring-context tests.** A context test can
+   fail because the assertion fired or because the mutation broke context startup, and those are
+   indistinguishable by exit code — a DEFENDED verdict would not mean what it says. Detected from the
+   annotations in the test source.
+2. **`grep -qF` without `--`** treated an expected message starting with a dash as its own flag. Fixed in the
+   hook and the self-test.
+
+`mutation-check-selftest.sh` now covers 5 cases and is itself verified against the pre-fix hook: it fails
+there, reproducing the exact false UNDEFENDED, and passes against the fixed one.
+
+Also recorded, because it wasted a cycle: **AssertJ's `.as(...)` description is NOT in the failure output when
+`assertThatThrownBy` fails because nothing was thrown** — the description is attached to the returned assert,
+which never exists. One test was reshaped to assert on the collection rather than on `getFirst()` blowing up,
+so its failure names the guarantee instead of throwing `NoSuchElementException`.
+
+### Gates at the final commit
+
+| Gate | Result |
+| --- | --- |
+| `./mvnw -pl pos-supplier -am -DskipTests=false verify` | **BUILD SUCCESS** — pos-supplier **519** tests (499 to 519) |
+| `./mvnw -pl pos-archunit -am -DskipTests=false test` | **BUILD SUCCESS** |
+| `./mvnw -pl pos-supplier spotless:check` | **clean** |
+| lint hook, 25 touched files | **PASS**, 113 rules, **0 findings** |
+| `scripts/generate-permissions.sh --sync --check` | **exit 0**, all up-to-date, **CATALOG_VERSION 42 unchanged** |
+| `scripts/check-flyway-hygiene.sh` | **passed**, 25 modules |
+| `pos-supplier/openapi.yaml` regenerated | **no change** — this wave altered no contract shape |
+| `openapi-aggregate.yaml` rebuilt, 26 modules | **no change**, 778 paths, no module dropped |
+
+### One new semgrep suppression
+
+`SupplierAuthStrategyTest`: `strategy.supportedType() == SupplierAuthType.BEARER` is an **enum** comparison,
+where `==` is correct and `.equals()` would be worse. Line-scoped, justification names the type and why the
+rule cannot see it.
+
+### Still owed at close-out
+
+1. Independent review of the full remaining range.
+2. `pos-supplier/README.md` + `BACKEND_CONTRACT_GUIDE.md`.
+3. Follow-ups: inbound `X-Correlation-Id` filter; cross-instance credential invalidation; fleet ADR-0013
+   assigned-id exemption (now cosmetic); CAP-318 per-binding redaction (F6).

--- a/domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md
+++ b/domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md
@@ -1,0 +1,356 @@
+---
+title: Positivity (Supplier Integrations) Backend Contract Guide
+domain: positivity
+doc_type: backend_contract
+contract_status: draft
+owner_repo: louisburroughs/durion
+guide_path: domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md
+openapi_source: durion-positivity-backend/pos-supplier/openapi.yaml
+openapi_commit: dde82cc
+last_verified_utc: 2026-08-11T18:00:00Z
+last_updated: 2026-08-11
+api_reference_generated: none — not yet generated for this domain
+traceability:
+  capability_manifest_root: docs/capabilities
+---
+
+# Positivity (Supplier Integrations) Backend Contract Guide
+
+## Purpose & Scope
+
+Curated contract guide for the supplier-integration domain (module `pos-supplier`, Eureka name
+`SUPPLIER`, package `com.positivity.supplier`).
+
+- Use this guide for capability intent, domain invariants, dependency boundaries, and UI-to-API mapping.
+- Use OpenAPI for request/response schemas and full endpoint detail.
+
+The domain owns **how** the platform reaches a supplier — connection configuration, credential
+references, the outbound transport, and the exchange audit trail. It does **not** own the wire formats:
+protocol codecs (EDIWheel A2.5/B/C1/JSON, Michelin S2S) arrive in CAP-318 behind the SPI ports in
+`internal.spi`.
+
+Authoritative references:
+
+- OpenAPI: `durion-positivity-backend/pos-supplier/openapi.yaml`
+- Module README (configuration, operations, YAML example): `durion-positivity-backend/pos-supplier/README.md`
+- ADR-0050 (vendor profile configuration): `docs/adr/0050-supplier-vendor-profile-configuration.adr.md`
+- ADR-0051 (protocol adapter versioning): `docs/adr/0051-supplier-protocol-adapter-versioning.adr.md`
+- ADR-0052 (outbound idempotency / duplicate-order prevention):
+  `docs/adr/0052-supplier-outbound-idempotency-duplicate-order-prevention.adr.md`
+- Global standards: `docs/architecture/api/BACKEND_CONTRACT_GLOBAL_STANDARDS.md`
+
+No generated API reference exists for this domain yet. Until one does, treat `pos-supplier/openapi.yaml`
+as the schema source of truth.
+
+## How To Use This Guide
+
+Backend coder workflow:
+
+1. Read `Domain Invariants` — several are load-bearing in ways that are not visible from a single class.
+2. Read the capability section for the behaviour you are changing.
+3. Use the `operationId` mappings here, then confirm payloads in `pos-supplier/openapi.yaml`.
+4. When you touch a controller, regenerate the spec and **verify the regenerated artifact**, not the
+   annotations — springdoc infers a body from the return type when `content` is absent.
+
+Frontend developer workflow:
+
+1. Start with `Frontend API Lookup`, identify the `operationId`.
+2. Open `pos-supplier/openapi.yaml` for exact payload and response detail.
+3. Note which operations require `supplier:audit:read` — it is not implied by profile admin rights.
+
+Gateway routing: external `/supplier/supplier/admin/...` with `X-API-Version: 1` → `lb://SUPPLIER
+/v1/supplier/admin/...` (the first `/supplier` routes to the service and is stripped; the version header
+is rewritten into the path). Pre-versioned form: `/supplier/v1/supplier/admin/...`. Same doubled-segment
+convention as `pos-warranty` and `pos-inventory`.
+
+## Domain Invariants
+
+1. **Credentials are references, never values.** Every credential field on an auth config holds a
+   `scheme:value` reference resolved at call time. The scheme must be backed by a registered resolver —
+   today `env:` only — enforced at admin write time *and* at YAML startup, so an unsupported scheme fails
+   immediately rather than at first vendor call. A `baseUrl` containing userinfo is rejected: that is a
+   plaintext credential (ADR-0050 §4).
+2. **Resolved credential values never leave the process.** They are not logged at any level, not carried
+   on `ExchangeContext`, not in metrics tags, and not in health details.
+3. **`vendorProfileId` is identity; `supplierRef` is a label.** Audit rows and events key on the UUID.
+   `supplierRef` is snapshotted alongside it for readability, never as a join key.
+4. **Two sources of truth, explicitly recorded.** A profile is `YAML`-managed (reconciled from
+   configuration at startup; admin mutation rejected with 409) or `ADMIN`-managed (owned by the API).
+5. **Disabling is reversible; deleting is not.** A disabled profile resolves every capability to
+   `SUPPLIER_PROFILE_DISABLED`; a disabled binding behaves as absent. `DELETE` hard-cascades profile,
+   bindings, auth configs and accounts. Exchange-audit rows deliberately survive — no FK to the profile —
+   because the trail of a deleted supplier is exactly what a dispute needs.
+6. **A missing capability is a typed outcome, not an error.** ADR-0050 §3: capability endpoints surface
+   `CAPABILITY_NOT_CONFIGURED` as a typed status on a 200 response. The handler's 409 mapping is a safety
+   net against an escaped exception, not the contract.
+7. **Only a pre-send failure may be retried automatically.** ADR-0052 §5. A post-send ambiguity is never
+   retried unless the caller declares the request an idempotent batch read; the failure mode is a
+   duplicate purchase order.
+8. **Every attempt is audited, including failures and each retry.** The audit writer is an
+   `ExchangeObserver`, so the transport never depends on a repository.
+9. **Payload reads are themselves audited, as a precondition.** ADR-0050 §7. The access record is written
+   in the read's own transaction with no catch: if it cannot be written, the read returns nothing.
+10. **Payload capture is bounded by the binding's capture level, enforced in the schema.**
+    `METADATA_ONLY` carrying a payload is rejected by a database CHECK constraint, not merely by code.
+
+## Capability Index
+
+| Capability | Stories | Status |
+| --- | --- | --- |
+| CAP-317 — pos-supplier foundation | #1221 (skeleton/model/SPI/registry), #1222 (vendor profiles + admin API), #1223 (base client, exchange audit, scheduler) | Implemented, reviewed, not yet merged |
+| CAP-318 — protocol codecs | not yet authored | Not started |
+
+## Frontend API Lookup
+
+All paths are service-relative (`/v1/...`); prefix with `/supplier` at the gateway.
+
+| UI action | Method & path | operationId | Permission |
+| --- | --- | --- | --- |
+| List configured suppliers | `GET /v1/supplier/admin/profiles` | `listProfiles` | `supplier:profile:read` |
+| View one supplier | `GET …/profiles/{vendorProfileId}` | `getProfile` | `supplier:profile:read` |
+| Onboard a supplier | `POST …/profiles` | `createProfile` | `supplier:profile:write` |
+| Edit a supplier | `PUT …/profiles/{vendorProfileId}` | `updateProfile` | `supplier:profile:write` |
+| Remove a supplier | `DELETE …/profiles/{vendorProfileId}` | `deleteProfile` | `supplier:profile:write` |
+| List auth configs | `GET …/profiles/{id}/auth-configs` | `listAuthConfigs` | `supplier:profile:read` |
+| Add auth config | `POST …/profiles/{id}/auth-configs` | `createAuthConfig` | `supplier:profile:write` |
+| Edit auth config | `PUT …/profiles/{id}/auth-configs/{authConfigId}` | `updateAuthConfig` | `supplier:profile:write` |
+| Remove auth config | `DELETE …/profiles/{id}/auth-configs/{authConfigId}` | `deleteAuthConfig` | `supplier:profile:write` |
+| List commercial accounts | `GET …/profiles/{id}/accounts` | `listAccounts` | `supplier:profile:read` |
+| Add account | `POST …/profiles/{id}/accounts` | `createAccount` | `supplier:profile:write` |
+| Edit account | `PUT …/profiles/{id}/accounts/{accountId}` | `updateAccount` | `supplier:profile:write` |
+| Remove account | `DELETE …/profiles/{id}/accounts/{accountId}` | `deleteAccount` | `supplier:profile:write` |
+| List capability bindings | `GET …/profiles/{id}/bindings` | `listBindings` | `supplier:profile:read` |
+| Add binding | `POST …/profiles/{id}/bindings` | `createBinding` | `supplier:profile:write` |
+| Edit binding | `PUT …/profiles/{id}/bindings/{bindingId}` | `updateBinding` | `supplier:profile:write` |
+| Remove binding | `DELETE …/profiles/{id}/bindings/{bindingId}` | `deleteBinding` | `supplier:profile:write` |
+| Browse exchanges in a window | `GET …/audit/exchanges` | `listExchanges` | `supplier:audit:read` |
+| Trace one call incl. retries | `GET …/audit/exchanges/by-correlation/{correlationId}` | `traceCorrelation` | `supplier:audit:read` |
+| One exchange's metadata | `GET …/audit/exchanges/{exchangeAuditId}` | `getExchange` | `supplier:audit:read` |
+| Read stored payload content | `GET …/audit/exchanges/{exchangeAuditId}/payload` | `readPayload` | `supplier:audit:read` |
+| Who read this payload | `GET …/audit/exchanges/{exchangeAuditId}/accesses` | `listAccesses` | `supplier:audit:read` |
+
+UI notes:
+
+- Auth-config responses **never** return credential reference fields. A form editing an auth config
+  writes references; it cannot read back what is currently set. Present this as intentional.
+- `listExchanges` takes a half-open `[from, to)` window; `from == to` is a typed 400, and `size` above
+  200 is a 400. Tiling adjacent windows will not double-count.
+- At `METADATA_ONLY`, `endpointUri` in a response has no query string. This is redaction at capture time,
+  not truncation at read time — the original was never stored.
+- `readPayload` writes an access record. Do not call it to pre-populate a list view or on hover; each
+  call is a recorded disclosure.
+
+## Permission Matrix
+
+| Permission | Bit | Grants |
+| --- | --- | --- |
+| `supplier:profile:read` | 446 | View profiles, auth configs (without references), accounts, bindings |
+| `supplier:profile:write` | 447 | Create/edit/delete profiles, auth configs, accounts, bindings |
+| `supplier:audit:read` | 445 | All five audit operations, including decrypted payload content |
+
+`supplier:audit:read` is deliberately **not** implied by profile administration: it exposes commercial
+documents exchanged with vendors, which is a strictly wider disclosure than knowing how a connection is
+configured. A caller holding both profile permissions and not `supplier:audit:read` receives 403 on every
+audit operation, and a test asserts exactly that combination.
+
+`CATALOG_VERSION` is 42 and covers bits 445–447. Because this module uses constant-based `@PreAuthorize`,
+`scripts/generate-permissions.sh --sync --check` structurally cannot detect drift here — the manual
+catalog entries are the only guarantee.
+
+## Capability Sections
+
+### CAP-317 — pos-supplier foundation
+
+#### Capability Metadata
+
+| Field | Value |
+| --- | --- |
+| Stories | #1221, #1222, #1223 |
+| Module | `pos-supplier` |
+| Branch | `cap/317-supplier-foundation` |
+| Migrations | V1 baseline, V2 vendor profiles, V3 exchange audit + schedule lease, V4 audit access, V5 widen `protocol_version` |
+| New permissions | none beyond bits 445–447 already in catalog v42 |
+
+#### Scope & Intent
+
+Configure a vendor connection, reach it safely, and keep an evidentiary record of the exchange. Three
+slices: the module skeleton with the SPI ports and adapter registry; vendor profiles with the admin API;
+the outbound base client with exchange audit, retention purge, scheduler lease and the audit read API.
+
+#### API Operation References (OpenAPI Source of Truth)
+
+22 operations, all under `/v1/supplier/admin`. See `Frontend API Lookup` for the full mapping; schemas
+live in `pos-supplier/openapi.yaml` at commit `dde82cc`.
+
+#### Behavioral Assertions
+
+Profile administration:
+
+1. Creating a profile with a credential reference whose scheme is unsupported is rejected at write time.
+2. Mutating a `YAML`-managed profile through the admin API is rejected; configuration wins.
+3. Renaming an auth config still referenced by a binding is a conflict, not a cascade.
+4. Deleting a profile cascades to its bindings, auth configs and accounts, and leaves audit rows intact.
+5. Changing or deleting an auth config invalidates any cached OAuth2 token for it, so a rotated secret
+   takes effect immediately rather than at token expiry.
+6. A `baseUrl` containing userinfo is rejected with a message that names the field and does not echo it.
+
+Outbound transport:
+
+7. A binding resolves to `(family, version, baseUrl, path, auth)`; an unregistered version resolves to
+   `CAPABILITY_NOT_CONFIGURED` rather than failing loudly. **A version is not validated on write.**
+8. Credentials are applied per attempt at call time and never logged.
+9. Connect and read timeouts are distinguished by exception type, not message text.
+10. Only `PRE_SEND_FAILURE` is retried; a token-endpoint transport failure is pre-send (nothing reached
+    the vendor's business endpoint) and therefore retryable, while a vendor 401/403 on the token leg is a
+    definitive credential rejection.
+11. A breaker opens on transport failures only; a 4xx or configuration error does not count toward it.
+12. The health indicator never reports DOWN — a vendor outage must not restart this service.
+
+Exchange audit:
+
+13. One row per attempt, including failures and each retry, sharing a correlation id.
+14. Payload columns are encrypted; the envelope binds its header as AAD, so a rewritten key id fails
+    authentication rather than decrypting.
+15. A payload sealed with a rotated-out key yields a typed unreadable-payload error; the metadata row
+    still lists and still reads by id.
+16. `METADATA_ONLY` stores no bodies and no URI query string; the database rejects a violation.
+17. An unknown or missing binding falls back to `REDACTED`, never `FULL`.
+18. The retention purge nulls payloads, stamps `payloads_purged_at`, and keeps metadata permanently.
+19. Reading payload content writes an access record in the same transaction; if that write fails, no
+    content is returned.
+20. A scheduler lease is claimed by an atomic database decision; a stolen lease leaves the old owner
+    unable to heartbeat, checkpoint or release, and its page rolls back with its checkpoint.
+
+#### Status Code Semantics (ADR-0017)
+
+| Code | Status | Meaning |
+| --- | --- | --- |
+| `SUPPLIER_UNKNOWN` | 404 | No profile for that alias or id |
+| `SUPPLIER_PROFILE_DISABLED` | 409 | Profile exists, disabled |
+| `SUPPLIER_CAPABILITY_NOT_CONFIGURED` | 409 | Safety net only — capability endpoints return a typed 200 status |
+| `SUPPLIER_MISSING_BILLING_ACCOUNT` | 409 | No billing account for an account-level operation |
+| `SUPPLIER_MISSING_DELIVERY_MAPPING` | 409 | Requested location has no delivery mapping |
+| `SUPPLIER_AUTH_CONFIG_MISSING` | 409 | Binding names a nonexistent auth config |
+| `SUPPLIER_AUTH_CREDENTIALS_REJECTED` | 409 | Vendor refused the resolved credentials (401/403 on the token leg) |
+| `SUPPLIER_PROFILE_YAML_MANAGED` | 409 | Admin mutation of a configuration-owned profile |
+| `SUPPLIER_URL_CONTAINS_CREDENTIALS` | 400 | `baseUrl` carries userinfo |
+| `SUPPLIER_SECRET_REF_MALFORMED` | 400 | Reference is not a supported `scheme:value` |
+| `SUPPLIER_AUTH_TOKEN_RESPONSE_INVALID` | 500 | Vendor returned 2xx with no usable token — vendor contract violation |
+| `SUPPLIER_SECRET_*`, `SUPPLIER_YAML_BOOTSTRAP_INVALID` | 500 | Deployment defect; generic client message, detail logged server-side |
+| `SUPPLIER_AUDIT_PAYLOAD_UNKNOWN_KEY_ID` / `_AUTHENTICATION_FAILED` / `_MALFORMED_ENVELOPE` | 500 | Stored payload unreadable; names no key id or variable |
+
+Deployment defects return 500 with a deliberately generic message: their detail names environment
+variables, and echoing that to a caller is information disclosure (ADR-0050 §3).
+
+#### Audit and Security Rules
+
+- Method security is deny-by-default `@PreAuthorize` on every operation (ADR-0040); the gateway supplies
+  identity via `X-Authorities` / `X-User`.
+- 401 responses carry **no body** (the shared entry point is bodiless); 403 responses carry `ApiError`.
+- Encryption fails closed: the service will not start without a key unless *every* active profile is
+  `dev` or `test`. `prod,dev` requires a key.
+- A retired encryption key must remain in `previous-keys` for the whole retention window.
+- Payload-body redaction is name-based with a compiled-in field set. It cannot redact a credential
+  carried positionally (e.g. an EDIFACT `UNB` password), and per-binding data classification is not yet
+  implemented — see Open Questions.
+
+#### ADR Constraints
+
+| ADR | Constraint |
+| --- | --- |
+| ADR-0050 §2 | Profile shape, sandbox overlay, per-profile timeouts |
+| ADR-0050 §3 | No error leaks; capability absence is a typed status |
+| ADR-0050 §4/§6 | Credential references only; plaintext never persists |
+| ADR-0050 §7 | Retention 400 days, encryption at rest, minimization, capture levels, audited access |
+| ADR-0051 | Protocol adapter versioning; `internal.domain` / `internal.spi` / `internal.registry` / `internal.adapter.<family>` |
+| ADR-0052 §5 | Pre-send vs post-send-ambiguous vs definitive classification (duplicate-order prevention) |
+| ADR-0011 | `/v1/{domain}` route convention |
+| ADR-0025 §4 | Declared permissions must be enforced |
+| ADR-0042 | 4xx typed `ApiError`; parameters carry schema and example |
+
+#### Events & Dependencies
+
+22 event types are registered, all admin-surface: `SUPPLIER_PROFILE_*`, `SUPPLIER_AUTHCONFIG_*`,
+`SUPPLIER_ACCOUNT_*`, `SUPPLIER_BINDING_*` (list/get/create/update/delete), plus
+`SUPPLIER_AUDIT_EXCHANGE_LIST`, `SUPPLIER_AUDIT_EXCHANGE_GET`, `SUPPLIER_AUDIT_EXCHANGE_TRACE`,
+`SUPPLIER_AUDIT_ACCESS_LIST` and `SUPPLIER_AUDIT_PAYLOAD_READ`. `SUPPLIER_AUDIT_PAYLOAD_READ` is
+deliberately budgeted as a write: it inserts an access row.
+
+Inbound dependencies: `pos-location` (delivery-location UUIDs on commercial accounts), `pos-security-service`
+(permission registration), `pos-event-receiver` (event type registration).
+
+Outbound: none within the platform. Vendor endpoints are external third parties, so ADR-0014's
+server-to-server rules do not apply to them.
+
+Consumers of this domain do not exist yet. CAP-318 codecs will be the first, through the SPI ports.
+
+#### Contract Test Traceability
+
+| Assertion group | Test |
+| --- | --- |
+| Admin CRUD, error envelopes, permission separation | `SupplierAdminControllersWebMvcTest` |
+| Secret-scheme allowlist | `AuthReferenceRulesTest`, `SecretSchemeRegistryTest`, `SupplierYamlBootstrapTest` |
+| Classification and retry safety | `SupplierBaseClientTest` (asserts requests that reached the wire) |
+| OAuth2 cache keying, single-flight, invalidation | `OAuth2ClientCredentialsAuthStrategyTest`, `SupplierAuthStrategyTest` |
+| Encryption envelope, tampering, rotation, key policy | `AuditPayloadCipherTest` |
+| Capture levels, redaction, URI redaction | `PayloadRedactorTest` |
+| Encryption at rest (asserts raw column bytes) | `ExchangeAuditObserverTest`, `ExchangeAuditWriterTest` |
+| Transaction boundaries | `ExchangeAuditWriterTest`, `SupplierExchangeAuditPersistenceTest` |
+| Lease contention, stolen lease, checkpoint | `SupplierScheduleLeaseRepositoryTest`, `SupplierScheduleCoordinatorTest` |
+| Enum/constraint and column-width parity | `SupplierContractKeyParityTest`, `ExchangeAuditColumnWidthParityTest` |
+
+Guarantees are additionally mutation-checked via `.github/hooks/mutation-check-hook.sh`: the mutation must
+be proven applied and the test must fail, or the guarantee is reported `UNDEFENDED`.
+
+#### Open Questions / Non-Goals
+
+- **Per-binding, data-classification-driven body-field redaction** (ADR-0050 §7) is not implemented.
+  Redaction is credential-name-based and compiled in. Owed by CAP-318, when codecs define real document
+  shapes. The ADR was deliberately **not** amended to match the implementation.
+- **Positional formats are not redactable by name.** `METADATA_ONLY` is the only level that guarantees a
+  positional document retains nothing.
+- **Inbound `X-Correlation-Id` reuse** is not wired; only outbound correlation is scoped.
+- **Binding `version` is not validated** against the adapter registry, so a typo persists and silently
+  resolves every call to `CAPABILITY_NOT_CONFIGURED`.
+- **Optimistic locking is deliberately absent** on the admin surface: last-write-wins is accepted and
+  recorded. Two operators editing one profile is last-write-wins.
+- **Non-goals:** wire formats and codecs (CAP-318), order reconciliation for post-send ambiguity
+  (CAP-320), secret-store resolvers beyond `env:`.
+
+## Events & Cross-Domain Dependencies
+
+This domain publishes only admin/audit-surface events and consumes none. It is a leaf: no other backend
+domain depends on it yet. `pos-location` UUIDs appear on commercial accounts as opaque references — there
+is no synchronous call to that service.
+
+## Verification Metadata
+
+| Gate | Result at `dde82cc` |
+| --- | --- |
+| `-pl pos-supplier -am -DskipTests=false verify` | SUCCESS, 546 module tests |
+| `-pl pos-archunit -am test` | SUCCESS (must run under `test`; `verify` repackages and hides classes — repo issue #909) |
+| `spotless:check` | clean |
+| Touched-file lint | 0 findings |
+| `generate-permissions.sh --sync --check` | exit 0, `CATALOG_VERSION` 42 unchanged |
+| `check-flyway-hygiene.sh` | passed, 25 modules |
+| Spec + 26-module aggregate | regenerated, aggregate byte-identical |
+
+Known gaps in verification, recorded rather than resolved:
+
+- Full-reactor `verify` is red for three causes unrelated to this domain: pos-accounting uses
+  PostgreSQL-only SQL under H2 (proven pre-existing by building the base commit in a worktree),
+  `FlywayMigrationIT` in four modules needs a Docker daemon, and pos-archunit fails under `verify` by
+  design. Reactor `test` is green across 41 modules.
+- **V5 has never executed against real PostgreSQL** — only H2 in PostgreSQL mode. Widening a `varchar` is
+  metadata-only and has repo precedent (`pos-security-service/V19`), but the first real execution will be
+  in a deployed environment.
+
+## References
+
+- `durion-positivity-backend/pos-supplier/README.md` — configuration, YAML example, operational detail
+- `durion-positivity-backend/pos-supplier/openapi.yaml` — schema source of truth
+- `docs/adr/0050-supplier-vendor-profile-configuration.adr.md`
+- `docs/adr/0051-supplier-protocol-adapter-versioning.adr.md`
+- `docs/adr/0052-supplier-outbound-idempotency-duplicate-order-prevention.adr.md`
+- `docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md` — decision record and follow-up queue
+- `domains/positivity/DOMAIN_NOTES.md`, `domains/positivity/AGENT_GUIDE.md`


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:317`
- Parent STORY (durion): louisburroughs/durion#372
- Child issues (backend): louisburroughs/durion-positivity-backend#1221, #1222, #1223
- Domain: `domain:positivity`

**Paired backend PR: louisburroughs/durion-positivity-backend#1243** — that PR's body references the contract guide added here by path, so the two should land together.

This PR intentionally closes no issues. The capability's stories are closed by the backend PR; this is the durion-side record and tooling that accompanies it.

## Contract References
- Contract guide entry: `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → `#cap-317--pos-supplier-foundation` — **new file**; the positivity domain had no contract guide, which story #1222 asked for
- OpenAPI source of truth: `durion-positivity-backend/pos-supplier/openapi.yaml` @ `dde82cc`

## Scope

9 files, +2,288 / −2, across four groups.

### 1. Positivity backend contract guide (new, 356 lines)

`domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md`, following the curated guide/reference split the other ten domains use — intent, invariants, UI-to-API mapping and constraints here; schemas stay in `pos-supplier/openapi.yaml`, named as the source of truth since no generated API reference exists for this domain yet.

Contents: ten domain invariants; the full 22-operation lookup table with `operationId`s and required permissions; the permission matrix explaining why `supplier:audit:read` is deliberately not implied by profile administration; the complete error-code-to-HTTP mapping; 20 behavioural assertions each mapped to the test that defends it; and a verification section.

Two deliberate choices in it:
- **Gaps are recorded as gaps.** Per-binding, data-classification-driven field redaction (ADR-0050 §7) is listed as owed by CAP-318, with an explicit note that **ADR-0050 was not amended** to match the implementation — the requirement is right, the code has not met it yet. Amending the ADR would have been lowering the bar to fit the code.
- **The verification section states two honest limits** rather than implying a clean sweep: full-reactor `verify` is red for three causes unrelated to this domain, and migration V5 has only ever executed against H2 in PostgreSQL mode.

### 2. CAP-317 wave record (new, 1,172 lines)

`docs/capabilities/CAP-317/WAVE_PAUSE_STATE.md` — the decision and evidence record for the whole wave. It exists because `Durion-Processing.md` is gitignored as a transient artifact, so nothing durable would otherwise survive the session.

It carries the binding arbitration decisions (audit payload encryption, test-stub strategy, package layout, scheduler lease, plus key rotation recorded as an amendment), the three architectural decisions taken during the wave (no FK from audit to `supplier_profile`; `env:`-only non-configurable secret-scheme allowlist; last-write-wins accepted on the admin surface), all four independent review verdicts with their fix queues, gate evidence per commit, and the follow-up queue.

It also records the recurring failure patterns this wave hit, which are the parts most likely to be useful to the next one:
- **Tests that asserted the defect** rather than defending against it — twice, both corrected rather than worked around.
- **Removing an annotation is not the same as declaring nothing.** springdoc infers a response body from the return type when `content` is absent, so a contract change must be verified against the *regenerated spec*, never reasoned about from the annotation diff. This cost two review rounds.
- **A prescription that did not survive contact with the framework** — twice, each caught by a real test rather than by review.

### 3. Mutation-check tooling (new, 4 files, mirrored `.github/hooks` ↔ `.claude/hooks`)

`mutation-check-hook.sh` plus a self-test. This exists because a mutation check in this wave **silently no-opped**: the removal pattern did not match spotless-reformatted code, the script reported success, the test passed, and an unproven guard was nearly recorded as proven. A mutation harness that can lie is worse than none, since it manufactures confidence.

The hook makes the three enabling conditions impossible to skip: the pattern must match exactly once or it aborts before touching the file; the file must actually differ after mutation; and the test must **fail** — an unexpected pass is reported as `UNDEFENDED`, framed as a finding about the test rather than a reason to retry. `--expect-fail-message` is mandatory for Spring-context tests, because a context test failing at startup is indistinguishable by exit code from the named assertion firing.

It caught real problems immediately, including two of its own: an inherited Java 21 `JAVA_HOME` producing "no tests ran" instead of a false green; a mutation detected by an exception assertion that short-circuited before the assertion being claimed; and — twice — `Tests run: 0` being accepted as a run, because `Class#method` does not match `@Nested` methods (surefire needs `Class$Nested#method`). The self-test covers five cases and is verified against the pre-fix hook: it reproduces the original false `UNDEFENDED` there and passes against the fixed one.

`CLAUDE.md` gains the hook in its registry table so the next session knows it exists.

### 4. ADR-0053 status (pre-existing on this branch)

`0053-supplier-pricat-ingestion-and-price-precedence.adr.md` moves `PROPOSED` → `ACCEPTED 2026-08-10` with domain sign-off recorded (durion#371), and the ADR index row follows. This commit predates the wave work on the branch and is included for completeness rather than as part of this capability.

**Why:** the backend PR references the contract guide by path, and the wave's decisions, review outcomes and follow-up queue need to live somewhere durable and reviewable rather than in a session transcript.

## Tests
- [ ] Unit tests added/updated — n/a, documentation and shell tooling
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated (backend) — n/a; the backend PR carries 546 module tests
- [ ] Consumer/UI tests added/updated (frontend) — n/a

The shell tooling has its own regression test rather than none:

```bash
.github/hooks/mutation-check-selftest.sh          # 5 cases; asserts the hook cannot silently pass
```

Documentation verification actually performed, rather than assumed:
- Every route, `operationId`, permission bit, error code, enum value and config property in both documents was read out of the source at `dde82cc` — not recalled. Four facts I would otherwise have inferred were wrong and were corrected: both ADR-0051 and ADR-0052 filenames and titles, and the registered event-type count (22, not 23).
- Both files pass `.markdownlint.jsonc`; the single over-length line is a table row, which MD013 exempts.
- The contract guide's YAML front matter parses and carries the same keys as the warranty guide it follows.

## Risk & Rollback
- **Risk level: Low.** Documentation and developer tooling only. No application code, no schema, no CI workflow, no runtime behaviour. The hooks are invoked manually by agents and workflows, not wired into a build lifecycle.
- **Rollback:** revert the branch. The only consequence is losing the wave record and the contract guide; nothing depends on either at runtime. Note the backend PR body links the contract guide by path, so reverting this without that one would leave a dangling reference.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — it is `claude/ediwheel-integration-arch-tr3ibn`, assigned by the session harness with instructions not to push elsewhere. Flagging the deviation rather than quietly renaming a pushed branch.
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated — created for this domain
- [x] Required CI checks passing — no code, no build; markdown lint verified locally

## Follow-ups this record hands off

Each needs its own PR and is out of scope here:
- **`pos-accounting` reactor blocker** — PostgreSQL-only `CROSS JOIN LATERAL generate_series` under H2, proven pre-existing by building base `da21c33` in a worktree. Owed by that module; worktree evidence is in the wave record.
- **resilience4j half-pin** — 2.4.0 autoconfiguration and retry over a 2.3.0 core/circuitbreaker/spring6 stack, because the root POM pins two artifacts of a family that `spring-cloud-circuitbreaker-dependencies:5.0.2` (line 88) governs as a coherent set. Verified by `dependency:tree` on two modules. Fix is to delete both pins and let the imported `resilience4j-bom` govern; it changes what `pos-document-helper` and `pos-tax` resolve, so it needs their tests as evidence.
- **Shared ArchUnit entity rule** — `EntityStandardsArchitectureTest` requires `@UUIDv7Id` on every UUID `@Id`, including assigned natural-key ids that are never generated. Affects 9 modules.
- **`module-inventory.yaml`** is missing `pos-marketing`, `pos-people-contact` and `pos-tax`, so those modules' specs are validated by nothing.
- **ADR-0042 fleet gaps** — no module supplies the §1 seven-part operation descriptions or §3 request-body documentation. `pos-supplier` now sits strictly ahead of the fleet on 401/403 and `ApiError` typing; the rest wants one coordinated pass rather than per-module divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bfb8uNXyRhAXMKYVf2vzZv)_