### PR TITLE
ADR-0056: Platform global exception handling and persistence error mapping

### DIFF
--- a/docs/adr/0056-platform-global-exception-handling.adr.md
+++ b/docs/adr/0056-platform-global-exception-handling.adr.md
@@ -1,0 +1,186 @@
+# ADR-0056: Platform Global Exception Handling and Persistence Error Mapping
+
+**Status:** PROPOSED **Date:** 2026-08-23 **Deciders:** Architecture, Backend Lead, API Lead **Affected Issues:** louisburroughs/durion-positivity-backend#1471
+
+---
+
+## Context
+
+[ADR-0017](0017-api-controller-http-response-codes.adr.md) requires every non-2xx response to carry the
+`ApiError` envelope (`code`, `message`, `status`, `timestamp`, `correlationId`) and to echo/generate
+`X-Correlation-Id`. In practice the requirement only held for exceptions someone had explicitly mapped:
+when an exception reached a controller without a matching `@ExceptionHandler`, Spring's default error
+page answered instead — a bare 500 with none of the envelope. Issue
+louisburroughs/durion-positivity-backend#1471 documented three production bugs in two days that all
+presented as this indistinguishable bare 500 (a `@Lob` read outside a transaction, a NOT NULL violation
+from a missing `AuditorAware`, and a UNIQUE violation on customer numbers), each costing hours that a
+mapped status plus a correlation id would have collapsed into minutes.
+
+Two structural gaps produced this:
+
+1. No service mapped `DataIntegrityViolationException`, so every unique/not-null/check violation became
+   an unmapped 500 despite ADR-0017 §2 already classifying duplicate-unique constraints as `409`.
+2. Only a minority of services had a catch-all `@ExceptionHandler(Exception.class)`. ADR-0017's
+   implementation notes said to centralize mapping in "global handlers" but mandated no mechanism, so
+   seven-plus services hand-rolled advices that each covered a different subset.
+
+---
+
+## Decision
+
+### 1. Platform catch-all is mandatory and shared
+
+**Decision:** ✅ **Resolved** — Every controller-bearing `pos-*` servlet module MUST have a catch-all
+exception handler that returns the ADR-0017 envelope with a correlation id and logs the stack trace at
+ERROR keyed by that correlation id ([ADR-0046](0046-environment-log-level-policy.adr.md) §6 structured
+logging carries the same id).
+
+The platform implementation is `GlobalApiExceptionHandler` in the shared **pos-web-common** module
+(durion-positivity-backend), registered via Spring Boot auto-configuration at
+`Ordered.LOWEST_PRECEDENCE`:
+
+- Service-specific `@ControllerAdvice` classes keep precedence for every exception type they map;
+  the shared advice only sees what nothing else handled.
+- Spring Security exceptions (`AccessDeniedException`, `AuthenticationException`) are rethrown so the
+  security filter chain renders its 401/403 — the advice never converts them to 500s.
+- Spring MVC's own web exceptions (unknown path, unsupported method/media type, malformed or unreadable
+  request bodies, parameter type mismatches) keep their framework status and gain the envelope, rather
+  than collapsing to 500.
+- 500 bodies stay generic (`INTERNAL_ERROR` / "Unexpected error occurred"); the correlation id is the
+  diagnostic handle. Rejected data values are never echoed; only constraint/column identifiers may be
+  named on 409/422.
+- Opt-out for tests or special cases: `pos.web.global-exception-handler.enabled=false`, or define a
+  module-local `GlobalApiExceptionHandler` bean (the auto-configuration backs off).
+
+### 2. Central `DataIntegrityViolationException` mapping
+
+**Decision:** ✅ **Resolved** — The shared advice classifies integrity violations by the SQLSTATE of the
+underlying `SQLException` (class 23 is standardized across PostgreSQL and H2) and maps:
+
+| Violation | SQLSTATE | Status | Code |
+| --- | --- | --- | --- |
+| Unique | `23505` | **409** | `DUPLICATE_RESOURCE` |
+| Not-null, client-supplied column | `23502` | **422** | `MISSING_REQUIRED_VALUE` |
+| Not-null, server-populated audit column | `23502` | **500** (enveloped, ERROR-logged) | `INTERNAL_ERROR` |
+| Check | `23514`/`23513` | **422** | `CONSTRAINT_VIOLATION` |
+| Foreign key | `23503`/`23506` | **409** | `REFERENCE_CONFLICT` |
+| Other class-23 | `23xxx` | **409** | `DATA_INTEGRITY_VIOLATION` |
+| Unclassifiable | — | **500** (enveloped, ERROR-logged) | `INTERNAL_ERROR` |
+
+The 409-for-unique row restates ADR-0017 §2 (duplicate-unique constraints are stateful collisions). The
+not-null split is the new decision this ADR adds: a NOT NULL violation on a server-populated audit column
+(`created_by`, `updated_at`, …; see [ADR-0018](0018-audit-actor-fields-from-security-context.adr.md) and
+[ADR-0024](0024-entity-createdat-updatedat-population-policy.adr.md)) means the *server* failed to
+populate it (e.g. a missing `AuditorAware`) — telling the client `422` would misdirect the retry, so it
+stays a 500, but an enveloped, correlated, ERROR-logged one. Client-supplied columns get `422`,
+consistent with ADR-0017's boundary (the payload was structurally valid; the domain data policy rejected
+it). Constraint and column names are extracted best-effort from the driver message; data values are
+never included.
+
+### 3. Shared advice lives in pos-web-common; pos-security-common re-exports it
+
+**Decision:** ✅ **Resolved** — The advice lives in a new shared library **pos-web-common**
+(`com.positivity.web.common`), not pos-security-common, because services without Spring Security
+(pos-event-receiver, the vehicle-reference proxies) must be able to consume it without inheriting
+Spring Boot's security auto-configuration lockdown. pos-security-common declares a compile dependency on
+pos-web-common, so all gateway-secured services (the overwhelming majority) receive the catch-all with no
+pom change; the few non-secured servlet services depend on pos-web-common directly.
+
+### 4. Enforced rather than remembered
+
+**Decision:** ✅ **Resolved** — pos-archunit's `GlobalExceptionHandlerEnforcementTest` fails the build for
+any module that declares `@RestController` endpoints but neither depends on pos-web-common (directly or
+via pos-security-common) nor declares its own `@ExceptionHandler(Exception.class)` advice.
+**pos-api-gateway is exempt**: it is a WebFlux application where the servlet advice does not apply, and
+gateway error rendering remains its own concern
+([ADR-0011](0011-api-gateway-security-architecture.adr.md)).
+
+---
+
+## Alternatives Considered
+
+1. **Copy a catch-all advice into every service**: Rejected — seven independent copies are how the
+   current drift happened; the copies already disagree on envelope shape (ProblemDetail vs ApiError).
+2. **Advice in pos-security-common directly**: Rejected — pulls `spring-boot-starter-security`
+   transitively into services that have no security configuration, activating Boot's default lockdown.
+3. **Advice in pos-shared-dtos**: Rejected — that module is deliberately dependency-light DTOs; web MVC
+   machinery does not belong there.
+4. **Map all not-null violations to 422**: Rejected — a NOT NULL failure on a server-populated audit
+   column is a server defect; a 4xx would tell the client to fix a request that was correct.
+5. **Enforce via Spring context tests per service**: Rejected — heavier and slower than a single
+   reactor-level source/pom scan, with no additional guarantee.
+
+---
+
+## Consequences
+
+### Positive ✅
+
+- ✅ No exception can leave a servlet service as Spring's bare default page: worst case is an enveloped,
+  correlated, ERROR-logged 500
+- ✅ Unique-constraint collisions surface as retryable 409s; not-null/check violations as 422s — SDK
+  integration suites can assert exact statuses on negative paths
+- ✅ One implementation to evolve; service advices keep full precedence for domain-specific mapping
+- ✅ The requirement is build-enforced, not convention-enforced
+
+### Negative ⚠️
+
+- ⚠️ Services relying on Spring's default 500 body shape (none should, per ADR-0017) see a body change
+- ⚠️ The audit-column list for the 422/500 not-null split is maintained centrally and must track any new
+  server-populated columns
+- ⚠️ SQLSTATE-based classification is driver-dependent for identifier extraction (best-effort names in
+  messages), though status mapping itself relies only on standardized class-23 codes
+
+### Neutral
+
+- pos-api-gateway (WebFlux) is out of scope; its error rendering is governed by ADR-0011
+- Existing per-service advices continue to work unchanged; migrating them onto shared codes is
+  incremental cleanup, not part of this decision
+
+---
+
+## Implementation Notes
+
+- Implementation (durion-positivity-backend PR louisburroughs/durion-positivity-backend#1474):
+  `pos-web-common` module (`GlobalApiExceptionHandler`, `DataIntegrityViolations`,
+  `WebCommonErrorAutoConfiguration`), auto-configured for servlet web applications only.
+- Enforcement: `pos-archunit/src/test/java/com/positivity/archunit/GlobalExceptionHandlerEnforcementTest.java`.
+- Envelope codes are documented in durion-positivity-backend `docs/ERROR_ENVELOPE.md`
+  ("Platform Fallback Codes").
+- ADR-0017 remains the status-matrix authority; on acceptance, add a changelog line there
+  cross-referencing this ADR for the not-null/check mapping.
+
+---
+
+## References
+
+- [ADR-0011: API Gateway Security Architecture](0011-api-gateway-security-architecture.adr.md)
+- [ADR-0017: API Controller HTTP Response Codes Standard](0017-api-controller-http-response-codes.adr.md)
+- [ADR-0018: Audit Actor Fields from Security Context](0018-audit-actor-fields-from-security-context.adr.md)
+- [ADR-0024: Entity createdAt/updatedAt Population Policy](0024-entity-createdat-updatedat-population-policy.adr.md)
+- [ADR-0046: Environment Log Level Policy](0046-environment-log-level-policy.adr.md)
+- Issue: louisburroughs/durion-positivity-backend#1471
+- Implementation PR: louisburroughs/durion-positivity-backend#1474
+
+---
+
+## Sign-Off
+
+| Role         | Name | Date | Notes |
+| ------------ | ---- | ---- | ----- |
+| Architecture |      |      |       |
+| Backend Lead |      |      |       |
+| API Lead     |      |      |       |
+
+---
+
+## Timeline
+
+- **Proposed**: 2026-08-23
+
+---
+
+## Changelog
+
+- **2026-08-23**: Initial draft, authored alongside the implementing change for
+  durion-positivity-backend#1471

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -120,6 +120,7 @@ ADRs are numbered sequentially starting from 0001. When creating a new ADR, use 
 | 0053   | Supplier PRICAT Ingestion, Effective Dating, and Price Precedence            | ACCEPTED              | 2026-08-10 |
 | 0054   | Sell-Price System of Record Split (pos-price Quoting, pos-catalog Reference) | ACCEPTED              | 2026-08-10 |
 | 0055   | Per-Product Inventory Quantity Divisibility                                  | ACCEPTED              | 2026-08-20 |
+| 0056   | Platform Global Exception Handling and Persistence Error Mapping             | PROPOSED              | 2026-08-23 |
 
 ## ADR Decision Matrix (When to Invoke + Agent Ownership)
 
@@ -182,6 +183,7 @@ Use this matrix during planning, implementation, and review to quickly decide wh
 | 0053 | PRICAT supplier-cost policy: pos-catalog owns append-only effective-dated supplier price entries (replacing supplier_item_cost), market-not-location scope, structural no-override of sell prices, deterministic EAN/UPC/MPN matching with quarantine, manifest-chunked import events               | Planner, Coder, Test, Orchestrator |
 | 0054 | Sell-price authority routing: pos-price is the transactional quoting SoR, pos-catalog narrows to list/MSRP reference (CUSTOMER_TIER book selection to be finished in the reference role); base-price history retention fix owned here                                                               | Planner, Coder, Test, Orchestrator |
 | 0055 | Inventory quantity divisibility declared per product via `product_uom.precision_scale` (undeclared = integral); symmetric demand/supply enforcement, decimal-capable ledger gated by the declaration, UOM on the workorder part line                                                                | Planner, Coder, Test, Orchestrator |
+| 0056 | Exception handling in any `pos-*` service: adding/changing a `@ControllerAdvice`, mapping `DataIntegrityViolationException`, catch-all handlers, error envelope/correlation-id behavior on unmapped failures, or a new controller-bearing module (must depend on pos-web-common or declare its own catch-all) | Planner, Coder, Test, Orchestrator |
 
 ### Agent role shorthand
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (governance/ADR, not a capability story)
- Parent STORY (durion): N/A — this PR is the decision record itself
- Child issue: louisburroughs/durion-positivity-backend#1471
- Domain: `domain:platform`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): N/A — governance doc only; the decision extends the platform standard in `docs/adr/0017-api-controller-http-response-codes.adr.md` (no domain `BACKEND_CONTRACT_GUIDE.md` semantics change)
- Durion contract PR (if applicable): implementation in louisburroughs/durion-positivity-backend#1474

