### PR TITLE
docs(adr): drop @Lob from ADR-0007 signature field examples

### DIFF
--- a/docs/adr/0007-approval-workflow-clarification.adr.md
+++ b/docs/adr/0007-approval-workflow-clarification.adr.md
@@ -71,17 +71,24 @@ The signature capture should support a dual format approach:
 public class CustomerApproval {
     // ... other fields
     
-    @Lob
     @Column(name = "signature_image_data", columnDefinition = "TEXT")
     private String signatureImageData; // Base64-encoded PNG
     
-    @Lob
     @Column(name = "signature_json_data", columnDefinition = "TEXT")
     private String signatureJsonData; // JSON stroke data
     
     private String signatureMimeType; // e.g., "image/png"
 }
 ```
+
+> **Do not add `@Lob` to these `String` fields.** On PostgreSQL, `@Lob` on a `String` maps
+> the column to a large-object `oid` rather than `text`, even when `columnDefinition` says
+> otherwise in H2-based tests. Large objects cannot be read in auto-commit mode — Hibernate
+> extracts them during entity hydration, so any load of the entity outside a transaction
+> fails — and they are not deleted with the referencing row, leaking `pg_largeobject`
+> storage on every update and delete. A plain `text` column has neither problem and no
+> length limit. See durion-positivity-backend#1461, which removed this pattern from the
+> platform and added an ArchUnit rule forbidding `@Lob` on `String` fields.
 
 **JSON Structure Example:**
 ```json


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (documentation correction)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1461
- Domain: `domain:workexec` (ADR-0007), prompted by a `domain:product` bug

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): n/a — docs-only change to an ADR's illustrative code example; no API or event behavior affected
- Durion contract PR (if applicable): n/a

## Scope
- What changed: the `CustomerApproval` example in `docs/adr/0007-approval-workflow-clarification.adr.md` no longer annotates its two signature `String` fields with `@Lob`, and a caution note now explains why `@Lob` must not be reintroduced.
- Why: on PostgreSQL, `@Lob` on a `String` maps the column to a large-object `oid` rather than `text` — even with `columnDefinition = "TEXT"`, which only shows up in H2-based tests. Large objects cannot be read in auto-commit mode (entity loads outside a transaction fail during hydration) and are not deleted with the referencing row, leaking `pg_largeobject` storage on every update and delete. This exact pattern shipped a production 500 in pos-catalog; louisburroughs/durion-positivity-backend#1461 (PR louisburroughs/durion-positivity-backend#1463) removed it from the platform and added an ArchUnit rule forbidding `@Lob` on `String` fields — so the ADR example, as written, would now fail the backend build.

## Tests
- [ ] Unit tests added/updated — n/a, docs only
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated (backend) — n/a
- [ ] Consumer/UI tests added/updated (frontend) — n/a
- How to run: n/a

## Risk & Rollback
- Risk level: Low — documentation only
- Rollback plan: revert the commit

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, docs fix branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [x] Links to parent + child issues are present (durion-positivity-backend#1461)
- [ ] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bih62ZDxS4H5DTdkyC6DTN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bih62ZDxS4H5DTdkyC6DTN)_