## Scope
- What changed:
  - New `docs/adr/0056-platform-global-exception-handling.adr.md` (**PROPOSED**, sign-off pending), deciding the four points issue durion-positivity-backend#1471 left open under ADR-0017:
    1. Every controller-bearing `pos-*` servlet module must have a catch-all exception handler returning the ADR-0017 `ApiError` envelope with a correlation id, stack trace ERROR-logged against that id.
    2. Central `DataIntegrityViolationException` mapping by SQLSTATE: 409 for unique/FK collisions, 422 for not-null/check violations on client-supplied columns, enveloped ERROR-logged 500 when the violated column is server-populated (audit columns — a server defect, not a client error).
    3. The shared advice lives in the new `pos-web-common` library (not pos-security-common, to avoid dragging Spring Security's lockdown auto-config into unsecured services); pos-security-common re-exports it.
    4. Build-time enforcement via pos-archunit (`GlobalExceptionHandlerEnforcementTest`); pos-api-gateway (WebFlux) exempt.
  - `docs/adr/README.md`: index row + decision-matrix row for 0056.
- Why: unmapped exceptions escaped as Spring's bare default 500 page — no `code`, no `correlationId` — making three recent production bugs (#1460/#1464/#1469 in the backend repo) indistinguishable from "the environment is down". ADR-0017 already implied the requirement; nothing mandated the mechanism or enforced it.

## Tests
- [ ] Unit tests added/updated — N/A (documentation-only PR)
- [ ] Integration tests added/updated — N/A
- [x] Provider behavioral contract tests added/updated (backend) — in the implementation PR durion-positivity-backend#1474 (28 unit tests + pos-archunit enforcement gate; full reactor suite green)
- [ ] Consumer/UI tests added/updated (frontend) — N/A
- How to run: see durion-positivity-backend#1474

## Risk & Rollback
- Risk level: Low — documentation only; behavioral risk is carried and mitigated by the implementation PR
- Rollback plan: revert this commit; the ADR is PROPOSED until sign-off

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (ADR branch `claude/adr-0056-global-exception-handling`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (no capability id)
- [x] Links to parent + child issues are present (durion-positivity-backend#1471, #1474)
- [x] Contract guide updated (when contract semantics changed) — N/A, ADR is the contract artifact
- [x] Required CI checks passing

Note: `knowledge-catalog/adr/` pointer stubs currently end at 0054; no 0056 pointer added here to match (0055 has none either) — happy to add both if the mirror is meant to stay complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpRCpHf6Kc211v8phS4phq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpRCpHf6Kc211v8phS4phq)_